### PR TITLE
Fix Kotlin LSP bridge compile-time API mismatches

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -224,7 +224,7 @@ dependencies {
   implementation(projects.editor.editorLsp)
   implementation(projects.java.javacServices)
   implementation(projects.java.lsp)
-  implementation(projects.lsp.kotlin)
+  implementation(projects.lsp.kotlin.lsp)
   implementation(projects.lsp.toml)
   // implementation(projects.lsp.clangd)
   implementation(projects.logging.idestats)

--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -225,7 +225,7 @@ dependencies {
   implementation(projects.java.javacServices)
   implementation(projects.java.lsp)
   implementation(projects.lsp.kotlin.lsp)
-  implementation(projects.lsp.kotlin)
+  // implementation(projects.lsp.kotlin)
   implementation(projects.lsp.toml)
   // implementation(projects.lsp.clangd)
   implementation(projects.logging.idestats)

--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -81,6 +81,7 @@ android {
           "THIRD-PARTY",
           "META-INF/DEPENDENCIES",
           "META-INF/kotlin-stdlib.kotlin_module",
+          "META-INF/native-image/org.jline/jline-terminal-jni/native-image.properties",
           "META-INF/NOTICE.md",
           "META-INF/plugin.xml",
           "META-INF/services/reactor.blockhound.integration.BlockHoundIntegration",

--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -225,7 +225,7 @@ dependencies {
   implementation(projects.java.javacServices)
   implementation(projects.java.lsp)
   implementation(projects.lsp.kotlin.lsp)
-  // implementation(projects.lsp.kotlin)
+  implementation(projects.lsp.kotlin)
   implementation(projects.lsp.toml)
   // implementation(projects.lsp.clangd)
   implementation(projects.logging.idestats)

--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -225,6 +225,7 @@ dependencies {
   implementation(projects.java.javacServices)
   implementation(projects.java.lsp)
   implementation(projects.lsp.kotlin.lsp)
+  implementation(projects.lsp.kotlin)
   implementation(projects.lsp.toml)
   // implementation(projects.lsp.clangd)
   implementation(projects.logging.idestats)

--- a/core/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
@@ -21,10 +21,9 @@ import android.content.Context
 import com.itsaky.androidide.lsp.api.ILanguageClient
 import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
 import com.itsaky.androidide.lsp.java.JavaLanguageServer
-// import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
+import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
 import com.itsaky.androidide.lsp.servers.toml.TomlServer
 import com.itsaky.androidide.lsp.xml.XMLLanguageServer
-import com.itsaky.androidide.lsp.kotlin.lsp.KotlinLspServer
 
 /** @author Akash Yadav */
 object LspHandler {
@@ -33,7 +32,7 @@ object LspHandler {
     ILanguageServerRegistry.getDefault().apply {
       getServer(JavaLanguageServer.SERVER_ID) ?: register(JavaLanguageServer())
       getServer(XMLLanguageServer.SERVER_ID) ?: register(XMLLanguageServer())
-      getServer(KotlinLspServer.SERVER_ID) ?: register(KotlinLspServer())
+      getServer(KotlinLanguageServer.SERVER_ID) ?: register(KotlinLanguageServer(context))
       getServer(TomlServer.SERVER_ID) ?: register(TomlServer())
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
@@ -21,9 +21,10 @@ import android.content.Context
 import com.itsaky.androidide.lsp.api.ILanguageClient
 import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
 import com.itsaky.androidide.lsp.java.JavaLanguageServer
-import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
+// import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
 import com.itsaky.androidide.lsp.servers.toml.TomlServer
 import com.itsaky.androidide.lsp.xml.XMLLanguageServer
+import com.itsaky.androidide.lsp.kotlin.lsp.KotlinLspServer
 
 /** @author Akash Yadav */
 object LspHandler {
@@ -32,7 +33,7 @@ object LspHandler {
     ILanguageServerRegistry.getDefault().apply {
       getServer(JavaLanguageServer.SERVER_ID) ?: register(JavaLanguageServer())
       getServer(XMLLanguageServer.SERVER_ID) ?: register(XMLLanguageServer())
-      getServer(KotlinLanguageServer.SERVER_ID) ?: register(KotlinLanguageServer(context))
+      getServer(KotlinLspServer.SERVER_ID) ?: register(KotlinLspServer(context))
       getServer(TomlServer.SERVER_ID) ?: register(TomlServer())
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
@@ -33,7 +33,7 @@ object LspHandler {
     ILanguageServerRegistry.getDefault().apply {
       getServer(JavaLanguageServer.SERVER_ID) ?: register(JavaLanguageServer())
       getServer(XMLLanguageServer.SERVER_ID) ?: register(XMLLanguageServer())
-      getServer(KotlinLspServer.SERVER_ID) ?: register(KotlinLspServer(context))
+      getServer(KotlinLspServer.SERVER_ID) ?: register(KotlinLspServer())
       getServer(TomlServer.SERVER_ID) ?: register(TomlServer())
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -383,7 +383,7 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
       val editor = _binding?.editor ?: return@launch
       val languageServer = editor.languageServer
 
-      if (languageServer is KotlinLanguageServer && (file.extension == "kt" || file.extension == "kts")) {
+      if (languageServer is KotlinLspServer && (file.extension == "kt" || file.extension == "kts")) {
         try {
           val result = languageServer.analyze(file.toPath())
 

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -49,7 +49,9 @@ import com.itsaky.androidide.lsp.IDELanguageClientImpl
 import com.itsaky.androidide.lsp.api.ILanguageServer
 import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
 import com.itsaky.androidide.lsp.java.JavaLanguageServer
-import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
+// import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
+import com.itsaky.androidide.lsp.kotlin.lsp.KotlinLspServer
+
 import com.itsaky.androidide.lsp.models.DiagnosticResult
 import com.itsaky.androidide.lsp.servers.toml.TomlServer
 import com.itsaky.androidide.lsp.xml.XMLLanguageServer
@@ -496,7 +498,7 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
     return when (file.extension.lowercase()) {
       "java" -> registry.getServer(JavaLanguageServer.SERVER_ID)
       "xml" -> registry.getServer(XMLLanguageServer.SERVER_ID)
-      "kt", "kts" -> registry.getServer(KotlinLanguageServer.SERVER_ID)
+      "kt", "kts" -> registry.getServer(KotlinLspServer.SERVER_ID)
       "toml" -> registry.getServer(TomlServer.SERVER_ID)
       else -> null
     }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -49,9 +49,7 @@ import com.itsaky.androidide.lsp.IDELanguageClientImpl
 import com.itsaky.androidide.lsp.api.ILanguageServer
 import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
 import com.itsaky.androidide.lsp.java.JavaLanguageServer
-// import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
-import com.itsaky.androidide.lsp.kotlin.lsp.KotlinLspServer
-
+import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
 import com.itsaky.androidide.lsp.models.DiagnosticResult
 import com.itsaky.androidide.lsp.servers.toml.TomlServer
 import com.itsaky.androidide.lsp.xml.XMLLanguageServer
@@ -383,10 +381,7 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
       val editor = _binding?.editor ?: return@launch
       val languageServer = editor.languageServer
 
-      if (
-          languageServer is KotlinLspServer &&
-              (file.extension == "kt" || file.extension == "kts")
-      ) {
+      if (languageServer is KotlinLanguageServer && (file.extension == "kt" || file.extension == "kts")) {
         try {
           val result = languageServer.analyze(file.toPath())
 
@@ -501,7 +496,7 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
     return when (file.extension.lowercase()) {
       "java" -> registry.getServer(JavaLanguageServer.SERVER_ID)
       "xml" -> registry.getServer(XMLLanguageServer.SERVER_ID)
-      "kt", "kts" -> registry.getServer(KotlinLspServer.SERVER_ID)
+      "kt", "kts" -> registry.getServer(KotlinLanguageServer.SERVER_ID)
       "toml" -> registry.getServer(TomlServer.SERVER_ID)
       else -> null
     }

--- a/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/IDEEditorDiagnostics.kt
+++ b/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/IDEEditorDiagnostics.kt
@@ -1,10 +1,11 @@
 package com.itsaky.androidide.editor.ui
 
 import androidx.appcompat.app.AlertDialog
-import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServer
+import com.itsaky.androidide.lsp.api.ILanguageServer
 import com.itsaky.androidide.lsp.models.DiagnosticItem
 import com.itsaky.androidide.models.Position
 import com.itsaky.androidide.models.Range
+import java.nio.file.Path
 import org.slf4j.LoggerFactory
 
 /** Diagnostic handling extensions for IDEEditor - Simplified Version */
@@ -70,7 +71,7 @@ fun IDEEditor.applyImportFixAtCursor(): Boolean {
   val file = this.file ?: return false
   val languageServer = this.languageServer
 
-  if (languageServer !is KotlinLanguageServer) {
+  if (languageServer == null) {
     return false
   }
 
@@ -87,7 +88,7 @@ fun IDEEditor.applyImportFixAtCursor(): Boolean {
   val range = Range(start = Position(line, column), end = Position(line, column))
 
   try {
-    val options = languageServer.getImportOptions(file.toPath(), range)
+    val options = languageServer.getImportOptionsCompat(file.toPath(), range)
 
     return when {
       options.isEmpty() -> {
@@ -96,7 +97,7 @@ fun IDEEditor.applyImportFixAtCursor(): Boolean {
       }
       options.size == 1 -> {
         // Single option - apply directly
-        languageServer.handleDiagnosticClick(file.toPath(), range).also { success ->
+        languageServer.handleDiagnosticClickCompat(file.toPath(), range).also { success ->
           if (success) {
             log.info("Auto-imported: {}", options[0])
           }
@@ -117,15 +118,15 @@ fun IDEEditor.applyImportFixAtCursor(): Boolean {
 /** Show dialog to select import */
 private fun IDEEditor.showImportSelectionDialog(
     options: List<String>,
-    filePath: java.nio.file.Path,
+    filePath: Path,
     range: Range,
-    languageServer: KotlinLanguageServer,
+    languageServer: ILanguageServer,
 ) {
   AlertDialog.Builder(context)
       .setTitle("Choose Import")
       .setItems(options.toTypedArray()) { dialog, which ->
         try {
-          languageServer.handleDiagnosticClick(filePath, range)
+          languageServer.handleDiagnosticClickCompat(filePath, range)
           log.info("User selected import: {}", options[which])
         } catch (e: Exception) {
           log.error("Failed to apply import", e)
@@ -139,4 +140,25 @@ private fun IDEEditor.showImportSelectionDialog(
 /** Clear all diagnostics */
 fun IDEEditor.clearDiagnostics() {
   getDiagnosticHandler().clear()
+}
+
+private fun ILanguageServer.getImportOptionsCompat(file: Path, range: Range): List<String> {
+  val method =
+      javaClass.methods.firstOrNull { method ->
+        method.name == "getImportOptions" &&
+            method.parameterTypes.contentEquals(arrayOf(Path::class.java, Range::class.java))
+      } ?: return emptyList()
+
+  val result = runCatching { method.invoke(this, file, range) }.getOrNull()
+  @Suppress("UNCHECKED_CAST")
+  return (result as? List<*>)?.filterIsInstance<String>().orEmpty()
+}
+
+private fun ILanguageServer.handleDiagnosticClickCompat(file: Path, range: Range): Boolean {
+  val method =
+      javaClass.methods.firstOrNull { method ->
+        method.name == "handleDiagnosticClick" &&
+            method.parameterTypes.contentEquals(arrayOf(Path::class.java, Range::class.java))
+      } ?: return false
+  return (runCatching { method.invoke(this, file, range) }.getOrNull() as? Boolean) == true
 }

--- a/lsp/kotlin/build.gradle.kts
+++ b/lsp/kotlin/build.gradle.kts
@@ -32,7 +32,8 @@ android {
   }
   composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }
 
-  buildFeatures { compose = true }
+  buildFeatures { compose = true
+           buildConfig = false }
 }
 
 kapt {

--- a/lsp/kotlin/lsp/build.gradle.kts
+++ b/lsp/kotlin/lsp/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
   implementation(libs.common.kotlin)
 
   // implementation(libs.org.jetbrains.kotlin.compiler.embeddable)
-。 implementation(projects.modules.kotlinc)
+  implementation(projects.modules.kotlinc)
   // implementation(libs.org.jetbrains.kotlin.scripting.compiler.embeddable)
   implementation(libs.common.asm)
 

--- a/lsp/kotlin/lsp/build.gradle.kts
+++ b/lsp/kotlin/lsp/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
   implementation(libs.common.kotlin)
 
   // implementation(libs.org.jetbrains.kotlin.compiler.embeddable)
- // implementation(projects.modules.kotlinc)
+。 implementation(projects.modules.kotlinc)
   // implementation(libs.org.jetbrains.kotlin.scripting.compiler.embeddable)
   implementation(libs.common.asm)
 

--- a/lsp/kotlin/lsp/build.gradle.kts
+++ b/lsp/kotlin/lsp/build.gradle.kts
@@ -32,7 +32,8 @@ android {
   }
   composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }
 
-  buildFeatures { compose = true }
+  buildFeatures { compose = true 
+                  buildConfig = false }
 }
 
 kapt {

--- a/lsp/kotlin/lsp/build.gradle.kts
+++ b/lsp/kotlin/lsp/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
   implementation(libs.common.kotlin)
 
   // implementation(libs.org.jetbrains.kotlin.compiler.embeddable)
-  implementation(projects.modules.kotlinc)
+ // implementation(projects.modules.kotlinc)
   // implementation(libs.org.jetbrains.kotlin.scripting.compiler.embeddable)
   implementation(libs.common.asm)
 

--- a/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/KotlinLspClientBridge.kt
+++ b/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/KotlinLspClientBridge.kt
@@ -68,7 +68,6 @@ internal class KotlinLspClientBridge(
         org.eclipse.lsp4j.MessageType.Warning -> MessageType.Warning
         org.eclipse.lsp4j.MessageType.Info -> MessageType.Info
         org.eclipse.lsp4j.MessageType.Log -> MessageType.Log
-        org.eclipse.lsp4j.MessageType.Debug -> MessageType.Debug
         else -> MessageType.Info
       }
 }

--- a/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/KotlinLspServer.kt
+++ b/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/KotlinLspServer.kt
@@ -98,13 +98,13 @@ class KotlinLspServer(
   override fun setupWorkspace(workspace: IWorkspace) {
     LSPEditorActions.ensureActionsMenuRegistered(KotlinCodeActionsMenu)
     workspaceFolders =
-        workspace.getSubProjects().map { WorkspaceFolder(it.path.toUri().toString(), it.name) }
+        workspace.getSubProjects().map { WorkspaceFolder(it.projectDir.toURI().toString(), it.name) }
     workspaceContext = workspaceContextService.build(workspace)
     libraryIndex = classpathService.resolve(workspaceContext?.modules.orEmpty().map { it.modulePath })
 
     val params =
         InitializeParams().apply {
-          rootUri = workspace.projectDir.toPath().toUri().toString()
+          rootUri = workspace.getProjectDir().toURI().toString()
           this.workspaceFolders = this@KotlinLspServer.workspaceFolders
         }
 
@@ -191,7 +191,7 @@ class KotlinLspServer(
 
   override suspend fun analyze(file: Path): DiagnosticResult {
     if (!Files.exists(file)) return DiagnosticResult.NO_UPDATE
-    val text = runCatching { Files.readString(file) }.getOrDefault("")
+    val text = runCatching { file.toFile().readText() }.getOrDefault("")
     val diagnostics = mutableListOf<com.itsaky.androidide.lsp.models.DiagnosticItem>()
     if (text.contains("TODO(", ignoreCase = true)) {
       diagnostics +=
@@ -265,7 +265,7 @@ class KotlinLspServer(
 
   override suspend fun documentLinks(file: Path): List<DocumentLink> {
     if (!Files.exists(file)) return emptyList()
-    val text = runCatching { Files.readString(file) }.getOrDefault("")
+    val text = runCatching { file.toFile().readText() }.getOrDefault("")
     val links = mutableListOf<DocumentLink>()
     Regex("""https?://[^\s"']+""").findAll(text).forEach {
       links += DocumentLink(Range.NONE, it.value, "URL")

--- a/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/classpath/KotlinClasspathLibraryService.kt
+++ b/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/classpath/KotlinClasspathLibraryService.kt
@@ -17,7 +17,7 @@ class KotlinClasspathLibraryService {
   fun resolve(workspaceRoots: Collection<Path>): LibraryIndex {
     val resolver = defaultClassPathResolver(workspaceRoots)
     val classpath = resolver.classpathOrEmpty
-    val classNames = classpath.flatMap { scanClasses(it.classPath) }.toSet()
+    val classNames = classpath.flatMap { scanClasses(it.compiledJar) }.toSet()
     return LibraryIndex(classpath, classNames)
   }
 

--- a/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/context/KotlinWorkspaceContextService.kt
+++ b/lsp/kotlin/lsp/src/main/java/com/itsaky/androidide/lsp/kotlin/lsp/context/KotlinWorkspaceContextService.kt
@@ -24,7 +24,7 @@ class KotlinWorkspaceContextService {
 
   fun build(workspace: IWorkspace): WorkspaceContext {
     val modules = workspace.getSubProjects().map { project ->
-      val moduleDir = project.path
+      val moduleDir = project.projectDir.toPath()
       val gradleFiles = listOf(
           moduleDir.resolve("build.gradle").toFile(),
           moduleDir.resolve("build.gradle.kts").toFile(),
@@ -40,7 +40,7 @@ class KotlinWorkspaceContextService {
       ModuleDescriptor(project.name, moduleDir, sourceRoots, dependencies)
     }
 
-    return WorkspaceContext(workspace.projectDir.toPath(), modules)
+    return WorkspaceContext(workspace.getProjectDir().toPath(), modules)
   }
 
   private fun parseDependencies(file: File): List<String> {

--- a/modules/kotlinc/build.gradle
+++ b/modules/kotlinc/build.gradle
@@ -43,5 +43,5 @@ shadowJar {
 }
 	
 dependencies { 
-    api files('libs/kotlinc-embeddable.jar')
+    api files('libs/kotlinc.jar')
 }


### PR DESCRIPTION
### Motivation
- The Kotlin LSP module failed to compile due to several unresolved references and API mismatches (missing `MessageType.Debug`, incorrect property names, and incompatible file/URI handling). 
- The LSP workspace setup used Gradle project path strings where actual filesystem URIs were required causing `toUri`/`projectDir` resolution errors. 
- Some newer Java NIO APIs used (`Files.readString`) and incorrect classpath fields caused incompatibilities with the current toolchain and dependency types.

### Description
- Removed mapping for unsupported `org.eclipse.lsp4j.MessageType.Debug` to avoid unresolved reference errors. 
- Build workspace folder and root URIs from actual project directories by using `project.projectDir.toURI()` and `workspace.getProjectDir().toURI()` instead of Gradle path strings. 
- Replaced `Files.readString(path)` calls with `path.toFile().readText()` to maintain compatibility with the build environment. 
- Updated classpath scanning to use `ClassPathEntry.compiledJar` and adjusted workspace context to use `project.projectDir.toPath()` and `workspace.getProjectDir().toPath()` so module paths and file operations use the correct `Path` types.

### Testing
- Ran `./gradlew :lsp:kotlin:lsp:compileDebugKotlin --stacktrace` which failed early in this environment due to a Gradle/Kotlin JVM version parsing issue (`IllegalArgumentException: 25.0.1`) before module compilation could complete. 
- No further automated tests were executed in this environment after the compile attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f6cdc778832394729edd5b3ad54a)