### PR TITLE
Fix Kotlin LSP compilation breakages with newer APIs

### DIFF
--- a/lsp/kotlin/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/lsp/kotlin/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -133,8 +133,8 @@ class KotlinLanguageServer(
 
         @Suppress("DEPRECATION")
         val folders = params.workspaceFolders?.takeIf { it.isNotEmpty() }
-            ?: params.rootUri?.let(::WorkspaceFolder)?.let(::listOf)
-            ?: params.rootPath?.let(Paths::get)?.toUri()?.toString()?.let(::WorkspaceFolder)?.let(::listOf)
+            ?: params.rootUri?.let(::toWorkspaceFolder)?.let(::listOf)
+            ?: params.rootPath?.let(Paths::get)?.toUri()?.toString()?.let(::toWorkspaceFolder)?.let(::listOf)
             ?: listOf()
 
         val progress = params.workDoneToken?.let { LanguageClientProgress("Workspace folders", it, client) }
@@ -164,6 +164,14 @@ class KotlinLanguageServer(
         val serverInfo = ServerInfo("Kotlin Language Server", VERSION)
 
         InitializeResult(serverCapabilities, serverInfo)
+    }
+
+    private fun toWorkspaceFolder(uri: String): WorkspaceFolder {
+        val folderName = runCatching { Paths.get(parseURI(uri)).fileName?.toString() }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: uri
+        return WorkspaceFolder(uri, folderName)
     }
 
     private fun connectLoggingBackend() {

--- a/lsp/kotlin/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
+++ b/lsp/kotlin/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
@@ -59,10 +59,6 @@ import org.javacs.kt.CompilerConfiguration
 import org.javacs.kt.ScriptsConfiguration
 import org.javacs.kt.util.LoggingMessageCollector
 import org.javacs.kt.util.getRange
-import org.jetbrains.kotlin.cli.common.output.writeAllTo
-import org.jetbrains.kotlin.codegen.ClassBuilderFactories
-import org.jetbrains.kotlin.codegen.KotlinCodegenFacade
-import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.container.getService
 import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -588,21 +584,10 @@ class Compiler(
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun generateCode(module: ModuleDescriptor, bindingContext: BindingContext, files: Collection<KtFile>) {
-        outputDirectory.takeIf { codegenConfig.enabled }?.let {
-            compileLock.withLock {
-                val compileEnv = compileEnvironmentFor(CompilationKind.DEFAULT)
-                val state = GenerationState.Builder(
-                    project = compileEnv.environment.project,
-                    builderFactory = ClassBuilderFactories.BINARIES,
-                    module = module,
-                    bindingContext = bindingContext,
-                    files = files.toList(),
-                    configuration = compileEnv.environment.configuration
-                ).build()
-                KotlinCodegenFacade.compileCorrectFiles(state)
-                state.factory.writeAllTo(it)
-            }
+        if (codegenConfig.enabled) {
+            LOG.warn("Bytecode generation is temporarily disabled for Kotlin {} compiler APIs", KotlinVersion.CURRENT)
         }
     }
 

--- a/lsp/kotlin/server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt
+++ b/lsp/kotlin/server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt
@@ -44,5 +44,6 @@ private fun severity(severity: Severity): DiagnosticSeverity =
             Severity.INFO -> DiagnosticSeverity.Information
             Severity.ERROR -> DiagnosticSeverity.Error
             Severity.WARNING -> DiagnosticSeverity.Warning
+            Severity.FIXED_WARNING -> DiagnosticSeverity.Warning
         }
 


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by API changes: `WorkspaceFolder` construction inference failures, removed Kotlin codegen symbols, and a non-exhaustive `when` over `Severity`.
- Keep the Kotlin LSP server building at source level while deferring migration to the current Kotlin codegen API.
- Ensure diagnostics mapping covers all current Kotlin `Severity` variants to avoid runtime/exhaustive-check issues.

### Description
- Add a helper `toWorkspaceFolder(uri: String)` and use it as a fallback for `params.rootUri`/`params.rootPath` in `KotlinLanguageServer.kt` to explicitly construct `WorkspaceFolder(uri, name)` and avoid type inference/constructor resolution errors. (`lsp/kotlin/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt`)
- Make `severity` conversion exhaustive by handling `Severity.FIXED_WARNING` and mapping it to `DiagnosticSeverity.Warning`. (`lsp/kotlin/server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt`)
- Remove direct usage of removed Kotlin codegen APIs and related imports, and replace `Compiler.generateCode` with a guarded no-op that logs a warning when codegen is enabled, while annotating the parameter as unused to silence warnings. (`lsp/kotlin/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt`)

### Testing
- Attempted to run `./gradlew :lsp:kotlin:server:compileKotlin`, but the Gradle/Kotlin script evaluation failed early with `IllegalArgumentException: 25.0.1` (Java version parsing), so the compile task could not complete in this environment.
- No automated unit test suite was run as part of this change due to the environment-level build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9556ff88c83289ee831b900514633)