### PR TITLE
Fix Compose dependency update screen refresh lifecycle

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt
@@ -153,15 +153,15 @@ fun DependencyUpdateScreen(
         reports = emptyList()
         errorMessage = e.message ?: "Unknown error while loading dependencies."
         onFlashError("Dependency scan failed: ${errorMessage}")
-      // } finally {
+      } finally {
         // MatrixApmTracker.reportModuleEvent(
-            // module = "dependency-scan",
-            // event = if (errorMessage == null) "refresh_ok" else "refresh_error",
-            // costMs = System.currentTimeMillis() - scanStart,
-            // extra = "count=${reports.size}"
+        //     module = "dependency-scan",
+        //     event = if (errorMessage == null) "refresh_ok" else "refresh_error",
+        //     costMs = System.currentTimeMillis() - scanStart,
+        //     extra = "count=${reports.size}"
         // )
-        // isLoading = false
-      // }
+        isLoading = false
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- A broken `try/catch/finally` in `DependencyUpdateScreen.refresh()` left cleanup code commented out, causing the Kotlin compiler to mis-parse downstream top-level `@Composable` functions as local functions and leaving the UI stuck in loading state.
- Restore proper control flow so the loading flag is always cleared and the composables remain top-level and valid.

### Description
- Restored the `finally` block inside `DependencyUpdateScreen.refresh()` and re-enabled `isLoading = false` so the loading state is cleared on both success and failure. 
- Preserved the existing APM tracking block as commented code but adjusted indentation so the block remains syntactically valid. 
- Change is limited to `core/app/src/main/java/com/itsaky/androidide/repository/dependencies/analyzer/ui/DependencyUpdateFragment.kt` and fixes the coroutine lifecycle/flow and function layout for Compose UI.

### Testing
- Attempted to run `./gradlew :core:app:compileDebugKotlin --stacktrace`; the build fails in this environment during Gradle/Kotlin script evaluation with `IllegalArgumentException: 25.0.1` (JDK version parsing issue), so module compilation could not be reached and no further automated tests ran.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ed924000832fa85496b4fc4defc2)