### PR TITLE
fix(lsp-kotlin): add Termux shared dependency

### DIFF
--- a/lsp/kotlin/build.gradle.kts
+++ b/lsp/kotlin/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
   api(projects.java.javacServices)
   api(projects.java.lsp)
   api(projects.termux.shell)
+  implementation(projects.termux.shared)
   api(projects.event.eventbusEvents)
 
   implementation(libs.composite.javac)


### PR DESCRIPTION
### Motivation
- The `lsp/kotlin` module imports `com.termux.shared.*` types from `KotlinServerProcessManager.kt` but did not have `projects.termux.shared` on its compile classpath, causing unresolved references like `ExecutionCommand`, `TermuxShellManager`, and `TermuxShellEnvironment`.

### Description
- Add `implementation(projects.termux.shared)` to `lsp/kotlin/build.gradle.kts` so the Termux shared APIs are available to the `lsp:kotlin` module at compile time.

### Testing
- Ran `./gradlew :lsp:kotlin:compileDebugKotlin`; the build fails early in this environment with `java.lang.IllegalArgumentException: 25.0.1` during Gradle Kotlin script evaluation, so full module compilation could not be completed here, but the dependency wiring change is committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d14c2f14832f87cfe3d6ccb7e4c1)