### PR TITLE
Bind LSP4J LanguageServer proxy, manage launcher/stderr and refactor LSP mappings

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
@@ -1,42 +1,54 @@
-/*
- * @author android_zero
- *
- * 功能：依赖更新检测与管理 UI 界面 (Jetpack Compose 驱动)
- * 修复内容：
- * 1. 彻底移除了对 ComposeOwnerHelper 的依赖，解决了 Unresolved reference 报错。
- * 2. 在 Fragment 中，利用 ComposeView 自动查找父级 Owner 的特性，无需手动设置。
- * 3. 在 PopupWindow 中，使用 [setParentCompositionContext] 替代手动设置 Owner。
- *    这是 Compose 官方推荐的跨窗口上下文传递方式，既解决了报错，又能完美继承主题和生命周期。
- */
 package com.itsaky.androidide.repository.dependencies.analyzer.ui
 
-import android.content.Context
 import android.os.Bundle
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.PopupWindow
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.itsaky.androidide.fragments.BaseFragment
 import com.itsaky.androidide.projects.IProjectManager
 import com.itsaky.androidide.repository.dependencies.analyzer.ProjectAnalyzer
 import com.itsaky.androidide.repository.dependencies.analyzer.impl.GradleProjectAnalyzerImpl
 import com.itsaky.androidide.repository.dependencies.analyzer.internal.DependencyUpdater
-import com.itsaky.androidide.repository.dependencies.models.datas.*
-import com.itsaky.androidide.repository.dependencies.models.enums.*
-import com.itsaky.androidide.repository.dependencies.models.interfaces.*
+import com.itsaky.androidide.repository.dependencies.models.datas.UpdateReport
 import com.itsaky.androidide.utils.flashError
 import com.itsaky.androidide.utils.flashSuccess
 import kotlinx.coroutines.launch
@@ -66,7 +78,12 @@ class DependencyUpdateFragment : BaseFragment() {
   }
 }
 
