### PR TITLE
Fix DependencyUpdateFragment composable structure

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
@@ -268,11 +268,7 @@ private fun DependencyListState(
           style = MaterialTheme.typography.bodySmall,
           color = MaterialTheme.colorScheme.onSurfaceVariant
       )
-      Spacer(modifier = Modifier.height(16.dp))
-      Button(onClick = onRetry) { Text("Retry") }
     }
-  }
-}
 
     if (reports.isEmpty()) {
       Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
### Motivation
- Remove an out-of-scope `onRetry` reference and fix mismatched composable braces to stop Kotlin parse/composable-context errors in `DependencyUpdateFragment.kt`.

### Description
- Deleted the accidental `Button(onClick = onRetry)` call that referenced `onRetry` outside of scope inside `DependencyListState`.
- Fixed closing braces so the reports empty-state and `LazyColumn` rendering remain inside the `DependencyListState` composable.
- Changed `core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt` accordingly and committed the change.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin --no-daemon` which failed due to the CI environment/toolchain error reported by Gradle (`* What went wrong: 25.0.1`).
- No additional automated tests were run in this environment; the change targets Kotlin parse/composable errors observed in the file and restores correct composable structure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e653776afc8322a7a160b5d40b63cd)