### PR TITLE
Make Matrix APM debug-only, add LSP command execution, and various stability/UI fixes

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -88,6 +88,10 @@ android {
           "META-INF/versions/9/OSGI-INF/MANIFEST.MF",
       )
   packaging {
+    jniLibs {
+      // matrix-backtrace 与 zero-regular-preview 都携带 libc++_shared.so，合并时需去重
+      pickFirsts += setOf("lib/*/libc++_shared.so")
+    }
     resources {
       pickFirsts +=
           setOf(
@@ -148,14 +152,14 @@ dependencies {
   implementation(libs.common.utilcode)
   implementation(libs.common.glide)
   implementation(libs.common.jsoup)
-  implementation(libs.common.matrix.android.lib)
-  implementation(libs.common.matrix.android.commons)
-  implementation(libs.common.matrix.trace.canary)
-  implementation(libs.common.matrix.resource.canary)
-  implementation(libs.common.matrix.io.canary)
-  implementation(libs.common.matrix.sqlite.lint)
-  implementation(libs.common.matrix.battery.canary)
-  implementation(libs.common.matrix.traffic)
+  debugImplementation(libs.common.matrix.android.lib)
+  debugImplementation(libs.common.matrix.android.commons)
+  debugImplementation(libs.common.matrix.trace.canary)
+  debugImplementation(libs.common.matrix.resource.canary)
+  debugImplementation(libs.common.matrix.io.canary)
+  debugImplementation(libs.common.matrix.sqlite.lint)
+  debugImplementation(libs.common.matrix.battery.canary)
+  debugImplementation(libs.common.matrix.traffic)
   implementation(libs.common.kotlin.coroutines.android)
   implementation(libs.common.retrofit)
   implementation(libs.common.retrofit.gson)

--- a/core/app/src/main/java/com/itsaky/androidide/adapters/EditorBottomSheetTabAdapter.java
+++ b/core/app/src/main/java/com/itsaky/androidide/adapters/EditorBottomSheetTabAdapter.java
@@ -29,6 +29,7 @@ import com.itsaky.androidide.fragments.output.AppLogFragment;
 import com.itsaky.androidide.fragments.output.BuildOutputFragment;
 import com.itsaky.androidide.fragments.output.IDELogFragment;
 import com.itsaky.androidide.app.MatrixApmPanelFragment;
+import com.itsaky.androidide.BuildConfig;
 import android.zero.studio.terminal.TermuxFragment;
 import com.itsaky.androidide.resources.R;
 import java.util.ArrayList;
@@ -74,8 +75,10 @@ public class EditorBottomSheetTabAdapter extends FragmentStateAdapter {
     this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_regular_preview), 
        com.itsaky.androidide.repository.dependencies.analyzer.ui.DependencyUpdateFragment.class, ++index));
        
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_apm_panel), 
-       MatrixApmPanelFragment.class, ++index));
+    if (BuildConfig.DEBUG) {
+      this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_apm_panel), 
+         MatrixApmPanelFragment.class, ++index));
+    }
 
     //诊断
      this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_diags),

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -127,13 +127,15 @@ class IDEApplication : TermuxApplication() {
     }
 
     Environment.init(this)
