### PR TITLE
Fix JAVA_HOME initialization when no valid JDK is selected

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/app/configuration/JdkDistributionProviderImpl.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/configuration/JdkDistributionProviderImpl.kt
@@ -68,8 +68,8 @@ class JdkDistributionProviderImpl : IJdkDistributionProvider {
         BuildPreferences.javaHome = defaultDist.javaHome
       }
 
-      val home = File(BuildPreferences.javaHome)
-      val java = File(home, "bin/java")
+      var home = File(BuildPreferences.javaHome)
+      var java = File(home, "bin/java")
 
       // the previously selected JDK distribution does not exist
       // check if we have other distributions installed
@@ -79,6 +79,11 @@ class JdkDistributionProviderImpl : IJdkDistributionProvider {
               "Previously selected java.home does not exists! Falling back to ${distributions[0]}..."
           )
           BuildPreferences.javaHome = distributions[0].javaHome
+          home = File(BuildPreferences.javaHome)
+          java = File(home, "bin/java")
+        } else {
+          log.warn("No JDK distribution is available. Skipping JAVA_HOME update.")
+          return@also
         }
       }
 
@@ -86,10 +91,10 @@ class JdkDistributionProviderImpl : IJdkDistributionProvider {
         java.setExecutable(true)
       }
 
-      log.debug("Setting Environment.JAVA_HOME to {}", BuildPreferences.javaHome)
+      log.debug("Setting Environment.JAVA_HOME to {}", home.absolutePath)
 
-      Environment.JAVA_HOME = File(BuildPreferences.javaHome)
-      Environment.JAVA = Environment.JAVA_HOME.resolve("bin/java")
+      Environment.JAVA_HOME = home
+      Environment.JAVA = java
 
       // Critical: Inject the selected JDK into the Native OS Environment
       // This ensures that ProcessBuilder, Terminal, and Shell sessions use THIS specific JDK


### PR DESCRIPTION
### Motivation
- Prevent exporting an invalid `JAVA_HOME` (e.g. `/`) when the saved `BuildPreferences.javaHome` is blank or points to a non-existent location, which can stop the Tooling API server and Gradle build service from starting.

### Description
- Recompute `home` and `java` after falling back to the first detected JDK distribution so the fallback values are used consistently.
- Skip injecting `JAVA_HOME` into the native environment and return early when no JDK distributions are available to avoid setting an invalid path.
- Update logging and assignments to use the validated `home`/`java` variables and set `Environment.JAVA_HOME` and `Environment.JAVA` from those values.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin` to validate the build path, but the build failed in this environment with a local SDK/toolchain error (`25.0.1`) that is unrelated to the logic change.
- Verified the code diff and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1366a3c883238e42ff9cf186cc4d)