### PR TITLE
Add workspace/executeCommand and code action resolve support; extend Command and CodeAction models

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/lsp/IDELanguageClientImpl.java
+++ b/core/app/src/main/java/com/itsaky/androidide/lsp/IDELanguageClientImpl.java
@@ -33,6 +33,7 @@ import com.itsaky.androidide.editor.ui.IDEEditor;
 import com.itsaky.androidide.fragments.sheets.ProgressSheet;
 import com.itsaky.androidide.lsp.api.ILanguageClient;
 import com.itsaky.androidide.lsp.models.CodeActionItem;
+import com.itsaky.androidide.lsp.models.Command;
 import com.itsaky.androidide.lsp.models.DiagnosticItem;
 import com.itsaky.androidide.lsp.models.DiagnosticResult;
 import com.itsaky.androidide.lsp.models.LogMessageParams;
@@ -192,8 +193,7 @@ public void publishDiagnostics(DiagnosticResult result) {
     if (!params.getAsync()) {
       applyActionEdits(editor, action);
       if (editor != null) {
-        action.getCommand();
-        editor.executeCommand(action.getCommand());
+        executeCommand(action.getCommand());
       }
       return;
     }
@@ -212,7 +212,7 @@ public void publishDiagnostics(DiagnosticResult result) {
             LOG.error("Unable to perform code action result={}", result, throwable);
             FlashbarActivityUtilsKt.flashError(this.activity, string.msg_cannot_perform_fix);
           } else if (editor != null) {
-            editor.executeCommand(action.getCommand());
+            executeCommand(action.getCommand());
           }
         });
   }