-    MatrixApmTracker.init(this)
-    MatrixApmInitializer.init(this)
-    MatrixApmTracker.reportModuleEvent(
-        module = "app",
-        event = "startup",
-        costMs = System.currentTimeMillis() - bootStart,
-    )
+    if (BuildConfig.DEBUG) {
+      MatrixApmTracker.init(this)
+      MatrixApmInitializer.init(this)
+      MatrixApmTracker.reportModuleEvent(
+          module = "app",
+          event = "startup",
+          costMs = System.currentTimeMillis() - bootStart,
+      )
+    }
   }
 
   /**

--- a/core/app/src/main/java/com/itsaky/androidide/app/MatrixApmInitializer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/MatrixApmInitializer.kt
@@ -1,6 +1,7 @@
 package com.itsaky.androidide.app
 
 import android.app.Application
+import com.itsaky.androidide.BuildConfig
 import java.lang.reflect.Proxy
 import org.slf4j.LoggerFactory
 
@@ -18,6 +19,10 @@ object MatrixApmInitializer {
   )
 
   fun init(application: Application) {
+    if (!BuildConfig.DEBUG) {
+      log.info("Matrix APM disabled for non-debug build")
+      return
+    }
     val apmConfig = MatrixApmConfig.load(application)
     val issueStore = MatrixIssueStore(application)
     issueStore.pruneOld(apmConfig.issueRetentionDays)

--- a/core/app/src/main/java/com/itsaky/androidide/app/MatrixApmTracker.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/MatrixApmTracker.kt
@@ -1,6 +1,7 @@
 package com.itsaky.androidide.app
 
 import android.app.Application
+import com.itsaky.androidide.BuildConfig
 
 /** 二阶段后半段：业务模块级自定义埋点。 */
 object MatrixApmTracker {
@@ -8,12 +9,14 @@ object MatrixApmTracker {
   @Volatile private var issueStore: MatrixIssueStore? = null
 
   fun init(application: Application) {
+    if (!BuildConfig.DEBUG) return
     if (issueStore == null) {
       issueStore = MatrixIssueStore(application)
     }
   }
 
   fun reportModuleEvent(module: String, event: String, costMs: Long? = null, extra: String? = null) {
+    if (!BuildConfig.DEBUG) return
     val payload =
         buildString {
           append("event=").append(event)

--- a/core/app/src/main/java/com/itsaky/androidide/app/MatrixIssueStore.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/MatrixIssueStore.kt
@@ -5,6 +5,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import org.json.JSONObject
 import org.slf4j.LoggerFactory
 
 /** Matrix Issue 本地持久化（ndjson），用于二阶段全链路观测。 */
@@ -61,11 +62,15 @@ class MatrixIssueStore(private val application: Application) {
   }
 
   private fun parseLine(line: String): MatrixIssueRecord? {
-    val ts = Regex(""""ts":(\\d+)""").find(line)?.groupValues?.getOrNull(1)?.toLongOrNull()
-    val plugin = Regex(""""plugin":"([^"]*)"""").find(line)?.groupValues?.getOrNull(1)
-    val content = Regex(""""content":"(.*)"}$""").find(line)?.groupValues?.getOrNull(1)
-    if (ts == null || plugin == null || content == null) return null
-    return MatrixIssueRecord(ts, plugin, content)
+    return runCatching {
+          val obj = JSONObject(line)
+          val ts = obj.optLong("ts", -1L)
+          val plugin = obj.optString("plugin", "")
+          val content = obj.optString("content", "")
+          if (ts <= 0L || plugin.isBlank()) return null
+          MatrixIssueRecord(ts, plugin, content)
+        }
+        .getOrNull()
   }
 
   fun export(records: List<MatrixIssueRecord>, target: File): File {

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/output/LogViewFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/output/LogViewFragment.kt
@@ -288,6 +288,19 @@ abstract class LogViewFragment :
   }
 
   override fun clearOutput() {
-    _binding?.editor?.setText("")?.also { isEmpty = true }
+    logHandler.removeCallbacks(logRunnable)
+    cacheLock.withLock {
+      cache.clear()
+      cacheLineTrack.clear()
+      lastLog = -1L
+    }
+
+    ThreadUtils.runOnUiThread {
+      _binding?.editor?.let { editor ->
+        val text = editor.text
+        text.delete(0, text.length)
+        isEmpty = true
+      }
+    }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/lsp/IDELanguageClientImpl.java
+++ b/core/app/src/main/java/com/itsaky/androidide/lsp/IDELanguageClientImpl.java
@@ -33,6 +33,7 @@ import com.itsaky.androidide.editor.ui.IDEEditor;
 import com.itsaky.androidide.fragments.sheets.ProgressSheet;
 import com.itsaky.androidide.lsp.api.ILanguageClient;
 import com.itsaky.androidide.lsp.models.CodeActionItem;
+import com.itsaky.androidide.lsp.models.Command;
 import com.itsaky.androidide.lsp.models.DiagnosticItem;
 import com.itsaky.androidide.lsp.models.DiagnosticResult;
 import com.itsaky.androidide.lsp.models.LogMessageParams;
@@ -192,8 +193,7 @@ public void publishDiagnostics(DiagnosticResult result) {
     if (!params.getAsync()) {
       applyActionEdits(editor, action);
       if (editor != null) {
-        action.getCommand();
-        editor.executeCommand(action.getCommand());
+        executeCommand(action.getCommand());
       }
       return;
     }
@@ -212,7 +212,7 @@ public void publishDiagnostics(DiagnosticResult result) {
             LOG.error("Unable to perform code action result={}", result, throwable);
             FlashbarActivityUtilsKt.flashError(this.activity, string.msg_cannot_perform_fix);
           } else if (editor != null) {
-            editor.executeCommand(action.getCommand());
+            executeCommand(action.getCommand());
           }
         });
   }
@@ -472,6 +472,26 @@ public void publishDiagnostics(DiagnosticResult result) {
   private Unit noOp(final Object obj) {
     return Unit.INSTANCE;
   }
+
+  @Override
+  public void executeCommand(@Nullable Command command) {
+    if (command == null || !canUseActivity()) {
+      return;
+    }
+
+    final var currentEditor = this.activity.getCurrentEditor();
+    final var editor = currentEditor != null ? currentEditor.getEditor() : null;
+    if (editor == null) {
+      return;
+    }
+
+    try {
+      editor.executeCommand(command);
+    } catch (Throwable th) {
+      LOG.error("Failed to execute LSP command: {}", command.getCommand(), th);
+    }
+  }
+
   @Override
   public boolean applyWorkspaceEdit(WorkspaceEdit edit) {
     if (edit == null || edit.getDocumentChanges() == null || edit.getDocumentChanges().isEmpty()) {

--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/internal/KotlinAstAnalyzer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/internal/KotlinAstAnalyzer.kt
@@ -45,7 +45,7 @@ class KotlinAstAnalyzer : ScriptAnalyzer {
             nextBlock = funcName
           } else if (currentBlock == "dependencies") {
             if (DependencyDslConfigurations.isDependencyConfiguration(funcName)) {
-              extractDependency(node, funcName, text, file, deps)
+              extractDependency(node, funcName, text, file, deps, versionVariables)
             }
           } else if (currentBlock == "repositories" || currentBlock == "pluginManagement") {
             extractRepository(node, funcName, text, file, repos)
@@ -72,6 +72,7 @@ class KotlinAstAnalyzer : ScriptAnalyzer {
       text: String,
       file: File,
       deps: MutableList<ScopedDependencyInfo>,
+      versionVariables: Map<String, Pair<String, TextRange>>,
   ) {
     var argsNode: TSNode? = null
     for (i in 0 until callNode.childCount) {

--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
@@ -18,9 +18,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -263,9 +260,8 @@ private fun DependencyListState(
     onApplyClicked: (UpdateReport, String) -> Unit
 ) {
   val listState = rememberLazyListState()
-  val pullRefreshState = rememberPullRefreshState(refreshing = isRefreshing, onRefresh = onRefresh)
 
-  Box(modifier = Modifier.fillMaxSize().padding(innerPadding).pullRefresh(pullRefreshState)) {
+  Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
     Column(modifier = Modifier.fillMaxSize()) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
@@ -281,6 +277,7 @@ private fun DependencyListState(
           onClick = { onFilterChange(DependencyFilter.ALL) },
           label = { Text("All ($totalCount)") }
       )
+      OutlinedButton(onClick = onRefresh, enabled = !isRefreshing) { Text("Refresh") }
     }
 
     if (!warningMessage.isNullOrBlank()) {
@@ -320,11 +317,6 @@ private fun DependencyListState(
         }
       }
     }
-    PullRefreshIndicator(
-        refreshing = isRefreshing,
-        state = pullRefreshState,
-        modifier = Modifier.align(Alignment.TopCenter)
-    )
   }
 }
 

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/DefaultLanguageServerRegistry.java
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/DefaultLanguageServerRegistry.java
@@ -29,6 +29,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -126,7 +127,15 @@ public class DefaultLanguageServerRegistry extends ILanguageServerRegistry {
     }
 
     ILogger.ROOT.debug("Dispatching ProjectInitializedEvent to language servers...");
-    for (final var server : mRegister.values()) {
+    final List<ILanguageServer> servers;
+    lock.readLock().lock();
+    try {
+      servers = List.copyOf(mRegister.values());
+    } finally {
+      lock.readLock().unlock();
+    }
+
+    for (final var server : servers) {
       server.setupWorkspace(workspace);
     }
   }

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageClient.java
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageClient.java
@@ -19,6 +19,7 @@ package com.itsaky.androidide.lsp.api;
 
 import androidx.annotation.Nullable;
 import com.itsaky.androidide.lsp.models.CodeActionItem;
+import com.itsaky.androidide.lsp.models.Command;
 import com.itsaky.androidide.lsp.models.DiagnosticItem;
 import com.itsaky.androidide.lsp.models.DiagnosticResult;
 import com.itsaky.androidide.lsp.models.PerformCodeActionParams;
@@ -101,6 +102,10 @@ public interface ILanguageClient {
    * @param locations The location to show.
    */
   void showLocations(List<Location> locations);
+
+
+  /** Execute a command returned by server (completion/codeAction/codeLens/etc). */
+  default void executeCommand(@Nullable Command command) {}
 
   /** Apply a workspace edit (documentChanges/resource operations). */
   default boolean applyWorkspaceEdit(WorkspaceEdit edit) {

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageServer.kt
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageServer.kt
@@ -45,6 +45,7 @@ import com.itsaky.androidide.lsp.models.DidCloseTextDocumentParams
 import com.itsaky.androidide.lsp.models.DidOpenTextDocumentParams
 import com.itsaky.androidide.lsp.models.DidSaveTextDocumentParams
 import com.itsaky.androidide.lsp.models.DocumentLink
+import com.itsaky.androidide.lsp.models.ExecuteCommandParams
 import com.itsaky.androidide.lsp.models.DocumentSymbolsResult
 import com.itsaky.androidide.lsp.models.ExpandSelectionParams
 import com.itsaky.androidide.lsp.models.FoldingRange
@@ -57,6 +58,7 @@ import com.itsaky.androidide.lsp.models.ReferenceParams
 import com.itsaky.androidide.lsp.models.ReferenceResult
 import com.itsaky.androidide.lsp.models.RenameParams
 import com.itsaky.androidide.lsp.models.SelectionRange
+import com.itsaky.androidide.lsp.models.CodeActionItem
 import com.itsaky.androidide.lsp.models.SelectionRangesParams
 import com.itsaky.androidide.lsp.models.SemanticTokens
 import com.itsaky.androidide.lsp.models.SemanticTokensDelta
@@ -270,6 +272,22 @@ interface ILanguageServer {
   /** Type hierarchy prepare. */
   suspend fun typeHierarchy(params: DefinitionParams): List<TypeHierarchyItem> {
     return emptyList()
+  }
+
+  /**
+   * Execute a workspace command on server side (LSP: workspace/executeCommand).
+   *
+   * Implementations should return any protocol-compatible value (including `null`).
+   */
+  suspend fun executeCommand(params: ExecuteCommandParams): Any? {
+    return null
+  }
+
+  /**
+   * Resolve additional code action information lazily (LSP: codeAction/resolve).
+   */
+  suspend fun resolveCodeAction(action: CodeActionItem): CodeActionItem {
+    return action
   }
 
   fun handleFailure(failure: LSPFailure?): Boolean {

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CodeActions.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CodeActions.kt
@@ -40,13 +40,23 @@ data class CodeActionItem(
     var title: String,
     var changes: List<DocumentChange>,
     var kind: CodeActionKind,
-    var command: Command,
+    var command: Command?,
+    var isPreferred: Boolean = false,
+    var disabledReason: String? = null,
+    var data: Any? = null,
 ) {
-  constructor() : this("", ArrayList(), None, Command("", ""))
+  constructor() : this("", ArrayList(), None, null, false, null, null)
 }
 
 enum class CodeActionKind {
   QuickFix,
+  Refactor,
+  RefactorExtract,
+  RefactorInline,
+  RefactorRewrite,
+  Source,
+  SourceOrganizeImports,
+  SourceFixAll,
   None,
 }
 

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CommandExecution.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/CommandExecution.kt
@@ -1,0 +1,29 @@
+package com.itsaky.androidide.lsp.models
+
+/** Client capability for workspace/executeCommand. */
+data class ExecuteCommandClientCapabilities(
+    var dynamicRegistration: Boolean = false,
+)
+
+/** Server capability for workspace/executeCommand. */
+data class ExecuteCommandOptions(
+    var commands: List<String> = emptyList(),
+    var workDoneProgress: Boolean = false,
+)
+
+/** Registration options for dynamic workspace/executeCommand registration. */
+data class ExecuteCommandRegistrationOptions(
+    var commands: List<String> = emptyList(),
+    var workDoneProgress: Boolean = false,
+)
+
+/** Request params for workspace/executeCommand. */
+data class ExecuteCommandParams(
+    var command: String,
+    var arguments: List<Any?>? = null,
+)
+
+/** Response wrapper for workspace/executeCommand. */
+data class ExecuteCommandResult(
+    var result: Any? = null,
+)

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Completions.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Completions.kt
@@ -276,7 +276,13 @@ constructor(
     val allowCommandExecution: Boolean = false,
 )
 
-data class Command(var title: String, var command: String) {
+data class Command(
+    var title: String,
+    var command: String,
+    var arguments: List<Any?>? = null,
+) {
+  constructor(title: String, command: String) : this(title, command, null)
+
   companion object {
 
     /** Action for triggering a signature help request to the language server. */

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Initialization.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/Initialization.kt
@@ -29,6 +29,9 @@ data class ServerCapabilities(
     var signatureHelpAvailable: Boolean,
     var codeAnalysisAvailable: Boolean,
     var smartSelectionsEnabled: Boolean,
+    var executeCommandAvailable: Boolean,
+    var supportedCommands: List<String>,
+    var codeActionResolveAvailable: Boolean,
 ) {
-  constructor() : this(false, false, false, false, false, false, false)
+  constructor() : this(false, false, false, false, false, false, false, false, emptyList(), false)
 }

--- a/lsp/kotlin/build.gradle.kts
+++ b/lsp/kotlin/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
   api(projects.java.javacServices)
   api(projects.java.lsp)
   api(projects.termux.shell)
+  implementation(projects.termux.shared)
   api(projects.event.eventbusEvents)
 
   implementation(libs.composite.javac)


### PR DESCRIPTION
### Motivation
- Prevent shipping heavy/telemetry Matrix APM bits and native libc clashes into non-debug builds while keeping them available during development.
- Add proper LSP `workspace/executeCommand` support and safer handling of code actions/commands for editors.
- Improve robustness of log clearing and Matrix issue parsing to avoid brittle parsing and threading issues.

### Description
- Move Matrix dependencies to `debugImplementation` and add a packaging rule to `pickFirst` `lib/*/libc++_shared.so` to deduplicate native library conflicts in `core/app/build.gradle.kts`.
- Guard Matrix initialization and tracking with `BuildConfig.DEBUG` checks in `IDEApplication`, `MatrixApmInitializer`, and `MatrixApmTracker` so APM is no-op in non-debug builds.
- Replace ad-hoc regex parsing in `MatrixIssueStore.parseLine` with `JSONObject`-based parsing and keep ndjson export format intact.
- Harden `LogViewFragment.clearOutput` by removing pending callbacks, clearing caches under `cacheLock`, and updating the editor text on the UI thread to avoid race conditions.
- Add LSP command execution support: introduce `ExecuteCommand*` models, extend `Command` with `arguments`, add `ILanguageClient.executeCommand` default, and add `ILanguageServer.executeCommand` and `resolveCodeAction` hooks; update `CodeActionItem` shape to accept nullable `command` and metadata.
- Implement `executeCommand` in `IDELanguageClientImpl` and invoke it after applying code action edits; restructure async flow to call the new API and handle failures safely.
- Make `DefaultLanguageServerRegistry.onProjectInitialized` take a read-locked snapshot (`List.copyOf`) of servers before iterating to avoid concurrent-modification issues.
- Update `KotlinAstAnalyzer.extractDependency` signature to accept `versionVariables` and propagate variable resolution.
- Replace Compose pull-to-refresh usage in `DependencyUpdateFragment` with a manual `Refresh` button and remove `PullRefreshIndicator` usage.
- Add `implementation(projects.termux.shared)` to `lsp/kotlin` dependencies.

### Testing
- Built the project with `./gradlew build` which completed successfully.
- Assembled the debug app with `./gradlew :core:app:assembleDebug` and the task succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d14c2f14832f87cfe3d6ccb7e4c1)