-/** 依赖更新界面的主屏幕组合函数。 */
+private enum class DependencyFilter {
+  ONLY_OUTDATED,
+  ALL,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DependencyUpdateScreen(
     analyzer: ProjectAnalyzer,
@@ -74,193 +91,232 @@ fun DependencyUpdateScreen(
     onFlashError: (String) -> Unit,
 ) {
   var reports by remember { mutableStateOf<List<UpdateReport>>(emptyList()) }
-  var isLoading by remember { mutableStateOf(true) }
+  var isLoading by remember { mutableStateOf(false) }
+  var errorMessage by remember { mutableStateOf<String?>(null) }
+  var filter by rememberSaveable { mutableStateOf(DependencyFilter.ONLY_OUTDATED) }
   val coroutineScope = rememberCoroutineScope()
 
   fun refreshData() {
-    isLoading = true
     coroutineScope.launch {
-      val workspace = IProjectManager.getInstance().getWorkspace()
-      val projectDir = workspace?.getProjectDir()
-      if (projectDir != null) {
+      isLoading = true
+      errorMessage = null
+      try {
+        val workspace = IProjectManager.getInstance().getWorkspace()
+        val projectDir = workspace?.getProjectDir()
+        if (projectDir == null) {
+          reports = emptyList()
+          errorMessage = "No opened workspace. Please open a project first."
+          return@launch
+        }
+
         val repos = analyzer.extractRepositories(projectDir)
         val deps = analyzer.extractDependencies(projectDir)
-        reports = analyzer.checkUpdates(deps, repos)
+        reports = analyzer.checkUpdates(deps, repos).sortedBy { it.dependency.gav }
+      } catch (e: Exception) {
+        reports = emptyList()
+        errorMessage = e.message ?: "Unknown error while loading dependencies."
+        onFlashError("Dependency scan failed: ${errorMessage}")
+      } finally {
+        isLoading = false
       }
-      isLoading = false
     }
   }
 
   LaunchedEffect(Unit) { refreshData() }
 
-  if (isLoading) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Analyzing dependencies & checking updates...",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+  val filteredReports =
+      when (filter) {
+        DependencyFilter.ONLY_OUTDATED ->
+            reports.filter { it.latestVersion != it.dependency.version }
+        DependencyFilter.ALL -> reports
+      }
+
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text("Dependencies") },
+            actions = { TextButton(onClick = { refreshData() }) { Text("Rescan") } },
         )
       }
-    }
-  } else {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
-        contentPadding = PaddingValues(vertical = 16.dp),
-    ) {
-      items(items = reports, key = { it.dependency.gav }, contentType = { "dependency_item" }) {
-          report ->
-        DependencyUpdateItem(
-            report = report,
-            onUpdateClicked = { selectedVersion ->
-              if (selectedVersion == report.dependency.version) {
-                onFlashSuccess("Already using ${report.dependency.artifactId}:$selectedVersion")
-              } else {
+  ) { innerPadding ->
+    when {
+      isLoading -> LoadingState(innerPadding)
+      errorMessage != null ->
+          ErrorState(
+              innerPadding = innerPadding,
+              message = errorMessage ?: "Unknown error.",
+              onRetry = { refreshData() },
+          )
+      else ->
+          DependencyListState(
+              innerPadding = innerPadding,
+              reports = filteredReports,
+              totalCount = reports.size,
+              filter = filter,
+              onFilterChange = { filter = it },
+              onApplyClicked = { report, selectedVersion ->
+                if (selectedVersion == report.dependency.version) {
+                  onFlashSuccess("Already using ${report.dependency.artifactId}:$selectedVersion")
+                  return@DependencyListState
+                }
                 coroutineScope.launch {
                   val success = DependencyUpdater.update(report.dependency, selectedVersion)
                   if (success) {
                     onFlashSuccess("Updated ${report.dependency.artifactId} to $selectedVersion")
                     refreshData()
                   } else {
-                    onFlashError(
-                        "Failed to update ${report.dependency.artifactId}. No match found."
-                    )
+                    onFlashError("Failed to update ${report.dependency.artifactId}")
                   }
                 }
-              }
-            },
+              },
+          )
+    }
+  }
+}
+
+@Composable
+private fun LoadingState(innerPadding: PaddingValues) {
+  Box(
+      modifier = Modifier.fillMaxSize().padding(innerPadding),
+      contentAlignment = Alignment.Center,
+  ) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      CircularProgressIndicator()
+      Spacer(modifier = Modifier.height(12.dp))
+      Text("Scanning dependencies...")
+    }
+  }
+}
+
+@Composable
+private fun ErrorState(
+    innerPadding: PaddingValues,
+    message: String,
+    onRetry: () -> Unit,
+) {
+  Box(
+      modifier = Modifier.fillMaxSize().padding(innerPadding).padding(20.dp),
+      contentAlignment = Alignment.Center,
+  ) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      Text(
+          text = "Failed to load dependencies",
+          style = MaterialTheme.typography.titleMedium,
+          fontWeight = FontWeight.SemiBold,
+      )
+      Spacer(modifier = Modifier.height(8.dp))
+      Text(
+          text = message,
+          style = MaterialTheme.typography.bodyMedium,
+          textAlign = TextAlign.Center,
+      )
+      Spacer(modifier = Modifier.height(16.dp))
+      Button(onClick = onRetry) { Text("Retry") }
+    }
+  }
+}
+
+@Composable
+private fun DependencyListState(
+    innerPadding: PaddingValues,
+    reports: List<UpdateReport>,
+    totalCount: Int,
+    filter: DependencyFilter,
+    onFilterChange: (DependencyFilter) -> Unit,
+    onApplyClicked: (UpdateReport, String) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      FilterChip(
+          selected = filter == DependencyFilter.ONLY_OUTDATED,
+          onClick = { onFilterChange(DependencyFilter.ONLY_OUTDATED) },
+          label = { Text("Outdated only") },
+      )
+      FilterChip(
+          selected = filter == DependencyFilter.ALL,
+          onClick = { onFilterChange(DependencyFilter.ALL) },
+          label = { Text("All ($totalCount)") },
+      )
+    }
+
+    if (reports.isEmpty()) {
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = "No dependencies to show for current filter.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Divider(
-            modifier = Modifier.padding(vertical = 8.dp),
-            color = MaterialTheme.colorScheme.surfaceVariant,
-        )
+      }
+      return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+      items(items = reports, key = { it.dependency.gav }) { report ->
+        DependencyUpdateItem(report = report, onApplyClicked = onApplyClicked)
+        HorizontalDivider(modifier = Modifier.padding(vertical = 10.dp))
       }
     }
   }
 }
 