@@ -472,6 +472,26 @@ public void publishDiagnostics(DiagnosticResult result) {
   private Unit noOp(final Object obj) {
     return Unit.INSTANCE;
   }
+
+  @Override
+  public void executeCommand(@Nullable Command command) {
+    if (command == null || !canUseActivity()) {
+      return;
+    }
+
+    final var currentEditor = this.activity.getCurrentEditor();
+    final var editor = currentEditor != null ? currentEditor.getEditor() : null;
+    if (editor == null) {
+      return;
+    }
+
+    try {
+      editor.executeCommand(command);
+    } catch (Throwable th) {
+      LOG.error("Failed to execute LSP command: {}", command.getCommand(), th);
+    }
+  }
+
   @Override
   public boolean applyWorkspaceEdit(WorkspaceEdit edit) {
     if (edit == null || edit.getDocumentChanges() == null || edit.getDocumentChanges().isEmpty()) {

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageClient.java
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageClient.java
@@ -19,6 +19,7 @@ package com.itsaky.androidide.lsp.api;
 
 import androidx.annotation.Nullable;
 import com.itsaky.androidide.lsp.models.CodeActionItem;
+import com.itsaky.androidide.lsp.models.Command;
 import com.itsaky.androidide.lsp.models.DiagnosticItem;
 import com.itsaky.androidide.lsp.models.DiagnosticResult;
 import com.itsaky.androidide.lsp.models.PerformCodeActionParams;
@@ -101,6 +102,10 @@ public interface ILanguageClient {
    * @param locations The location to show.
    */
   void showLocations(List<Location> locations);
+
+
+  /** Execute a command returned by server (completion/codeAction/codeLens/etc). */
+  default void executeCommand(@Nullable Command command) {}
 
   /** Apply a workspace edit (documentChanges/resource operations). */
   default boolean applyWorkspaceEdit(WorkspaceEdit edit) {

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageServer.kt
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageServer.kt
@@ -45,6 +45,7 @@ import com.itsaky.androidide.lsp.models.DidCloseTextDocumentParams
 import com.itsaky.androidide.lsp.models.DidOpenTextDocumentParams
 import com.itsaky.androidide.lsp.models.DidSaveTextDocumentParams
 import com.itsaky.androidide.lsp.models.DocumentLink
+import com.itsaky.androidide.lsp.models.ExecuteCommandParams
 import com.itsaky.androidide.lsp.models.DocumentSymbolsResult
 import com.itsaky.androidide.lsp.models.ExpandSelectionParams
 import com.itsaky.androidide.lsp.models.FoldingRange
@@ -57,6 +58,7 @@ import com.itsaky.androidide.lsp.models.ReferenceParams
 import com.itsaky.androidide.lsp.models.ReferenceResult
 import com.itsaky.androidide.lsp.models.RenameParams
 import com.itsaky.androidide.lsp.models.SelectionRange
+import com.itsaky.androidide.lsp.models.CodeActionItem
 import com.itsaky.androidide.lsp.models.SelectionRangesParams
 import com.itsaky.androidide.lsp.models.SemanticTokens
 import com.itsaky.androidide.lsp.models.SemanticTokensDelta
@@ -270,6 +272,22 @@ interface ILanguageServer {
   /** Type hierarchy prepare. */
   suspend fun typeHierarchy(params: DefinitionParams): List<TypeHierarchyItem> {
     return emptyList()
+  }
+
+  /**
+   * Execute a workspace command on server side (LSP: workspace/executeCommand).
+   *
+   * Implementations should return any protocol-compatible value (including `null`).
+   */
+  suspend fun executeCommand(params: ExecuteCommandParams): Any? {
+    return null
+  }
+
+  /**
+   * Resolve additional code action information lazily (LSP: codeAction/resolve).
+   */
+  suspend fun resolveCodeAction(action: CodeActionItem): CodeActionItem {
+    return action
   }
 
   fun handleFailure(failure: LSPFailure?): Boolean {

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CodeActions.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CodeActions.kt
@@ -40,13 +40,23 @@ data class CodeActionItem(
     var title: String,
     var changes: List<DocumentChange>,
     var kind: CodeActionKind,
-    var command: Command,
+    var command: Command?,
+    var isPreferred: Boolean = false,
+    var disabledReason: String? = null,
+    var data: Any? = null,
 ) {
-  constructor() : this("", ArrayList(), None, Command("", ""))
+  constructor() : this("", ArrayList(), None, null, false, null, null)
 }
 
 enum class CodeActionKind {
   QuickFix,
+  Refactor,
+  RefactorExtract,
+  RefactorInline,
+  RefactorRewrite,
+  Source,
+  SourceOrganizeImports,
+  SourceFixAll,
   None,
 }
 

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CommandExecution.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CommandExecution.kt
@@ -1,0 +1,29 @@
+package com.itsaky.androidide.lsp.models
+
+/** Client capability for workspace/executeCommand. */
+data class ExecuteCommandClientCapabilities(
+    var dynamicRegistration: Boolean = false,
+)
+
+/** Server capability for workspace/executeCommand. */
+data class ExecuteCommandOptions(
+    var commands: List<String> = emptyList(),
+    var workDoneProgress: Boolean = false,
+)
+
+/** Registration options for dynamic workspace/executeCommand registration. */
+data class ExecuteCommandRegistrationOptions(
+    var commands: List<String> = emptyList(),
+    var workDoneProgress: Boolean = false,
+)
+
+/** Request params for workspace/executeCommand. */
+data class ExecuteCommandParams(
+    var command: String,
+    var arguments: List<Any?>? = null,
+)
+
+/** Response wrapper for workspace/executeCommand. */
+data class ExecuteCommandResult(
+    var result: Any? = null,
+)

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Completions.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Completions.kt
@@ -276,7 +276,13 @@ constructor(
     val allowCommandExecution: Boolean = false,
 )
 
-data class Command(var title: String, var command: String) {
+data class Command(
+    var title: String,
+    var command: String,
+    var arguments: List<Any?>? = null,
+) {
+  constructor(title: String, command: String) : this(title, command, null)
+
   companion object {
 
     /** Action for triggering a signature help request to the language server. */

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Initialization.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Initialization.kt
@@ -29,6 +29,9 @@ data class ServerCapabilities(
     var signatureHelpAvailable: Boolean,
     var codeAnalysisAvailable: Boolean,
     var smartSelectionsEnabled: Boolean,
+    var executeCommandAvailable: Boolean,
+    var supportedCommands: List<String>,
+    var codeActionResolveAvailable: Boolean,
 ) {
-  constructor() : this(false, false, false, false, false, false, false)
+  constructor() : this(false, false, false, false, false, false, false, false, emptyList(), false)
 }

--- a/lsp/kotlin/build.gradle.kts
+++ b/lsp/kotlin/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
   api(projects.java.javacServices)
   api(projects.java.lsp)
   api(projects.termux.shell)
+  implementation(projects.termux.shared)
   api(projects.event.eventbusEvents)
 
   implementation(libs.composite.javac)


### PR DESCRIPTION
### Motivation

- Add support for LSP workspace command execution and richer code action semantics so servers can request client-side command execution and resolve code actions lazily.
- Extend models and capabilities to carry command arguments, supported commands list, and additional code action metadata required by modern language servers.

### Description

- Introduce `ExecuteCommand` request/response models and client/server capability/registration types in `lsp-models` to represent `workspace/executeCommand` protocol pieces.
- Extend `Command` with optional `arguments` and convenience constructor, and update usages across completions and client code to accept nullable commands.
- Expand `CodeActionItem` to allow nullable `command`, `isPreferred`, `disabledReason`, and `data`, and add a `resolveCodeAction` suspend function to `ILanguageServer` for lazy resolution of code actions.
- Add `executeCommand` default method to `ILanguageClient` and implement `executeCommand` in `IDELanguageClientImpl` to safely run commands in the active editor with error logging; update code action execution paths to use the new helper.
- Add server `ServerCapabilities` fields for `executeCommandAvailable`, `supportedCommands`, and `codeActionResolveAvailable`, and initialize defaults.
- Add `termux.shared` project dependency in the Kotlin LSP module buildscript where required.

### Testing

- Ran the project Gradle build (`./gradlew build`) locally to ensure compilation across changed modules and the build completed successfully.
- Ran unit tests via Gradle (`./gradlew test`) and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d14c2f14832f87cfe3d6ccb7e4c1)