### PR TITLE
Kotlin LSP: prompt/install flow, background launcher fallback, Termux-based installer, and safe ServiceLoader stream

### DIFF
--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServer.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServer.kt
@@ -381,6 +381,12 @@ class KotlinLanguageServer(private val context: Context) : ILanguageServer {
     }
   }
 
+  private fun ensureKotlinLspInstalledIfNeeded(file: Path) {
+    if (!processManager.shouldPromptInstallFor(file.toFile())) return
+    KslLogs.warn("Kotlin file detected but Kotlin LSP files are missing. Prompting install.")
+    processManager.install {}
+  }
+
   private fun analyzeSelected() {
     val file = selectedFile ?: return
     val client = _client ?: return
@@ -414,6 +420,7 @@ class KotlinLanguageServer(private val context: Context) : ILanguageServer {
             event.openedFile.toString().endsWith(".kts"))
     )
         return
+    ensureKotlinLspInstalledIfNeeded(event.openedFile)
     selectedFile = event.openedFile
     startOrRestartAnalyzeTimer()
   }
@@ -426,6 +433,7 @@ class KotlinLanguageServer(private val context: Context) : ILanguageServer {
         event.selectedFile.toString().endsWith(".kt") ||
             event.selectedFile.toString().endsWith(".kts")
     ) {
+      ensureKotlinLspInstalledIfNeeded(event.selectedFile)
       documentManager.ensureDocumentOpen(event.selectedFile)
     }
   }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinServerProcessManager.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinServerProcessManager.kt
@@ -24,6 +24,7 @@ import com.itsaky.androidide.lsp.kotlin.events.LspEventBus
 import com.itsaky.androidide.lsp.kotlin.events.LspInstallRequestEvent
 import com.itsaky.androidide.lsp.models.DiagnosticResult
 import com.itsaky.androidide.utils.Environment
+import com.itsaky.androidide.utils.executioncommand.FireAndForgetRunner
 import java.io.*
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
@@ -70,6 +71,12 @@ class KotlinServerProcessManager(context: Context) {
     }
 
     return KotlinServerConstants.REQUIRED_LIB_JARS.all { jarName -> File(libDir, jarName).exists() }
+  }
+
+  fun shouldPromptInstallFor(file: File): Boolean {
+    val isKotlinFile = file.name.endsWith(".kt") || file.name.endsWith(".kts")
+    if (!isKotlinFile) return false
+    return !isInstalled()
   }
 
   /** 触发 UI 的安装弹窗 (基于 Kotlin SharedFlow)。 */
@@ -205,6 +212,32 @@ class KotlinServerProcessManager(context: Context) {
       KslLogs.info("Server started successfully with JAVA_HOME: {}", javaHome)
     } catch (e: Exception) {
       KslLogs.error("Failed to start server", e)
+      startLauncherInBackground(launcherScript, androidClasspath, classpathProvider)
+    }
+  }
+
+  private fun startLauncherInBackground(
+      launcherScript: File,
+      androidClasspath: String,
+      classpathProvider: KotlinClasspathProvider,
+  ) {
+    try {
+      val args =
+          arrayOf(
+              launcherScript.absolutePath,
+              "-DkotlinLanguageServer.version=1.3.13",
+              "-DkotlinLanguageServer.skipClasspathResolution=true",
+              "-DkotlinLanguageServer.predefinedClasspath=$androidClasspath",
+          )
+      FireAndForgetRunner.fire(context, Environment.BASH_SHELL.absolutePath, args)
+      val sdkPath = classpathProvider.getAndroidSdkPath()
+      KslLogs.warn(
+          "Fallback: launched Kotlin LSP in background via Termux shell API. script={}, sdkPath={}",
+          launcherScript.absolutePath,
+          sdkPath,
+      )
+    } catch (fallbackError: Exception) {
+      KslLogs.error("Fallback start via Termux shell API failed", fallbackError)
     }
   }
 

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/ui/LspInstallerDialog.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/ui/LspInstallerDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
@@ -31,13 +32,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
 import com.blankj.utilcode.util.FileUtils
-import com.blankj.utilcode.util.ZipUtils
 import com.itsaky.androidide.lsp.kotlin.events.LspInstallRequestEvent
+import com.itsaky.androidide.utils.executioncommand.TermuxCommand
 import com.itsaky.androidide.utils.Environment
 import java.io.File
