### PR TITLE
Fix unresolved selectTab reference in EditorHandlerActivity

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -323,7 +323,7 @@ open class EditorHandlerActivity : ProjectHandlerActivity(), IEditorHandler {
         cache.selectedTabIndex.takeIf { it in 0 until cache.allFiles.size }
             ?: cache.allFiles.indexOfFirst { it.filePath == cache.selectedFile }
     if (restoreTabIndex >= 0) {
-      selectTab(restoreTabIndex)
+      content.tabs.getTabAt(restoreTabIndex)?.select()
     }
   }
 


### PR DESCRIPTION
### Motivation
- Restore previously selected editor tab when reopening cached files and fix an unresolved reference where `selectTab` was not available in the current class/API.

### Description
- Replace the invalid call `selectTab(restoreTabIndex)` with a direct TabLayout selection using `content.tabs.getTabAt(restoreTabIndex)?.select()` in `core/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt`.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin --no-daemon`, which failed in this environment with a Gradle/toolchain error (`* What went wrong: 25.0.1`), so full build verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b017e2488328b3693b1f1cfdbd26)