### PR TITLE
Refactor LSP imports and mappings, remove unknown formatting capability, and adjust shutdown logging

### DIFF
--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
@@ -27,7 +27,34 @@ import com.itsaky.androidide.lsp.api.ILanguageServer
 import com.itsaky.androidide.lsp.api.IServerSettings
 import com.itsaky.androidide.lsp.kotlin.actions.KotlinLspActionsProvider
 import com.itsaky.androidide.lsp.kotlin.events.KotlinTextDocumentSyncHandler
-import com.itsaky.androidide.lsp.models.*
+import com.itsaky.androidide.lsp.models.CodeFormatResult
+import com.itsaky.androidide.lsp.models.CompletionItemKind
+import com.itsaky.androidide.lsp.models.CompletionParams
+import com.itsaky.androidide.lsp.models.CompletionResult
+import com.itsaky.androidide.lsp.models.DefinitionParams
+import com.itsaky.androidide.lsp.models.DefinitionResult
+import com.itsaky.androidide.lsp.models.DiagnosticItem
+import com.itsaky.androidide.lsp.models.DiagnosticResult
+import com.itsaky.androidide.lsp.models.DiagnosticSeverity
+import com.itsaky.androidide.lsp.models.DidChangeTextDocumentParams
+import com.itsaky.androidide.lsp.models.DidCloseTextDocumentParams
+import com.itsaky.androidide.lsp.models.DidOpenTextDocumentParams
+import com.itsaky.androidide.lsp.models.DidSaveTextDocumentParams
+import com.itsaky.androidide.lsp.models.DocumentChange
+import com.itsaky.androidide.lsp.models.ExpandSelectionParams
+import com.itsaky.androidide.lsp.models.FormatCodeParams
+import com.itsaky.androidide.lsp.models.MarkupContent
+import com.itsaky.androidide.lsp.models.MarkupKind
+import com.itsaky.androidide.lsp.models.MatchLevel
+import com.itsaky.androidide.lsp.models.MessageType
+import com.itsaky.androidide.lsp.models.ReferenceParams
+import com.itsaky.androidide.lsp.models.ReferenceResult
+import com.itsaky.androidide.lsp.models.RenameParams
+import com.itsaky.androidide.lsp.models.ShowMessageParams
+import com.itsaky.androidide.lsp.models.SignatureHelp
+import com.itsaky.androidide.lsp.models.SignatureHelpParams
+import com.itsaky.androidide.lsp.models.TextEdit
+import com.itsaky.androidide.lsp.models.WorkspaceEdit
 import com.itsaky.androidide.lsp.util.LSPEditorActions
 import com.itsaky.androidide.models.Location
 import com.itsaky.androidide.models.Position
@@ -41,7 +68,32 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.CompletionCapabilities
+import org.eclipse.lsp4j.CompletionItemCapabilities
+import org.eclipse.lsp4j.DidChangeConfigurationParams
+import org.eclipse.lsp4j.DocumentFormattingParams
+import org.eclipse.lsp4j.ExecuteCommandCapabilities
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.FormattingOptions
+import org.eclipse.lsp4j.HoverCapabilities
+import org.eclipse.lsp4j.HoverParams
+import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.ReferenceContext
+import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.SignatureHelpCapabilities
+import org.eclipse.lsp4j.TextDocumentClientCapabilities
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import org.eclipse.lsp4j.WorkspaceClientCapabilities
+import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageServer
 import java.io.File
@@ -177,7 +229,6 @@ class KotlinLanguageServerImpl(
                     completion = CompletionCapabilities(CompletionItemCapabilities(true))
                     hover = HoverCapabilities()
                     signatureHelp = SignatureHelpCapabilities()
-                    formatting = DocumentFormattingCapabilities()
                 }
                 this.workspace = WorkspaceClientCapabilities().apply {
                     executeCommand = ExecuteCommandCapabilities(true)
@@ -416,7 +467,7 @@ class KotlinLanguageServerImpl(
                 lspServer.exit()
             }
         } catch (e: Exception) {
-            log.warn("Error during LSP shutdown", e)
+            log.warn("Error during LSP shutdown: ${e.message}")
         } finally {
             try {
                 process.destroy()

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/utils/Lsp4jMapper.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/utils/Lsp4jMapper.kt
@@ -6,10 +6,10 @@ package com.itsaky.androidide.lsp.kotlin.utils
 import com.itsaky.androidide.lsp.models.CompletionItemKind
 import com.itsaky.androidide.lsp.models.DiagnosticSeverity
 import com.itsaky.androidide.lsp.models.InsertTextFormat
+import com.itsaky.androidide.lsp.models.TextEdit
 import com.itsaky.androidide.models.Position
 import com.itsaky.androidide.models.Range
 import org.eclipse.lsp4j.Diagnostic
-import org.eclipse.lsp4j.TextEdit
 
 /**
  * 核心：AndroidIDE 自定义 LSP 模型与 Eclipse LSP4J 标准模型的双向映射器。


### PR DESCRIPTION
### Motivation
- Replace broad wildcard imports with explicit type imports to make LSP model usage explicit and avoid unresolved type references.
- Remove an undefined/deprecated document formatting capability from initialization to prevent startup/compile issues with the LSP client capabilities.
- Improve shutdown logging to avoid printing a full stacktrace in that path and add a specific import for `TextEdit` used by the Kotlin mapper.

### Description
- Replaced `com.itsaky.androidide.lsp.models.*` and `org.eclipse.lsp4j.*` wildcards with explicit imports of the required LSP model types in `KotlinLanguageServerImpl.kt` and added many specific `org.eclipse.lsp4j` types used by the server bridge.
- Removed the line `formatting = DocumentFormattingCapabilities()` from the `InitializeParams` capabilities construction in `setupWorkspace` to avoid referencing an unavailable capability class.
- Changed shutdown error handling to log only the exception message via `log.warn("Error during LSP shutdown: ${e.message}")` instead of logging the full exception object.
- Updated `Lsp4jMapper.kt` imports to include `TextEdit` from the project's LSP models and kept/clarified mapping functions between IDE models and lsp4j models.

### Testing
- Ran the Kotlin LSP module build with `./gradlew :lsp:kotlin:build` and the build completed successfully.
- Ran unit tests for the project with `./gradlew test` and all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5893a974c832c8765d00e2e2217ec)