-/** 单项依赖视图 */
 @Composable
-fun DependencyUpdateItem(report: UpdateReport, onUpdateClicked: (String) -> Unit) {
-  var selectedVersion by remember { mutableStateOf(report.dependency.version) }
-  val currentView = LocalView.current
-
-  // 这个 Context 包含了当前的 Lifecycle、SavedState 以及 Theme 信息。
-  val compositionContext = rememberCompositionContext()
+private fun DependencyUpdateItem(
+    report: UpdateReport,
+    onApplyClicked: (UpdateReport, String) -> Unit,
+) {
+  var selectedVersion by remember(report.dependency.gav) { mutableStateOf(report.latestVersion) }
+  val versions = remember(report.availableVersions) {
+    report.availableVersions.distinct().ifEmpty { listOf(report.dependency.version) }
+  }
   val hasUpdate = report.latestVersion != report.dependency.version
 
-  Row(
-      modifier = Modifier.fillMaxWidth(),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.SpaceBetween,
-  ) {
-    Column(modifier = Modifier.weight(1f)) {
+  Card(modifier = Modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
       Text(
           text = "${report.dependency.groupId}:${report.dependency.artifactId}",
           style = MaterialTheme.typography.titleSmall,
           fontWeight = FontWeight.SemiBold,
-          color = MaterialTheme.colorScheme.onSurface,
       )
       Spacer(modifier = Modifier.height(4.dp))
       Text(
-          text =
-              if (hasUpdate) {
-                "Current: ${report.dependency.version}  →  Latest: ${report.latestVersion}"
-              } else {
-                "Current: ${report.dependency.version}  ·  Latest: ${report.latestVersion}"
-              },
+          text = "Current: ${report.dependency.version}  Latest: ${report.latestVersion}",
           style = MaterialTheme.typography.bodySmall,
           color = MaterialTheme.colorScheme.onSurfaceVariant,
       )
-    }
+      Spacer(modifier = Modifier.height(10.dp))
 
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      OutlinedButton(
-          onClick = {
-            // 将 compositionContext 传递给 PopupWindow
-            VersionSelectionPopupWindow(
-                    context = currentView.context,
-                    versions = report.availableVersions,
-                    parentCompositionContext = compositionContext, // 传递上下文
-                ) { version ->
-                  selectedVersion = version
-                }
-                .showAtLocation(currentView, Gravity.CENTER, 0, 0)
-          },
-          modifier = Modifier.padding(end = 8.dp),
-      ) {
-        Text(text = selectedVersion)
-      }
-
-      Button(onClick = { onUpdateClicked(selectedVersion) }) { Text("Apply") }
-    }
-  }
-}
-
-/**
- * 使用 [setParentCompositionContext] 替代了直接设置 ViewTreeLifecycleOwner。 这是一个纯 Compose 的 API，不依赖 AndroidX
- * Lifecycle 的特定类，因此不会报 Unresolved reference。
- */
-class VersionSelectionPopupWindow(
-    context: Context,
-    versions: List<String>,
-    parentCompositionContext: CompositionContext,
-    onVersionSelected: (String) -> Unit,
-) : PopupWindow(context) {
-
-  init {
-    val composeView =
-        ComposeView(context).apply {
-          setParentCompositionContext(parentCompositionContext)
-
-          setContent {
-            MaterialTheme {
-              Surface(
-                  modifier = Modifier.fillMaxWidth(0.7f).heightIn(max = 400.dp),
-                  shape = MaterialTheme.shapes.medium,
-                  shadowElevation = 8.dp,
-                  color = MaterialTheme.colorScheme.surface,
-              ) {
-                Column {
-                  Text(
-                      text = "Select Version",
-                      style = MaterialTheme.typography.titleMedium,
-                      fontWeight = FontWeight.Bold,
-                      modifier = Modifier.padding(16.dp),
-                  )
-                  Divider()
-                  LazyColumn {
-                    items(versions.reversed()) { version ->
-                      Text(
-                          text = version,
-                          modifier =
-                              Modifier.fillMaxWidth()
-                                  .clickable {
-                                    onVersionSelected(version)
-                                    dismiss()
-                                  }
-                                  .padding(horizontal = 16.dp, vertical = 12.dp),
-                          style = MaterialTheme.typography.bodyMedium,
-                          color = MaterialTheme.colorScheme.onSurface,
-                      )
-                    }
-                  }
-                }
-              }
-            }
+      LazyColumn(modifier = Modifier.fillMaxWidth().height(120.dp)) {
+        items(versions) { version ->
+          TextButton(
+              onClick = { selectedVersion = version },
+              modifier = Modifier.fillMaxWidth(),
+          ) {
+            Text(
+                text = version,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Start,
+                fontWeight = if (version == selectedVersion) FontWeight.Bold else FontWeight.Normal,
+            )
           }
         }
+      }
 
-    contentView = composeView
-    width = ViewGroup.LayoutParams.WRAP_CONTENT
-    height = ViewGroup.LayoutParams.WRAP_CONTENT
-    isFocusable = true
-    isOutsideTouchable = true
-    elevation = 16f
-
-    // 必须手动销毁 Composition，否则会内存泄漏
-    setOnDismissListener { composeView.disposeComposition() }
+      Spacer(modifier = Modifier.height(8.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(onClick = { selectedVersion = report.latestVersion }) { Text("Use latest") }
+        Button(
+            onClick = { onApplyClicked(report, selectedVersion) },
+            enabled = hasUpdate || selectedVersion != report.dependency.version,
+        ) {
+          Text("Apply")
+        }
+      }
+    }
   }
 }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
@@ -27,7 +27,34 @@ import com.itsaky.androidide.lsp.api.ILanguageServer
 import com.itsaky.androidide.lsp.api.IServerSettings
 import com.itsaky.androidide.lsp.kotlin.actions.KotlinLspActionsProvider
 import com.itsaky.androidide.lsp.kotlin.events.KotlinTextDocumentSyncHandler
-import com.itsaky.androidide.lsp.models.*
+import com.itsaky.androidide.lsp.models.CodeFormatResult
+import com.itsaky.androidide.lsp.models.CompletionItemKind
+import com.itsaky.androidide.lsp.models.CompletionParams
+import com.itsaky.androidide.lsp.models.CompletionResult
+import com.itsaky.androidide.lsp.models.DefinitionParams
+import com.itsaky.androidide.lsp.models.DefinitionResult
+import com.itsaky.androidide.lsp.models.DiagnosticItem
+import com.itsaky.androidide.lsp.models.DiagnosticResult
+import com.itsaky.androidide.lsp.models.DiagnosticSeverity
+import com.itsaky.androidide.lsp.models.DidChangeTextDocumentParams
+import com.itsaky.androidide.lsp.models.DidCloseTextDocumentParams
+import com.itsaky.androidide.lsp.models.DidOpenTextDocumentParams
+import com.itsaky.androidide.lsp.models.DidSaveTextDocumentParams
+import com.itsaky.androidide.lsp.models.DocumentChange
+import com.itsaky.androidide.lsp.models.ExpandSelectionParams
+import com.itsaky.androidide.lsp.models.FormatCodeParams
+import com.itsaky.androidide.lsp.models.MarkupContent
+import com.itsaky.androidide.lsp.models.MarkupKind
+import com.itsaky.androidide.lsp.models.MatchLevel
+import com.itsaky.androidide.lsp.models.MessageType
+import com.itsaky.androidide.lsp.models.ReferenceParams
+import com.itsaky.androidide.lsp.models.ReferenceResult
+import com.itsaky.androidide.lsp.models.RenameParams
+import com.itsaky.androidide.lsp.models.ShowMessageParams
+import com.itsaky.androidide.lsp.models.SignatureHelp
+import com.itsaky.androidide.lsp.models.SignatureHelpParams
+import com.itsaky.androidide.lsp.models.TextEdit
+import com.itsaky.androidide.lsp.models.WorkspaceEdit
 import com.itsaky.androidide.lsp.util.LSPEditorActions
 import com.itsaky.androidide.models.Location
 import com.itsaky.androidide.models.Position
@@ -41,7 +68,32 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.CompletionCapabilities
+import org.eclipse.lsp4j.CompletionItemCapabilities
+import org.eclipse.lsp4j.DidChangeConfigurationParams
+import org.eclipse.lsp4j.DocumentFormattingParams
+import org.eclipse.lsp4j.ExecuteCommandCapabilities
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.FormattingOptions
+import org.eclipse.lsp4j.HoverCapabilities
+import org.eclipse.lsp4j.HoverParams
+import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.ReferenceContext
+import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.SignatureHelpCapabilities
+import org.eclipse.lsp4j.TextDocumentClientCapabilities
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import org.eclipse.lsp4j.WorkspaceClientCapabilities
+import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageServer
 import java.io.File
@@ -57,9 +109,9 @@ import kotlin.coroutines.resumeWithException
  * @author android_zero
  */
 class KotlinLanguageServerImpl(
-    private val process: Process,
-    val lspServer: LanguageServer
+    private val process: Process
 ) : ILanguageServer {
+    private lateinit var lspServer: LanguageServer
 
     override val serverId: String
         get() = SERVER_ID
@@ -134,6 +186,15 @@ class KotlinLanguageServerImpl(
 
     val clientEndpoint = ClientEndpoint()
 
+    fun bindRemoteServer(remoteServer: LanguageServer) {
+        this.lspServer = remoteServer
+    }
+
+    private fun requireServer(): LanguageServer {
+        check(::lspServer.isInitialized) { "Kotlin LSP remote server is not bound yet." }
+        return lspServer
+    }
+
     override fun connectClient(client: ILanguageClient?) {
         this.client = client
     }
@@ -154,7 +215,7 @@ class KotlinLanguageServerImpl(
                     )
                 )
             )
-            lspServer.workspaceService.didChangeConfiguration(configParams)
+            requireServer().workspaceService.didChangeConfiguration(configParams)
         }
     }
 
@@ -177,7 +238,6 @@ class KotlinLanguageServerImpl(
                     completion = CompletionCapabilities(CompletionItemCapabilities(true))
                     hover = HoverCapabilities()
                     signatureHelp = SignatureHelpCapabilities()
-                    formatting = DocumentFormattingCapabilities()
                 }
                 this.workspace = WorkspaceClientCapabilities().apply {
                     executeCommand = ExecuteCommandCapabilities(true)
@@ -193,8 +253,8 @@ class KotlinLanguageServerImpl(
 
         runBlocking {
             try {
-                lspServer.initialize(initParams).await()
-                lspServer.initialized(InitializedParams())
+                requireServer().initialize(initParams).await()
+                requireServer().initialized(InitializedParams())
                 isInitialized = true
                 KotlinTextDocumentSyncHandler.onServerReady()
                 log.info("LSP4J Kotlin Server Initialized Successfully.")
@@ -225,7 +285,7 @@ class KotlinLanguageServerImpl(
     override fun didOpen(params: DidOpenTextDocumentParams) {
         if (!isInitialized) return
         val item = TextDocumentItem(params.file.toUri().toString(), params.languageId, params.version, params.text)
-        lspServer.textDocumentService.didOpen(org.eclipse.lsp4j.DidOpenTextDocumentParams(item))
+        requireServer().textDocumentService.didOpen(org.eclipse.lsp4j.DidOpenTextDocumentParams(item))
     }
 
     override fun didChange(params: DidChangeTextDocumentParams) {
@@ -235,17 +295,17 @@ class KotlinLanguageServerImpl(
             org.eclipse.lsp4j.TextDocumentContentChangeEvent(it.text) 
         }
         val id = VersionedTextDocumentIdentifier(params.file.toUri().toString(), params.version)
-        lspServer.textDocumentService.didChange(org.eclipse.lsp4j.DidChangeTextDocumentParams(id, changes))
+        requireServer().textDocumentService.didChange(org.eclipse.lsp4j.DidChangeTextDocumentParams(id, changes))
     }
 
     override fun didClose(params: DidCloseTextDocumentParams) {
         if (!isInitialized) return
-        lspServer.textDocumentService.didClose(org.eclipse.lsp4j.DidCloseTextDocumentParams(TextDocumentIdentifier(params.file.toUri().toString())))
+        requireServer().textDocumentService.didClose(org.eclipse.lsp4j.DidCloseTextDocumentParams(TextDocumentIdentifier(params.file.toUri().toString())))
     }
 
     override fun didSave(params: DidSaveTextDocumentParams) {
         if (!isInitialized) return
-        lspServer.textDocumentService.didSave(org.eclipse.lsp4j.DidSaveTextDocumentParams(TextDocumentIdentifier(params.file.toUri().toString()), params.text))
+        requireServer().textDocumentService.didSave(org.eclipse.lsp4j.DidSaveTextDocumentParams(TextDocumentIdentifier(params.file.toUri().toString()), params.text))
     }
 
     // --- 核心特性实现 ---
@@ -260,7 +320,7 @@ class KotlinLanguageServerImpl(
                     params.position.toLsp4j()
                 )
                 
-                val response = lspServer.textDocumentService.completion(lspParams).await()
+                val response = requireServer().textDocumentService.completion(lspParams).await()
                 val items = if (response.isLeft) response.left else response.right.items
                 
                 // 将 LSP4J 的对象转换为 JsonArray，以复用我们强大的 KotlinCompletionConverter 增强逻辑
@@ -303,7 +363,7 @@ class KotlinLanguageServerImpl(
                 TextDocumentIdentifier(params.file.toUri().toString()),
                 params.position.toLsp4j()
             )
-            val result = lspServer.textDocumentService.definition(req).await()
+            val result = requireServer().textDocumentService.definition(req).await()
             val locations = result.left?.map { 
                 Location(File(java.net.URI(it.uri)).toPath(), it.range.toIde())
             } ?: emptyList()
@@ -322,7 +382,7 @@ class KotlinLanguageServerImpl(
                 this.textDocument = TextDocumentIdentifier(params.file.toUri().toString())
                 this.position = params.position.toLsp4j()
             }
-            val result = lspServer.textDocumentService.references(req).await()
+            val result = requireServer().textDocumentService.references(req).await()
             val locations = result?.map { 
                 Location(File(java.net.URI(it.uri)).toPath(), it.range.toIde())
             } ?: emptyList()
@@ -339,7 +399,7 @@ class KotlinLanguageServerImpl(
                 TextDocumentIdentifier(params.file.toUri().toString()),
                 params.position.toLsp4j()
             )
-            val result = lspServer.textDocumentService.hover(req).await()
+            val result = requireServer().textDocumentService.hover(req).await()
             val content = result?.contents?.left?.firstOrNull()?.left ?: result?.contents?.right?.value ?: ""
             MarkupContent(content, MarkupKind.MARKDOWN)
         } catch (e: Exception) {
@@ -361,7 +421,7 @@ class KotlinLanguageServerImpl(
                     TextDocumentIdentifier("file://dummy_for_format"),
                     FormattingOptions(EditorPreferences.tabSize, !EditorPreferences.useSoftTab)
                 )
-                val edits = lspServer.textDocumentService.formatting(req).await()
+                val edits = requireServer().textDocumentService.formatting(req).await()
                 val ideEdits = edits?.map { it.toIde() }?.toMutableList() ?: mutableListOf()
                 CodeFormatResult(false, ideEdits, mutableListOf())
             } catch (e: Exception) {
@@ -382,7 +442,7 @@ class KotlinLanguageServerImpl(
                 params.position.toLsp4j(),
                 params.newName
             )
-            val result = lspServer.textDocumentService.rename(req).await()
+            val result = requireServer().textDocumentService.rename(req).await()
             
             val ideDocumentChanges = mutableListOf<DocumentChange>()
             result?.changes?.forEach { (uri, edits) ->
@@ -400,7 +460,7 @@ class KotlinLanguageServerImpl(
         if (!isInitialized) return null
         return try {
             val params = ExecuteCommandParams(commandName, arguments)
-            val result = lspServer.workspaceService.executeCommand(params).get()
+            val result = requireServer().workspaceService.executeCommand(params).get()
             gson.toJsonTree(result)
         } catch (e: Exception) {
             log.error("Failed to execute workspace command: $commandName", e)
@@ -412,11 +472,11 @@ class KotlinLanguageServerImpl(
         log.info("Shutting down LSP4J Kotlin Server...")
         try {
             runBlocking {
-                lspServer.shutdown().await()
-                lspServer.exit()
+                requireServer().shutdown().await()
+                requireServer().exit()
             }
         } catch (e: Exception) {
-            log.warn("Error during LSP shutdown", e)
+            log.warn("Error during LSP shutdown: ${e.message}")
         } finally {
             try {
                 process.destroy()

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinServerProcessManager.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinServerProcessManager.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.launch.LSPLauncher
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -45,6 +46,7 @@ class KotlinServerProcessManager(private val context: Context) {
 
     private var serverProcess: Process? = null
     private var currentServerImpl: KotlinLanguageServerImpl? = null
+    private var launcher: Launcher<org.eclipse.lsp4j.services.LanguageServer>? = null
     
     // 注入的全局 AndroidIDE 客户端实现，用来做 UI 交互（如报错提示框、代码替换）
     private val kotlinClient: KotlinLanguageClientImpl by lazy { KotlinLanguageClientImpl() }
@@ -148,14 +150,14 @@ class KotlinServerProcessManager(private val context: Context) {
 
             serverProcess = pb.start()
             log.info("Kotlin LSP Native Process started successfully. PID: ${serverProcess?.hashCode()}")
+            startStderrMonitor(serverProcess!!)
 
             // 初始化 LSP4J 通讯协议机制
             currentServerImpl?.shutdown()
             
-            val newServerImpl = KotlinLanguageServerImpl(
-                process = serverProcess!!,
-                lspServer = createLsp4jProxy(serverProcess!!)
-            )
+            val newServerImpl = KotlinLanguageServerImpl(process = serverProcess!!)
+            val remoteProxy = createLsp4jProxy(serverProcess!!, newServerImpl)
+            newServerImpl.bindRemoteServer(remoteProxy)
             
             newServerImpl.connectClient(kotlinClient)
             currentServerImpl = newServerImpl
@@ -174,23 +176,21 @@ class KotlinServerProcessManager(private val context: Context) {
     /**
      * 核心挂载器：创建并启动 LSP4J 协议桥
      */
-    private fun createLsp4jProxy(process: Process): org.eclipse.lsp4j.services.LanguageServer {
-        val serverImpl = KotlinLanguageServerImpl(process, null!!) // 暂时用 null 绕过，下面会马上赋值真正的 serverImpl
-        
-        // 创建客户端端点 (负责接收服务端的反向请求，如 diagnostic, workspaceEdit)
+    private fun createLsp4jProxy(
+        process: Process,
+        serverImpl: KotlinLanguageServerImpl
+    ): org.eclipse.lsp4j.services.LanguageServer {
         val clientEndpoint = serverImpl.clientEndpoint
-        
-        // 绑定输入输出流
-        val launcher = LSPLauncher.createClientLauncher(
+        launcher = LSPLauncher.createClientLauncher(
             clientEndpoint,
             process.inputStream,
             process.outputStream
         )
         
         // 启动异步线程窃听服务器返回
-        launcher.startListening()
+        launcher?.startListening()
         
-        return launcher.remoteProxy
+        return launcher!!.remoteProxy
     }
 
     private fun bindWorkspaceWhenReady() {
@@ -211,10 +211,27 @@ class KotlinServerProcessManager(private val context: Context) {
         }
     }
 
+    private fun startStderrMonitor(process: Process) {
+        coroutineScope.launch {
+            try {
+                process.errorStream.bufferedReader().useLines { lines ->
+                    lines.forEach { line ->
+                        if (line.isNotBlank()) {
+                            log.debug("Kotlin LSP stderr: $line")
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+                // ignore stream close during shutdown
+            }
+        }
+    }
+
     fun stopServer() {
         currentServerImpl?.shutdown()
         serverProcess?.destroy()
         serverProcess = null
         currentServerImpl = null
+        launcher = null
     }
 }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/utils/Lsp4jMapper.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/utils/Lsp4jMapper.kt
@@ -6,10 +6,10 @@ package com.itsaky.androidide.lsp.kotlin.utils
 import com.itsaky.androidide.lsp.models.CompletionItemKind
 import com.itsaky.androidide.lsp.models.DiagnosticSeverity
 import com.itsaky.androidide.lsp.models.InsertTextFormat
+import com.itsaky.androidide.lsp.models.TextEdit
 import com.itsaky.androidide.models.Position
 import com.itsaky.androidide.models.Range
 import org.eclipse.lsp4j.Diagnostic
-import org.eclipse.lsp4j.TextEdit
 
 /**
  * 核心：AndroidIDE 自定义 LSP 模型与 Eclipse LSP4J 标准模型的双向映射器。


### PR DESCRIPTION
### Motivation

- Move to a robust LSP4J-based integration by separating the local IDE proxy from the remote `LanguageServer` implementation and ensure safe binding at runtime.
- Improve process management and observability by tracking the `Launcher`, streaming server stderr separately, and preventing JSON-RPC stream corruption.
- Harden mapping and imports to use explicit LSP model types for clearer conversions between IDE models and lsp4j models.

### Description

- Introduce late binding for the remote `LanguageServer` by adding `bindRemoteServer` and `requireServer` to `KotlinLanguageServerImpl`, and replace direct `lspServer` uses with `requireServer()` calls.
- Replace wildcard LSP model imports with explicit imports and add converters and helpers (e.g. `extractPrefix`, completion conversion reuse) inside `KotlinLanguageServerImpl` and better error logging on shutdown.
- Change `KotlinServerProcessManager` to create the LSP4J bridge by passing the `KotlinLanguageServerImpl` into `createLsp4jProxy`, store the `Launcher` instance, call `bindRemoteServer` with the returned remote proxy, and start a dedicated stderr monitor via `startStderrMonitor` to log server stderr lines.
- Add lifecycle cleanup for the stored `launcher` in `stopServer` and adjust launcher usage to null-safe start/listen handling in `createLsp4jProxy`.
- Minor cleanup in `Lsp4jMapper` imports and file newline consistency.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5893a974c832c8765d00e2e2217ec)