### PR TITLE
Make onboarding skip when a usable JDK is present

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
+import java.io.File
 
 class OnboardingActivity : AppIntro2() {
 
@@ -229,12 +230,25 @@ class OnboardingActivity : AppIntro2() {
   }
 
   private fun checkToolsIsInstalled(): Boolean {
-    return IJdkDistributionProvider.getInstance().installedDistributions.isNotEmpty() &&
-        Environment.ANDROID_HOME.exists()
+    val distributions = IJdkDistributionProvider.getInstance().installedDistributions
+    return distributions.any(::isJdkDistributionUsable)
+  }
+
+  private fun isJdkDistributionUsable(distribution: JdkDistribution): Boolean {
+    val javaBinary = File(distribution.javaHome, "bin/java")
+    if (!javaBinary.exists() || !javaBinary.isFile) {
+      return false
+    }
+
+    if (!javaBinary.canExecute()) {
+      javaBinary.setExecutable(true)
+    }
+
+    return javaBinary.canExecute()
   }
 
   private fun isSetupCompleted(): Boolean {
-    return checkToolsIsInstalled() && checkAllPermissionsGranted()
+    return checkToolsIsInstalled()
   }
 
   private fun tryNavigateToMainIfSetupIsCompleted(): Boolean {


### PR DESCRIPTION
### Motivation
- Users could remain stuck inside `OnboardingActivity` even after installing JDK/SDK because the completion check required `ANDROID_HOME` and permissions instead of verifying a usable `java` binary.

### Description
- Changed `checkToolsIsInstalled()` in `core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt` to validate discovered JDK distributions rather than requiring `Environment.ANDROID_HOME`.
- Added `isJdkDistributionUsable(distribution: JdkDistribution)` which checks that `javaHome/bin/java` exists and is executable and tries to set the executable bit if needed.
- Simplified `isSetupCompleted()` to return the result of `checkToolsIsInstalled()` so the app can proceed to `MainActivity` once a usable JDK is present.
- Added an import for `java.io.File` used by the new check.

### Testing
- Attempted to compile the modified module with `./gradlew :core:app:compileDebugKotlin`, which failed due to an environment/toolchain issue (`25.0.1`) unrelated to the Kotlin changes, so no successful full build could be produced in this environment.
- No unit/instrumentation tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db62bae274832391b814734de71908)