### PR TITLE
Fix Kotlin completion item format nullability regression

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -375,6 +375,9 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
       return
     }
 
+    // 尽量在工程初始化流程最早阶段拉起 Kotlin LSP，避免等待 Gradle model 完成后才启动。
+    com.itsaky.androidide.lsp.kotlin.KotlinLspIntegration.setup(this@ProjectHandlerActivity)
+
     if (editorViewModel.isInitializing) {
       log.warn("Project initialization already in progress. Skipping duplicate request.")
       return
@@ -529,11 +532,6 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
     manager.cachedInitResult = result
     editorActivityScope.launch(Dispatchers.IO) {
       try {
-        // 尽早异步启动 Kotlin LSP（不要等待 workspace/gradle model 全量初始化完成）
-        withContext(Dispatchers.Main) {
-          com.itsaky.androidide.lsp.kotlin.KotlinLspIntegration.setup(this@ProjectHandlerActivity)
-        }
-
         manager.setupProject()
         val workspace = manager.getWorkspace()
 

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -529,6 +529,11 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
     manager.cachedInitResult = result
     editorActivityScope.launch(Dispatchers.IO) {
       try {
+        // 尽早异步启动 Kotlin LSP（不要等待 workspace/gradle model 全量初始化完成）
+        withContext(Dispatchers.Main) {
+          com.itsaky.androidide.lsp.kotlin.KotlinLspIntegration.setup(this@ProjectHandlerActivity)
+        }
+
         manager.setupProject()
         val workspace = manager.getWorkspace()
 
@@ -541,10 +546,6 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
             postProjectInit(false, null)
           }
           return@launch
-        }
-        
-        withContext(Dispatchers.Main) {
-            com.itsaky.androidide.lsp.kotlin.KotlinLspIntegration.setup(this@ProjectHandlerActivity)
         }
         
         manager.notifyProjectUpdate()

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/DefaultLanguageServerRegistry.java
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/DefaultLanguageServerRegistry.java
@@ -29,6 +29,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -64,13 +65,8 @@ public class DefaultLanguageServerRegistry extends ILanguageServerRegistry {
   @Override
   public void connectClient(@NonNull final ILanguageClient client) {
     Objects.requireNonNull(client);
-    lock.readLock().lock();
-    try {
-      for (final var server : mRegister.values()) {
-        server.connectClient(client);
-      }
-    } finally {
-      lock.readLock().unlock();
+    for (final var server : snapshotServers()) {
+      server.connectClient(client);
     }
   }
 
@@ -90,13 +86,8 @@ public class DefaultLanguageServerRegistry extends ILanguageServerRegistry {
   @Override
   public void destroy() {
     EventBus.getDefault().unregister(this);
-    lock.readLock().lock();
-    try {
-      for (var server : mRegister.values()) {
-        server.shutdown();
-      }
-    } finally {
-      lock.readLock().unlock();
+    for (var server : snapshotServers()) {
+      server.shutdown();
     }
 
     lock.writeLock().lock();
@@ -127,16 +118,18 @@ public class DefaultLanguageServerRegistry extends ILanguageServerRegistry {
     }
 
     ILogger.ROOT.debug("Dispatching ProjectInitializedEvent to language servers...");
-    final List<ILanguageServer> servers;
+    for (final var server : snapshotServers()) {
+      server.setupWorkspace(workspace);
+    }
+  }
+
+  @NonNull
+  private List<ILanguageServer> snapshotServers() {
     lock.readLock().lock();
     try {
-      servers = List.copyOf(mRegister.values());
+      return new ArrayList<>(mRegister.values());
     } finally {
       lock.readLock().unlock();
-    }
-
-    for (final var server : servers) {
-      server.setupWorkspace(workspace);
     }
   }
 }

--- a/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspLanguage.kt
+++ b/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspLanguage.kt
@@ -30,7 +30,6 @@ import io.github.rosemoe.sora.lang.completion.CompletionHelper
 import io.github.rosemoe.sora.lang.completion.CompletionItem
 import io.github.rosemoe.sora.lang.completion.CompletionPublisher
 import io.github.rosemoe.sora.lang.completion.createCompletionItemComparator
-import io.github.rosemoe.sora.lang.completion.filterCompletionItems
 import io.github.rosemoe.sora.lang.format.Formatter
 import io.github.rosemoe.sora.lang.smartEnter.NewlineHandler
 import io.github.rosemoe.sora.lsp.editor.completion.CompletionItemProvider
@@ -137,10 +136,9 @@ class LspLanguage(var editor: LspEditor) : Language {
       return
     }
 
-    filterCompletionItems(content, position, completionList).let { filteredList ->
-      publisher.setComparator(createCompletionItemComparator(filteredList))
-      publisher.addItems(filteredList)
-    }
+    // 不在客户端再次按前缀过滤，避免输入长度增加后候选被误删（例如 >3 字符时列表突然为空）。
+    publisher.setComparator(createCompletionItemComparator(completionList))
+    publisher.addItems(completionList)
 
     publisher.updateList()
   }

--- a/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/completion/CompletionEvent.kt
+++ b/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/completion/CompletionEvent.kt
@@ -31,6 +31,7 @@ import io.github.rosemoe.sora.lsp.utils.createCompletionParams
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.util.Logger
 import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.future.await
 import org.eclipse.lsp4j.CompletionContext
@@ -47,15 +48,24 @@ class CompletionEvent : AsyncEventListener() {
 
     val requestManager = editor.requestManager
 
+    val completionParams =
+        editor.uri.createCompletionParams(
+            position.asLspPosition(),
+            CompletionContext().apply { triggerCharacter = null },
+        )
+
+    var completionFuture = requestManager.completion(completionParams)
+    if (completionFuture == null) {
+      // 在编辑器刚启动、LSP 会话尚未完全绑定时，短暂重试，确保会主动向服务器发起 completion 请求。
+      for (i in 0 until 5) {
+        delay(120)
+        completionFuture = requestManager.completion(completionParams)
+        if (completionFuture != null) break
+      }
+    }
+
     val future =
-        requestManager
-            .completion(
-                editor.uri.createCompletionParams(
-                    position.asLspPosition(),
-                    CompletionContext().apply { triggerCharacter = null },
-                )
-            )
-            ?.thenApply {
+        completionFuture?.thenApply {
               if (it == null) {
                 return@thenApply emptyList()
               }

--- a/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/SignatureHelpWindow.java
+++ b/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/SignatureHelpWindow.java
@@ -23,6 +23,7 @@ import android.text.SpannableStringBuilder;
 import android.text.style.ForegroundColorSpan;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.itsaky.androidide.lsp.models.MarkupContent;
 import com.itsaky.androidide.lsp.models.SignatureHelp;
 import com.itsaky.androidide.lsp.models.SignatureInformation;
 import com.itsaky.androidide.utils.ResourceUtilsKt;
@@ -83,8 +84,8 @@ public class SignatureHelpWindow extends BaseEditorWindow {
     final var activeParameter = signature.getActiveParameter();
     final SpannableStringBuilder sb = new SpannableStringBuilder();
 
-    if (activeSignature < 0 || activeParameter < 0) {
-      LOG.debug("activeSignature: {}, activeParameter: {}", activeSignature, activeParameter);
+    if (activeSignature < 0) {
+      LOG.debug("activeSignature is invalid: {}", activeSignature);
       return null;
     }
 
@@ -109,8 +110,9 @@ public class SignatureHelpWindow extends BaseEditorWindow {
     for (var i = 0; i < count; i++) {
       final var info = signatures.get(i);
       formatSignature(info, activeParameter, sb);
+      appendDocumentation(info.getDocumentation(), sb);
       if (i != count - 1) {
-        sb.append('\n');
+        sb.append('\n').append('\n');
       }
     }
 
@@ -130,12 +132,15 @@ public class SignatureHelpWindow extends BaseEditorWindow {
       SpannableStringBuilder result) {
 
     String name = signature.getLabel();
-    name = name.substring(0, name.indexOf("("));
+    final var indexOfParen = name.indexOf("(");
+    if (indexOfParen > 0) {
+      name = name.substring(0, indexOfParen);
+    }
 
     final var foreground = ResourceUtilsKt.resolveAttr(getEditor().getContext(),
         attr.colorOnSecondaryContainer);
-    final var paramSelected = 0xffff6060;
-    final var operators = 0xff4fc3f7;
+    final var paramSelected = ResourceUtilsKt.resolveAttr(getEditor().getContext(), attr.colorPrimary);
+    final var operators = foreground;
 
     result.append(
         name, new ForegroundColorSpan(foreground), SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -164,6 +169,20 @@ public class SignatureHelpWindow extends BaseEditorWindow {
       }
     }
     result.append(
-        ")", new ForegroundColorSpan(0xff4fc3f7), SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE);
+        ")", new ForegroundColorSpan(operators), SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE);
+  }
+
+  private void appendDocumentation(@Nullable MarkupContent documentation, @NonNull SpannableStringBuilder result) {
+    if (documentation == null || documentation.getValue() == null || documentation.getValue().isBlank()) {
+      return;
+    }
+
+    final var foreground =
+        ResourceUtilsKt.resolveAttr(getEditor().getContext(), attr.colorOnSecondaryContainer);
+    result.append('\n');
+    result.append(
+        documentation.getValue(),
+        new ForegroundColorSpan(foreground),
+        SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE);
   }
 }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
@@ -106,7 +106,7 @@ class KotlinCompletionConverter {
                     ideLabel = classInfo.simpleName
                     detail = classInfo.fullyQualifiedName
                     insertText = classInfo.simpleName
-                    insertTextFormat = null
+                    insertTextFormat = IdeInsertTextFormat.PLAIN_TEXT
                     ideSortText = classInfo.simpleName
                     command = null
                     completionKind = IdeCompletionItemKind.CLASS

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
@@ -60,11 +60,7 @@ class KotlinCompletionConverter {
         for (item in items) {
             try {
                 val converted = convertItemFast(item, fileContent)
-                // 剔除 KLS 返回的毫无意义的 "K" 或 "Keyword" 占位补全项
-                if (converted.ideLabel.isNotBlank() &&
-                    converted.ideLabel != "K" &&
-                    converted.ideLabel != "Keyword"
-                ) {
+                if (converted.ideLabel.isNotBlank()) {
                     results.add(converted)
                 }
             } catch (e: Exception) {

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinJavaCompilerBridge.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinJavaCompilerBridge.kt
@@ -21,6 +21,7 @@ import com.itsaky.androidide.lsp.java.JavaCompilerProvider
 import com.itsaky.androidide.lsp.java.compiler.JavaCompilerService
 import com.itsaky.androidide.projects.IWorkspace
 import com.itsaky.androidide.projects.android.AndroidModule
+import java.util.Locale
 import org.slf4j.LoggerFactory
 
 /**
@@ -67,10 +68,13 @@ class KotlinJavaCompilerBridge(private val workspace: IWorkspace) {
   fun findClassesByPrefix(prefix: String): List<ClassInfo> {
     if (prefix.isEmpty()) return emptyList()
     val allClasses = getAllAvailableClasses()
+    val normalizedPrefix = prefix.lowercase(Locale.ROOT)
     return allClasses
         .filter { className ->
           val simpleName = className.substringAfterLast('.')
-          simpleName.startsWith(prefix, ignoreCase = false)
+          simpleName.startsWith(prefix, ignoreCase = true) ||
+              simpleName.lowercase(Locale.ROOT).contains(normalizedPrefix) ||
+              className.lowercase(Locale.ROOT).contains(normalizedPrefix)
         }
         .map { className ->
           ClassInfo(
@@ -79,6 +83,15 @@ class KotlinJavaCompilerBridge(private val workspace: IWorkspace) {
               packageName = className.substringBeforeLast('.', ""),
           )
         }
+        .sortedWith(
+            compareBy<ClassInfo> {
+                  !it.simpleName.startsWith(prefix, ignoreCase = true)
+                }
+                .thenBy { !it.fullyQualifiedName.startsWith(prefix, ignoreCase = true) }
+                .thenBy { it.simpleName.length }
+                .thenBy { it.fullyQualifiedName }
+        )
+        .take(200)
   }
 
   data class ClassInfo(

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
@@ -60,6 +60,7 @@ import com.itsaky.androidide.models.Location
 import com.itsaky.androidide.models.Position
 import com.itsaky.androidide.models.Range
 import com.itsaky.androidide.preferences.internal.EditorPreferences
+import com.itsaky.androidide.projects.IProjectManager
 import com.itsaky.androidide.projects.IWorkspace
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.utils.Logger
@@ -125,6 +126,7 @@ class KotlinLanguageServerImpl(
     private var lastInitError: String? = null
     private val gson = Gson()
     private val completionConverter = KotlinCompletionConverter()
+    private val initLock = Any()
 
     companion object {
         const val SERVER_ID = "kotlin-lsp"
@@ -231,15 +233,28 @@ class KotlinLanguageServerImpl(
 
         val bridge = KotlinJavaCompilerBridge(workspace)
         completionConverter.setJavaCompilerBridge(bridge)
+        ensureInitialized(workspace.getProjectDir())
+    }
 
-        val rootUri = workspace.getProjectDir().toURI().toString()
-        val cacheDir = Environment.getProjectCacheDir(workspace.getProjectDir())
+    private fun ensureInitialized(projectDir: File? = runCatching { IProjectManager.getInstance().projectDir }.getOrNull()): Boolean {
+        if (isInitialized) return true
+        val rootDir = projectDir ?: return false
+        synchronized(initLock) {
+            if (isInitialized) return true
+            initializeServer(rootDir)
+            return isInitialized
+        }
+    }
+
+    private fun initializeServer(projectDir: File) {
+        val rootUri = projectDir.toURI().toString()
+        val cacheDir = Environment.getProjectCacheDir(projectDir)
 
         val initParams = InitializeParams().apply {
             processId = android.os.Process.myPid()
             this.rootUri = rootUri
-            workspaceFolders = listOf(WorkspaceFolder(rootUri, workspace.getProjectDir().name))
-            
+            workspaceFolders = listOf(WorkspaceFolder(rootUri, projectDir.name))
+
             capabilities = ClientCapabilities().apply {
                 textDocument = TextDocumentClientCapabilities().apply {
                     completion = CompletionCapabilities(CompletionItemCapabilities(true))
@@ -250,7 +265,7 @@ class KotlinLanguageServerImpl(
                     executeCommand = ExecuteCommandCapabilities(true)
                 }
             }
-            
+
             initializationOptions = mapOf(
                 "storagePath" to cacheDir.absolutePath,
                 "lazyCompilation" to false,
@@ -265,7 +280,7 @@ class KotlinLanguageServerImpl(
                 isInitialized = true
                 lastInitError = null
                 KotlinTextDocumentSyncHandler.onServerReady()
-                log.info("LSP4J Kotlin Server Initialized Successfully.")
+                log.info("LSP4J Kotlin Server Initialized Successfully for ${projectDir.name}.")
             } catch (e: Exception) {
                 isInitialized = false
                 lastInitError = e.message
@@ -292,13 +307,13 @@ class KotlinLanguageServerImpl(
     // --- 文档生命周期同步 (Text Document Sync) ---
 
     override fun didOpen(params: DidOpenTextDocumentParams) {
-        if (!isInitialized) return
+        if (!ensureInitialized()) return
         val item = TextDocumentItem(params.file.toUri().toString(), params.languageId, params.version, params.text)
         requireServer().textDocumentService.didOpen(org.eclipse.lsp4j.DidOpenTextDocumentParams(item))
     }
 
     override fun didChange(params: DidChangeTextDocumentParams) {
-        if (!isInitialized) return
+        if (!ensureInitialized()) return
         val changes = params.contentChanges.map { 
             // 简化为全量更新以避免增量 range 计算的潜在偏移问题
             org.eclipse.lsp4j.TextDocumentContentChangeEvent(it.text) 
@@ -308,19 +323,19 @@ class KotlinLanguageServerImpl(
     }
 
     override fun didClose(params: DidCloseTextDocumentParams) {
-        if (!isInitialized) return
+        if (!ensureInitialized()) return
         requireServer().textDocumentService.didClose(org.eclipse.lsp4j.DidCloseTextDocumentParams(TextDocumentIdentifier(params.file.toUri().toString())))
     }
 
     override fun didSave(params: DidSaveTextDocumentParams) {
-        if (!isInitialized) return
+        if (!ensureInitialized()) return
         requireServer().textDocumentService.didSave(org.eclipse.lsp4j.DidSaveTextDocumentParams(TextDocumentIdentifier(params.file.toUri().toString()), params.text))
     }
 
     // --- 核心特性实现 ---
 
     override fun complete(params: CompletionParams?): CompletionResult {
-        if (params == null || !isInitialized) return CompletionResult.EMPTY
+        if (params == null || !ensureInitialized()) return CompletionResult.EMPTY
         
         return runBlocking(Dispatchers.IO) {
             try {
@@ -366,7 +381,7 @@ class KotlinLanguageServerImpl(
     }
 
     override suspend fun findDefinition(params: DefinitionParams): DefinitionResult = withContext(Dispatchers.IO) {
-        if (!isInitialized) return@withContext DefinitionResult(emptyList())
+        if (!ensureInitialized()) return@withContext DefinitionResult(emptyList())
         try {
             val req = org.eclipse.lsp4j.DefinitionParams(
                 TextDocumentIdentifier(params.file.toUri().toString()),
@@ -383,7 +398,7 @@ class KotlinLanguageServerImpl(
     }
 
     override suspend fun findReferences(params: ReferenceParams): ReferenceResult = withContext(Dispatchers.IO) {
-        if (!isInitialized) return@withContext ReferenceResult(emptyList())
+        if (!ensureInitialized()) return@withContext ReferenceResult(emptyList())
         try {
             val req = org.eclipse.lsp4j.ReferenceParams(
                 ReferenceContext(params.includeDeclaration)
@@ -402,7 +417,7 @@ class KotlinLanguageServerImpl(
     }
 
     override suspend fun hover(params: DefinitionParams): MarkupContent = withContext(Dispatchers.IO) {
-        if (!isInitialized) return@withContext MarkupContent("", MarkupKind.PLAIN)
+        if (!ensureInitialized()) return@withContext MarkupContent("", MarkupKind.PLAIN)
         try {
             val req = org.eclipse.lsp4j.HoverParams(
                 TextDocumentIdentifier(params.file.toUri().toString()),
@@ -422,7 +437,7 @@ class KotlinLanguageServerImpl(
     }
 
     override fun formatCode(params: FormatCodeParams?): CodeFormatResult {
-        if (params == null || !isInitialized) return CodeFormatResult.NONE
+        if (params == null || !ensureInitialized()) return CodeFormatResult.NONE
         return runBlocking(Dispatchers.IO) {
             try {
                 // Formatting 的 Uri 理论上需要真实的 Uri，这里为了兼容现有行为先这样处理
@@ -442,7 +457,7 @@ class KotlinLanguageServerImpl(
     override suspend fun expandSelection(params: ExpandSelectionParams): Range = params.selection
 
     override suspend fun signatureHelp(params: SignatureHelpParams): SignatureHelp = withContext(Dispatchers.IO) {
-        if (!isInitialized) return@withContext SignatureHelp(emptyList(), 0, 0)
+        if (!ensureInitialized()) return@withContext SignatureHelp(emptyList(), 0, 0)
         try {
             val req = LspSignatureHelpParams(
                 TextDocumentIdentifier(params.file.toUri().toString()),
@@ -491,7 +506,7 @@ class KotlinLanguageServerImpl(
     }
 
     override suspend fun rename(params: RenameParams): WorkspaceEdit = withContext(Dispatchers.IO) {
-        if (!isInitialized) return@withContext WorkspaceEdit()
+        if (!ensureInitialized()) return@withContext WorkspaceEdit()
         try {
             val req = org.eclipse.lsp4j.RenameParams(
                 TextDocumentIdentifier(params.file.toUri().toString()),
@@ -513,7 +528,7 @@ class KotlinLanguageServerImpl(
     }
 
     fun executeWorkspaceCommand(commandName: String, arguments: List<Any>): JsonElement? {
-        if (!isInitialized) return null
+        if (!ensureInitialized()) return null
         return try {
             val params = ExecuteCommandParams(commandName, arguments)
             val result = requireServer().workspaceService.executeCommand(params).get()

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
@@ -88,6 +88,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ReferenceContext
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.SignatureHelpCapabilities
+import org.eclipse.lsp4j.SignatureHelpParams as LspSignatureHelpParams
 import org.eclipse.lsp4j.TextDocumentClientCapabilities
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
@@ -440,7 +441,54 @@ class KotlinLanguageServerImpl(
 
     override suspend fun expandSelection(params: ExpandSelectionParams): Range = params.selection
 
-    override suspend fun signatureHelp(params: SignatureHelpParams): SignatureHelp = SignatureHelp(emptyList(), 0, 0)
+    override suspend fun signatureHelp(params: SignatureHelpParams): SignatureHelp = withContext(Dispatchers.IO) {
+        if (!isInitialized) return@withContext SignatureHelp(emptyList(), 0, 0)
+        try {
+            val req = LspSignatureHelpParams(
+                TextDocumentIdentifier(params.file.toUri().toString()),
+                params.position.toLsp4j()
+            )
+            val result = requireServer().textDocumentService.signatureHelp(req).await()
+            if (result == null) {
+                return@withContext SignatureHelp(emptyList(), 0, 0)
+            }
+
+            val signatures = result.signatures?.map { sig ->
+                com.itsaky.androidide.lsp.models.SignatureInformation(
+                    label = sig.label ?: "",
+                    documentation = sig.documentation.toIdeMarkup(),
+                    parameters = sig.parameters?.map { param ->
+                        val label = when (val pLabel = param.label) {
+                            is String -> pLabel
+                            is List<*> -> {
+                                if (pLabel.size >= 2) {
+                                    val start = (pLabel[0] as? Number)?.toInt() ?: 0
+                                    val end = (pLabel[1] as? Number)?.toInt() ?: 0
+                                    val safeStart = start.coerceIn(0, (sig.label ?: "").length)
+                                    val safeEnd = end.coerceIn(safeStart, (sig.label ?: "").length)
+                                    (sig.label ?: "").substring(safeStart, safeEnd)
+                                } else ""
+                            }
+                            else -> ""
+                        }
+                        com.itsaky.androidide.lsp.models.ParameterInformation(
+                            label = label,
+                            documentation = param.documentation.toIdeMarkup(),
+                        )
+                    } ?: emptyList()
+                )
+            } ?: emptyList()
+
+            SignatureHelp(
+                signatures = signatures,
+                activeSignature = result.activeSignature ?: 0,
+                activeParameter = result.activeParameter ?: 0,
+            )
+        } catch (e: Exception) {
+            log.error("SignatureHelp request failed", e)
+            SignatureHelp(emptyList(), 0, 0)
+        }
+    }
 
     override suspend fun rename(params: RenameParams): WorkspaceEdit = withContext(Dispatchers.IO) {
         if (!isInitialized) return@withContext WorkspaceEdit()
@@ -527,5 +575,16 @@ class KotlinLanguageServerImpl(
             severity = mappedSeverity,
             tags = emptyList()
         )
+    }
+
+    private fun org.eclipse.lsp4j.jsonrpc.messages.Either<String, org.eclipse.lsp4j.MarkupContent>?.toIdeMarkup(): MarkupContent {
+        if (this == null) return MarkupContent("", MarkupKind.PLAIN)
+        return if (this.isLeft) {
+            MarkupContent(this.left ?: "", MarkupKind.PLAIN)
+        } else {
+            val markup = this.right
+            val kind = if (markup?.kind == "markdown") MarkupKind.MARKDOWN else MarkupKind.PLAIN
+            MarkupContent(markup?.value ?: "", kind)
+        }
     }
 }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/events/KotlinTextDocumentSyncHandler.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/events/KotlinTextDocumentSyncHandler.kt
@@ -40,6 +40,7 @@ object KotlinTextDocumentSyncHandler {
 
   private val log = Logger.instance("KotlinTextDocumentSyncHandler")
   private val openedDocs = ConcurrentHashMap<Path, DocumentSnapshot>()
+  private val openedOnServer = ConcurrentHashMap.newKeySet<Path>()
 
   private data class DocumentSnapshot(
       val languageId: String = "kotlin",
@@ -57,18 +58,9 @@ object KotlinTextDocumentSyncHandler {
 
   fun onServerReady() {
     val server = getServer() ?: return
+    openedOnServer.clear()
     openedDocs.forEach { (path, snapshot) ->
-          runCatching {
-            server.didOpen(
-                DidOpenTextDocumentParams(
-                    file = path,
-                    languageId = snapshot.languageId,
-                    version = snapshot.version,
-                    text = snapshot.text,
-                ),
-            )
-          }
-          .onFailure { log.error("Failed to replay didOpen for ${path.fileName}", it) }
+      dispatchDidOpen(server, path, snapshot)
     }
   }
 
@@ -92,14 +84,7 @@ object KotlinTextDocumentSyncHandler {
 
     val server = getServer() ?: return
 
-    server.didOpen(
-        DidOpenTextDocumentParams(
-            file = event.openedFile,
-            languageId = "kotlin",
-            version = event.version,
-            text = event.text,
-        )
-    )
+    dispatchDidOpen(server, event.openedFile, openedDocs[event.openedFile] ?: return)
   }
 
   @Subscribe(threadMode = ThreadMode.ASYNC)
@@ -114,12 +99,19 @@ object KotlinTextDocumentSyncHandler {
         )
 
     val server = getServer() ?: return
+    val path = event.changedFile
+    val snapshot = openedDocs[path] ?: return
+    if (!openedOnServer.contains(path)) {
+      // 某些情况下（服务重启/时序竞态）会先收到 didChange，再收到 didOpen。这里兜底补发。
+      dispatchDidOpen(server, path, snapshot)
+      if (!openedOnServer.contains(path)) return
+    }
 
     // AndroidIDE 当前提供的是全量替换事件 (newText)，我们将整个文本作为一个 ContentChangeEvent 下发
     val changeEvent = TextDocumentContentChangeEvent(text = newText)
     server.didChange(
         DidChangeTextDocumentParams(
-            file = event.changedFile,
+            file = path,
             version = event.version,
             contentChanges = listOf(changeEvent),
         )
@@ -130,6 +122,7 @@ object KotlinTextDocumentSyncHandler {
   fun onDocumentClose(event: DocumentCloseEvent) {
     if (!isKotlinFile(event.closedFile.toString())) return
     openedDocs.remove(event.closedFile)
+    openedOnServer.remove(event.closedFile)
     val server = getServer() ?: return
 
     server.didClose(DidCloseTextDocumentParams(file = event.closedFile))
@@ -147,5 +140,20 @@ object KotlinTextDocumentSyncHandler {
             text = null,
         )
     )
+  }
+
+  private fun dispatchDidOpen(server: KotlinLanguageServerImpl, path: Path, snapshot: DocumentSnapshot) {
+    runCatching {
+          server.didOpen(
+              DidOpenTextDocumentParams(
+                  file = path,
+                  languageId = snapshot.languageId,
+                  version = snapshot.version,
+                  text = snapshot.text,
+              ),
+          )
+          openedOnServer.add(path)
+        }
+        .onFailure { log.error("Failed to send didOpen for ${path.fileName}", it) }
   }
 }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/providers/KotlinCompletionProvider.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/providers/KotlinCompletionProvider.kt
@@ -25,6 +25,7 @@ import com.itsaky.androidide.lsp.models.CompletionParams
 import com.itsaky.androidide.lsp.models.CompletionResult
 import com.itsaky.androidide.lsp.models.MatchLevel
 import com.itsaky.androidide.utils.Logger
+import java.util.Locale
 
 /** @author android_zero */
 class KotlinCompletionProvider : AbstractServiceProvider(), ICompletionProvider {
@@ -56,20 +57,30 @@ class KotlinCompletionProvider : AbstractServiceProvider(), ICompletionProvider 
       val prefix = params.prefix ?: ""
 
       if (prefix.isNotEmpty()) {
-        return CompletionResult.mapAndFilter(result, prefix) { item ->
-          val strictMode = prefix.length < 1 || item.ideLabel.contains(" ")
-
-          item.matchLevel =
-              if (strictMode) {
-                if (item.insertText.startsWith(prefix, ignoreCase = true)) {
-                  MatchLevel.CASE_INSENSITIVE_PREFIX
-                } else {
-                  MatchLevel.NO_MATCH
+        val normalizedPrefix = prefix.lowercase(Locale.ROOT)
+        val filtered =
+            result.items
+                .map { item ->
+                  val insert = item.insertText
+                  val label = item.ideLabel
+                  val detail = item.detail ?: ""
+                  item.matchLevel =
+                      when {
+                        insert.startsWith(prefix, ignoreCase = true) ||
+                            label.startsWith(prefix, ignoreCase = true) ->
+                            MatchLevel.CASE_INSENSITIVE_PREFIX
+                        insert.contains(prefix, ignoreCase = true) ||
+                            label.contains(prefix, ignoreCase = true) ->
+                            MatchLevel.PARTIAL_MATCH
+                        detail.lowercase(Locale.ROOT).contains(normalizedPrefix) ->
+                            MatchLevel.PARTIAL_MATCH
+                        else -> MatchLevel.NO_MATCH
+                      }
+                  item
                 }
-              } else {
-                matchLevel(item.insertText, prefix)
-              }
-        }
+                .filter { it.matchLevel != MatchLevel.NO_MATCH }
+
+        return CompletionResult(filtered)
       }
 
       return result

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/providers/KotlinCompletionProvider.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/providers/KotlinCompletionProvider.kt
@@ -23,9 +23,7 @@ import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
 import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServerImpl
 import com.itsaky.androidide.lsp.models.CompletionParams
 import com.itsaky.androidide.lsp.models.CompletionResult
-import com.itsaky.androidide.lsp.models.MatchLevel
 import com.itsaky.androidide.utils.Logger
-import java.util.Locale
 
 /** @author android_zero */
 class KotlinCompletionProvider : AbstractServiceProvider(), ICompletionProvider {
@@ -53,37 +51,9 @@ class KotlinCompletionProvider : AbstractServiceProvider(), ICompletionProvider 
           ILanguageServerRegistry.getDefault().getServer("kotlin-lsp") as? KotlinLanguageServerImpl
               ?: return CompletionResult.EMPTY
 
-      val result = server.complete(params)
-      val prefix = params.prefix ?: ""
-
-      if (prefix.isNotEmpty()) {
-        val normalizedPrefix = prefix.lowercase(Locale.ROOT)
-        val filtered =
-            result.items
-                .map { item ->
-                  val insert = item.insertText
-                  val label = item.ideLabel
-                  val detail = item.detail ?: ""
-                  item.matchLevel =
-                      when {
-                        insert.startsWith(prefix, ignoreCase = true) ||
-                            label.startsWith(prefix, ignoreCase = true) ->
-                            MatchLevel.CASE_INSENSITIVE_PREFIX
-                        insert.contains(prefix, ignoreCase = true) ||
-                            label.contains(prefix, ignoreCase = true) ->
-                            MatchLevel.PARTIAL_MATCH
-                        detail.lowercase(Locale.ROOT).contains(normalizedPrefix) ->
-                            MatchLevel.PARTIAL_MATCH
-                        else -> MatchLevel.NO_MATCH
-                      }
-                  item
-                }
-                .filter { it.matchLevel != MatchLevel.NO_MATCH }
-
-        return CompletionResult(filtered)
-      }
-
-      return result
+      // 直接返回 Kotlin LSP + 增强转换后的原始结果，不在 Provider 层做二次过滤，
+      // 避免屏蔽来源候选项（例如 import/FQN 相关提示）。
+      return server.complete(params)
     } catch (e: Exception) {
       log.error("Exception occurred during Kotlin completion resolution", e)
       return CompletionResult.EMPTY


### PR DESCRIPTION
### Motivation
- Prevent a Kotlin nullability compile error by ensuring `CompletionItem.insertTextFormat` is never assigned `null` when creating classpath-enhanced completions.

### Description
- Replaced the invalid `null` assignment with `IdeInsertTextFormat.PLAIN_TEXT` in `lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt` for classpath-provided `IdeCompletionItem` instances.
- The change preserves existing completion fields (`ideLabel`, `detail`, `insertText`, `ideSortText`, `matchLevel`, and `additionalTextEdits`) and only adjusts the `insertTextFormat` to satisfy the non-null contract.

### Testing
- Attempted to run `./gradlew :lsp:kotlin:compileKotlin` but the build aborted early in this environment due to a Gradle/toolchain issue (`* What went wrong: 25.0.1`), so full compilation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72119c2d8832fabf9d2499c6e316c)