### PR TITLE
feat(deps): workspace-wide Gradle/TOML dependency scanner

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/impl/GradleProjectAnalyzerImpl.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/impl/GradleProjectAnalyzerImpl.kt
@@ -3,7 +3,6 @@
  */
 package com.itsaky.androidide.repository.dependencies.analyzer.impl
 
-import com.itsaky.androidide.projects.IProjectManager
 import com.itsaky.androidide.repository.dependencies.analyzer.ProjectAnalyzer
 import com.itsaky.androidide.repository.dependencies.analyzer.internal.*
 import com.itsaky.androidide.repository.dependencies.analyzer.network.MavenMetadataFetcher
@@ -22,36 +21,13 @@ class GradleProjectAnalyzerImpl : ProjectAnalyzer {
 
   private val linker = DependencyLinker()
   private val tomlParser = TomlCatalogParser()
+  private val scanner = WorkspaceDependencyScanner(tomlParser = tomlParser, linker = linker)
 
   override suspend fun extractRepositories(projectDir: File): List<ScopedRepositoryInfo> =
       withContext(Dispatchers.IO) {
-        val repos = mutableListOf<ScopedRepositoryInfo>()
-        val workspace =
-            IProjectManager.getInstance().getWorkspace() ?: return@withContext emptyList()
+        val scanResult = scanner.scan(projectDir)
+        val repos = scanResult.repositories.toMutableList()
 
-        //  扫描根项目和所有子项目的构建脚本
-        val allProjects = listOfNotNull(workspace.getRootProject()) + workspace.getSubProjects()
-        allProjects.forEach { project ->
-          val scriptFile = project.buildScript
-          if (scriptFile != null && scriptFile.exists()) {
-            val analyzer = ScriptAnalyzerFactory.create(scriptFile)
-            val (scriptRepos, _) = analyzer.analyze(scriptFile)
-            repos.addAll(scriptRepos)
-          }
-        }
-
-        // 扫描 settings.gradle (用于 pluginManagement)
-        val settingsFile =
-            File(projectDir, "settings.gradle").takeIf { it.exists() }
-                ?: File(projectDir, "settings.gradle.kts").takeIf { it.exists() }
-
-        if (settingsFile != null) {
-          val analyzer = ScriptAnalyzerFactory.create(settingsFile)
-          val (scriptRepos, _) = analyzer.analyze(settingsFile)
-          repos.addAll(scriptRepos.map { it.copy(isPluginRepository = true) })
-        }
-
-        // 添加默认兜底仓库
         repos.add(
             ScopedRepositoryInfo(
                 "google",
@@ -68,7 +44,6 @@ class GradleProjectAnalyzerImpl : ProjectAnalyzer {
                 File(projectDir, "build.gradle"),
             )
         )
-
         repos.add(
             ScopedRepositoryInfo(
                 "mavenCentral",
@@ -78,54 +53,13 @@ class GradleProjectAnalyzerImpl : ProjectAnalyzer {
             )
         )
 
-        return@withContext repos.distinctBy { it.url }
+        repos.distinctBy { it.url }
       }
 
   override suspend fun extractDependencies(projectDir: File): List<DependencyInfo> =
       withContext(Dispatchers.IO) {
-        val allRawDependencies = mutableListOf<ScopedDependencyInfo>()
-        val catalogMap = mutableMapOf<String, VersionCatalog>()
-        val workspace = IProjectManager.getInstance().getWorkspace()
-
-        // 分析 settings.gradle 获取所有版本目录文件
-        val settingsAnalyzer = SettingsDslAnalyzer(projectDir)
-        val catalogFilesMap = settingsAnalyzer.extractCatalogs()
-
-        // 解析所有目录文件
-        catalogFilesMap.forEach { (alias, file) -> catalogMap[alias] = tomlParser.parse(file) }
-
-        //  遍历所有模块，提取原始依赖声明
-        if (workspace != null) {
-          val modules = listOfNotNull(workspace.getRootProject()) + workspace.getSubProjects()
-          modules.forEach { module ->
-            val buildScript = module.buildScript
-            if (buildScript != null && buildScript.exists()) {
-              val analyzer = ScriptAnalyzerFactory.create(buildScript)
-              val (_, scriptDeps) = analyzer.analyze(buildScript)
-              allRawDependencies.addAll(scriptDeps)
-            }
-          }
-        }
-
-        if (allRawDependencies.isEmpty()) {
-          projectDir
-              .walkTopDown()
-              .filter {
-                it.isFile &&
-                    (it.name == "build.gradle" || it.name == "build.gradle.kts") &&
-                    !it.path.contains("/build/")
-              }
-              .forEach { scriptFile ->
-                val analyzer = ScriptAnalyzerFactory.create(scriptFile)
-                val (_, scriptDeps) = analyzer.analyze(scriptFile)
-                allRawDependencies.addAll(scriptDeps)
-              }
-        }
-
-        // 链接
-        val linkedDependencies = linker.link(allRawDependencies, catalogMap)
-
-        return@withContext linkedDependencies.distinctBy { it.gav }
+        val scanResult = scanner.scan(projectDir)
+        scanResult.dependencies
       }
 
   override suspend fun checkUpdates(

--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/internal/WorkspaceDependencyScanner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/internal/WorkspaceDependencyScanner.kt
@@ -1,0 +1,114 @@
+package com.itsaky.androidide.repository.dependencies.analyzer.internal
+
+import com.itsaky.androidide.repository.dependencies.models.datas.ScopedDependencyInfo
+import com.itsaky.androidide.repository.dependencies.models.datas.VersionCatalog
+import com.itsaky.androidide.repository.dependencies.models.enums.DeclarationType
+import java.io.File
+
+/**
+ * 主动扫描工作区内的所有 Gradle Groovy/Kotlin DSL 与 TOML catalog，确保每个依赖都可进入 UI 列表。
+ */
+class WorkspaceDependencyScanner(
+    private val tomlParser: TomlCatalogParser,
+    private val linker: DependencyLinker,
+) {
+
+  data class ScanResult(
+      val repositories: List<com.itsaky.androidide.repository.dependencies.models.datas.ScopedRepositoryInfo>,
+      val dependencies: List<ScopedDependencyInfo>,
+      val catalogs: Map<String, VersionCatalog>,
+  )
+
+  fun scan(projectDir: File): ScanResult {
+    val scriptFiles = findGradleScripts(projectDir)
+    val repositories = mutableListOf<com.itsaky.androidide.repository.dependencies.models.datas.ScopedRepositoryInfo>()
+    val rawDependencies = mutableListOf<ScopedDependencyInfo>()
+
+    scriptFiles.forEach { script ->
+      val analyzer = ScriptAnalyzerFactory.create(script)
+      val (scriptRepos, scriptDeps) = analyzer.analyze(script)
+      repositories += scriptRepos
+      rawDependencies += scriptDeps
+    }
+
+    val catalogMap = loadCatalogs(projectDir)
+    val linkedScriptDependencies = linker.link(rawDependencies, catalogMap)
+    val catalogDeclaredDependencies = extractCatalogDeclaredDependencies(catalogMap)
+
+    val allDependencies = linkedScriptDependencies + catalogDeclaredDependencies
+
+    return ScanResult(
+        repositories = repositories.distinctBy { "${it.url}:${it.declaredFile.absolutePath}" },
+        dependencies = allDependencies,
+        catalogs = catalogMap,
+    )
+  }
+
+  private fun findGradleScripts(projectDir: File): List<File> {
+    return projectDir
+        .walkTopDown()
+        .filter {
+          it.isFile &&
+              (it.name == "build.gradle" || it.name == "build.gradle.kts" || it.name == "settings.gradle" || it.name == "settings.gradle.kts") &&
+              !it.inIgnoredDir(projectDir)
+        }
+        .toList()
+  }
+
+  private fun loadCatalogs(projectDir: File): Map<String, VersionCatalog> {
+    val settingsAnalyzer = SettingsDslAnalyzer(projectDir)
+    val catalogFiles = settingsAnalyzer.extractCatalogs()
+    val catalogMap = linkedMapOf<String, VersionCatalog>()
+
+    catalogFiles.forEach { (alias, file) ->
+      catalogMap[alias] = tomlParser.parse(file)
+    }
+
+    return catalogMap
+  }
+
+  private fun extractCatalogDeclaredDependencies(
+      catalogs: Map<String, VersionCatalog>
+  ): List<ScopedDependencyInfo> {
+    val result = mutableListOf<ScopedDependencyInfo>()
+
+    catalogs.forEach { (alias, catalog) ->
+      catalog.libraries.forEach { (libAlias, lib) ->
+        val version = lib.versionLiteral ?: lib.versionRef?.let { ref -> catalog.versions[ref]?.value } ?: return@forEach
+        val range =
+            if (lib.versionRef != null) {
+              catalog.versions[lib.versionRef]?.textRange
+            } else {
+              lib.textRange
+            }
+
+        result +=
+            ScopedDependencyInfo(
+                configuration = "versionCatalog($alias)",
+                groupId = lib.group,
+                artifactId = lib.name,
+                version = version,
+                declaredFile = catalog.sourceFile,
+                declarationType = DeclarationType.CATALOG_ACCESSOR,
+                statementTextRange = range,
+                versionDefinitionFile = catalog.sourceFile,
+                versionDefinitionRange = range,
+                tomlReference = "${alias}.${libAlias}",
+                versionReference = libAlias,
+            )
+      }
+    }
+
+    return result
+  }
+
+  private fun File.inIgnoredDir(projectDir: File): Boolean {
+    val relative = this.relativeTo(projectDir).invariantSeparatorsPath
+    return relative.contains("/build/") ||
+        relative.startsWith("build/") ||
+        relative.contains("/.gradle/") ||
+        relative.startsWith(".gradle/") ||
+        relative.contains("/.git/") ||
+        relative.startsWith(".git/")
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
@@ -110,7 +110,14 @@ fun DependencyUpdateScreen(
         modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
         contentPadding = PaddingValues(vertical = 16.dp),
     ) {
-      items(items = reports, key = { it.dependency.gav }, contentType = { "dependency_item" }) {
+      items(
+          items = reports,
+          key = { report ->
+            val dep = report.dependency as? ScopedDependencyInfo
+            "${report.dependency.gav}:${dep?.declaredFile?.absolutePath ?: "unknown"}:${dep?.statementTextRange?.startOffset ?: -1}"
+          },
+          contentType = { "dependency_item" },
+      ) {
           report ->
         DependencyUpdateItem(
             report = report,
@@ -163,6 +170,15 @@ fun DependencyUpdateItem(report: UpdateReport, onUpdateClicked: (String) -> Unit
           fontWeight = FontWeight.SemiBold,
           color = MaterialTheme.colorScheme.onSurface,
       )
+      val scoped = report.dependency as? ScopedDependencyInfo
+      scoped?.let {
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = "${it.configuration} · ${it.declaredFile.name}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+      }
       Spacer(modifier = Modifier.height(4.dp))
       Text(
           text =


### PR DESCRIPTION
### Motivation
- Ensure every dependency declared in the workspace (Groovy DSL, Kotlin DSL, or Version Catalog TOML) can be discovered and presented as a list item for update and editing in the UI.

### Description
- Added `WorkspaceDependencyScanner` (`core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/internal/WorkspaceDependencyScanner.kt`) which proactively scans the workspace for `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts` and loads catalogs declared from `settings` into a `ScanResult`.
- Reworked `GradleProjectAnalyzerImpl` to use the scanner as the single source for extraction by replacing the previous project/module traversal with `scanner.scan(projectDir)` for both `extractRepositories` and `extractDependencies` and preserved the default fallback repositories.
- Converted TOML catalog `libraries` entries into `ScopedDependencyInfo` so catalog-declared dependencies become first-class items (with `versionDefinitionFile`, `versionDefinitionRange`, `tomlReference`, etc.) and linked script-extracted placeholders via the existing `DependencyLinker`.
- Updated UI keying and metadata in `DependencyUpdateFragment` to disambiguate identical GAVs from different files/locations by including file path and position in the item key and to display source context (`configuration` + filename) in each list item.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin` to validate compilation in the environment, and the build failed early due to an environment/toolchain issue (`What went wrong: 25.0.1`), so compilation validation is inconclusive for this environment.
- No additional automated tests were executed as part of this rollout and no unit test failures from the project test suite were observed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5848e7070832caf0bce77140cef4a)