### PR TITLE
Enable Compose in java/lsp module to fix kapt stub annotation errors

### DIFF
--- a/java/lsp/build.gradle.kts
+++ b/java/lsp/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
   id("com.android.library")
   id("kotlin-android")
   id("kotlin-kapt")
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -29,6 +30,10 @@ android {
   sourceSets {
     getByName("androidTest") { assets.srcDirs(rootProject.file("utilities/framework-stubs/libs")) }
   }
+
+  composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }
+
+  buildFeatures { compose = true }
 }
 
 kapt { arguments { arg("eventBusIndex", "${BuildConfig.packageName}.events.LspJavaEventsIndex") } }
@@ -66,6 +71,7 @@ dependencies {
   implementation(libs.composite.jdt)
   implementation(libs.composite.googleJavaFormat)
 
+  implementation(libs.bundles.compose) // androidx compose
   implementation(libs.androidx.core.ktx)
   implementation(libs.common.kotlin)
 


### PR DESCRIPTION
### Motivation
- Kapt-generated stubs for Kotlin UI types produced `error.NonExistentClass` annotations because Compose UI symbols were not present during annotation processing, causing `NonExistentClass cannot be converted to Annotation` errors. 

### Description
- Added the Compose Kotlin plugin `org.jetbrains.kotlin.plugin.compose` to `java/lsp/build.gradle.kts` to enable compiler support for Compose in the module.  
- Enabled Compose build features and set `composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }` in `java/lsp` so the module compiles with the project's Compose setup.  
- Added the Compose dependency bundle (`implementation(libs.bundles.compose)`) to `java/lsp` so `@Composable`/Material3 UI symbols resolve during kapt stub generation.  

### Testing
- Ran `./gradlew :java:lsp:kaptDebugKotlin --stacktrace` to validate kapt behavior, but the run was blocked by a local JDK parsing issue (`IllegalArgumentException: 25.0.1`), so the original kapt error could not be fully re-verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa288af748323bebacf1809fe12e6)