-import java.io.FileOutputStream
-import java.net.HttpURLConnection
-import java.net.URL
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -49,6 +47,7 @@ import kotlinx.coroutines.withContext
  */
 @Composable
 fun LspInstallerDialog(request: LspInstallRequestEvent, onDismiss: () -> Unit) {
+  val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
 
   // 状态管理
@@ -147,74 +146,67 @@ fun LspInstallerDialog(request: LspInstallRequestEvent, onDismiss: () -> Unit) {
               statusMessage = "Initializing..."
 
               coroutineScope.launch(Dispatchers.IO) {
-                var tempFile: File? = null
+                var tmpZip: File? = null
                 try {
-                  log("Starting download sequence for ${request.serverName}...")
-
-                  tempFile =
+                  val targetDir = request.installPath
+                  tmpZip =
                       File(
                           Environment.TMP_DIR,
-                          "${request.serverId}-${System.currentTimeMillis()}.tmp",
+                          "${request.serverId}-${System.currentTimeMillis()}.zip",
                       )
-                  FileUtils.createOrExistsFile(tempFile)
+                  FileUtils.createOrExistsDir(tmpZip.parentFile)
 
-                  val url = URL(request.downloadUrl)
-                  val connection = url.openConnection() as HttpURLConnection
-                  connection.connectTimeout = 10000
-                  connection.readTimeout = 10000
-                  connection.connect()
+                  fun shellQuote(value: String): String = "'${value.replace("'", "'\"'\"'")}'"
 
-                  if (connection.responseCode != HttpURLConnection.HTTP_OK) {
-                    throw Exception(
-                        "Server returned HTTP ${connection.responseCode}: ${connection.responseMessage}"
-                    )
-                  }
-
-                  val fileLength = connection.contentLength
-                  val input = connection.inputStream
-                  val output = FileOutputStream(tempFile)
-
-                  val data = ByteArray(8192)
-                  var total: Long = 0
-                  var count: Int
-
+                  progress = 0.2f
+                  statusMessage = "Downloading..."
                   log("Downloading from: ${request.downloadUrl}")
 
-                  while (input.read(data).also { count = it } != -1) {
-                    if (!isInstalling) throw Exception("Installation cancelled")
+                  val downloadCmd =
+                      """
+                      set -e
+                      if command -v curl >/dev/null 2>&1; then
+                        curl -L --fail ${shellQuote(request.downloadUrl)} -o ${shellQuote(tmpZip!!.absolutePath)}
+                      elif command -v wget >/dev/null 2>&1; then
+                        wget -O ${shellQuote(tmpZip!!.absolutePath)} ${shellQuote(request.downloadUrl)}
+                      else
+                        echo "Neither curl nor wget found in PATH." >&2
+                        exit 127
+                      fi
+                      """.trimIndent()
 
-                    total += count.toLong()
-                    if (fileLength > 0) {
-                      val currentProg = total.toFloat() / fileLength.toFloat()
-                      if (Math.abs(currentProg - progress) > 0.01f) {
-                        progress = currentProg
+                  val downloadResult =
+                      TermuxCommand.run(context) {
+                        label("Download Kotlin LSP")
+                        executable("sh")
+                        args("-c", downloadCmd)
                       }
-                    }
-                    output.write(data, 0, count)
+                  if (!downloadResult.isSuccess) {
+                    throw IllegalStateException(downloadResult.stderr.ifBlank { downloadResult.stdout })
                   }
-                  output.flush()
-                  output.close()
-                  input.close()
+                  log("Download finished: ${tmpZip!!.absolutePath}")
 
-                  progress = 1.0f
-                  statusMessage = "Extracting..."
-                  log("Download completed. Size: ${total / 1024} KB")
-
-                  val targetDir = request.installPath
+                  progress = 0.6f
+                  statusMessage = "Preparing install directory..."
                   if (targetDir.exists()) {
-                    log("Cleaning up old version...")
-                    FileUtils.deleteAllInDir(targetDir)
-                  } else {
-                    FileUtils.createOrExistsDir(targetDir)
+                    FileUtils.delete(targetDir)
                   }
+                  FileUtils.createOrExistsDir(targetDir)
 
-                  if (request.isZipArchive) {
-                    log("Unzipping to ${targetDir.absolutePath}...")
-                    ZipUtils.unzipFile(tempFile, targetDir)
-                  } else {
-                    log("Moving binary to ${targetDir.absolutePath}...")
-                    val destFile = File(targetDir, request.downloadUrl.substringAfterLast("/"))
-                    FileUtils.move(tempFile, destFile)
+                  progress = 0.8f
+                  statusMessage = "Extracting..."
+                  log("Extracting archive to ${targetDir.absolutePath}")
+                  val unzipResult =
+                      TermuxCommand.run(context) {
+                        label("Extract Kotlin LSP")
+                        executable("sh")
+                        args(
+                            "-c",
+                            "set -e; unzip -o ${shellQuote(tmpZip!!.absolutePath)} -d ${shellQuote(targetDir.absolutePath)}",
+                        )
+                      }
+                  if (!unzipResult.isSuccess) {
+                    throw IllegalStateException(unzipResult.stderr.ifBlank { unzipResult.stdout })
                   }
 
                   val binDir = File(targetDir, "bin")
@@ -231,6 +223,7 @@ fun LspInstallerDialog(request: LspInstallRequestEvent, onDismiss: () -> Unit) {
 
                   log("Installation successfully finished.")
                   statusMessage = "Done."
+                  progress = 1.0f
 
                   // 标记为成功，防止取消回调被错误触发
                   isSuccess = true
@@ -249,7 +242,7 @@ fun LspInstallerDialog(request: LspInstallRequestEvent, onDismiss: () -> Unit) {
                     isInstalling = false
                   }
                 } finally {
-                  tempFile?.delete()
+                  tmpZip?.delete()
                 }
               }
             },

--- a/utilities/shared/src/main/java/com/itsaky/androidide/utils/ServiceLoader.java
+++ b/utilities/shared/src/main/java/com/itsaky/androidide/utils/ServiceLoader.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -300,7 +301,7 @@ public final class ServiceLoader<S> implements Iterable<S> {
     BufferedReader r = null;
     ArrayList<String> names = new ArrayList<>();
     try {
-      in = u.openStream();
+      in = openUrlStreamSafely(u);
       r = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
       int lc = 1;
 
@@ -322,6 +323,23 @@ public final class ServiceLoader<S> implements Iterable<S> {
       }
     }
     return names.iterator();
+  }
+
+  /**
+   * Use reflection to open URL stream to avoid hard-linking calls that may be bytecode-rewritten
+   * to optional Firebase Performance classes on some build variants.
+   */
+  private InputStream openUrlStreamSafely(URL url) throws IOException {
+    try {
+      Method openStream = URL.class.getMethod("openStream");
+      Object value = openStream.invoke(url);
+      if (value instanceof InputStream) {
+        return (InputStream) value;
+      }
+      throw new IOException("Unexpected stream type from URL.openStream()");
+    } catch (ReflectiveOperationException e) {
+      throw new IOException("Failed to open service configuration stream", e);
+    }
   }
 
   // Private inner class implementing fully-lazy provider lookup


### PR DESCRIPTION
### Motivation

- Detect when a Kotlin file is opened/selected and prompt to install the Kotlin Language Server if the runtime files are missing. 
- Provide a fallback mechanism to start the Kotlin LSP launcher in the background when direct process start fails. 
- Use shell-based download/extract via Termux APIs for the installer UI to avoid embedding heavy download/extract logic and to work in restricted Android environments. 
- Avoid hard-linking `URL.openStream()` to reduce runtime issues from bytecode-rewritten optional classes by opening the stream reflectively.

### Description

- Added `ensureKotlinLspInstalledIfNeeded(file: Path)` to `KotlinLanguageServer` and call sites in `onFileOpened` and `onFileSelected` to trigger the install prompt when `.kt`/`.kts` files are encountered. 
- Added `shouldPromptInstallFor(file: File)` to `KotlinServerProcessManager` to encapsulate the install prompt condition and call `install {}` when needed. 
- In `KotlinServerProcessManager`, on failure to start the server process a fallback `startLauncherInBackground(...)` is invoked which uses `FireAndForgetRunner.fire(...)` to launch the server script via a shell in background and logs the fallback. 
- Reworked `LspInstallerDialog` to run download and unzip steps via `TermuxCommand` shell invocations, switched to using `LocalContext.current`, switched temp filename extension to `.zip`, ensured directory cleanup and executable bit setting, improved progress/status updates, and removed direct HTTP/Zip handling and `ZipUtils`. 
- Modified `ServiceLoader` to open provider configuration streams via a new reflective helper `openUrlStreamSafely(URL)` that calls `URL.openStream()` via reflection and added the required `Method` import to avoid hard-linking issues.

### Testing

- No automated tests were added or executed as part of this change.
- Changes compiled locally as part of the module edit cycle (manual compile/check), but no CI unit/integration test run results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64e1b56008331848d8f9133c7f072)