### PR TITLE
Improve Kotlin completion relevance and reduce class-only noise

### DIFF
--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
@@ -123,7 +123,7 @@ class KotlinCompletionConverter {
         val detail = item.detail ?: ""
         
         // LSP4J 中，优先取 textEdit 中的文本，其次取 insertText，最后降级取 label
-        var insertText = item.textEdit?.left?.newText ?: item.insertText ?: label
+        var insertText = extractInsertText(item, label)
         val sortText = item.sortText
         
         val isSnippet = item.insertTextFormat == Lsp4jInsertTextFormat.Snippet
@@ -188,6 +188,17 @@ class KotlinCompletionConverter {
         }
     }
 
+    private fun extractInsertText(item: Lsp4jCompletionItem, fallbackLabel: String): String {
+        val textEdit = item.textEdit
+        val fromTextEdit =
+            when {
+                textEdit == null -> null
+                textEdit.isLeft -> textEdit.left?.newText
+                else -> textEdit.right?.newText
+            }
+        return fromTextEdit ?: item.insertText ?: fallbackLabel
+    }
+
     /** 提取由 LSP4J 给出的 additionalTextEdits 里的 import 语句 */
     private fun extractImportFromAdditionalEdits(edits: List<Lsp4jTextEdit>?): String? {
         if (edits.isNullOrEmpty()) return null
@@ -211,6 +222,7 @@ class KotlinCompletionConverter {
             Lsp4jCompletionItemKind.Module -> IdeCompletionItemKind.MODULE
             Lsp4jCompletionItemKind.Property -> IdeCompletionItemKind.PROPERTY
             Lsp4jCompletionItemKind.Value -> IdeCompletionItemKind.VALUE
+            Lsp4jCompletionItemKind.Constant -> IdeCompletionItemKind.VALUE
             Lsp4jCompletionItemKind.Enum -> IdeCompletionItemKind.ENUM
             Lsp4jCompletionItemKind.Keyword -> IdeCompletionItemKind.KEYWORD
             Lsp4jCompletionItemKind.Snippet -> IdeCompletionItemKind.SNIPPET

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinCompletionConverter.kt
@@ -69,7 +69,8 @@ class KotlinCompletionConverter {
         }
 
         // 如果用户输入了至少 1 个字符，向本地 Java/Android 类库请求跨层补全
-        val classpathItems = if (prefix.length >= 1 && javaCompilerBridge != null) {
+        val shouldQueryClasspath = prefix.length >= 1 && prefix.firstOrNull()?.isUpperCase() == true
+        val classpathItems = if (shouldQueryClasspath && javaCompilerBridge != null) {
             getClasspathCompletions(prefix, fileContent)
         } else emptyList()
 

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
@@ -354,10 +354,10 @@ class KotlinLanguageServerImpl(
                 val prefix = extractPrefix(contentStr, params.position)
                 
                 val enhancedItems = completionConverter.convertWithClasspathEnhancement(items, contentStr, prefix)
-                
-                enhancedItems.forEach {
-                    it.completionKind = it.completionKind ?: CompletionItemKind.NONE
-                    it.matchLevel = MatchLevel.PARTIAL_MATCH
+
+                enhancedItems.forEach { item ->
+                    item.completionKind = item.completionKind ?: CompletionItemKind.NONE
+                    applyCompletionRanking(item, prefix)
                 }
 
                 CompletionResult(enhancedItems)
@@ -378,6 +378,54 @@ class KotlinLanguageServerImpl(
             start--
         }
         return line.substring(start, col)
+    }
+
+    private fun applyCompletionRanking(
+        item: com.itsaky.androidide.lsp.models.CompletionItem,
+        prefix: String
+    ) {
+        if (prefix.isBlank()) {
+            item.matchLevel = MatchLevel.PARTIAL_MATCH
+            return
+        }
+
+        val normalizedPrefix = prefix.lowercase()
+        val label = item.ideLabel
+        val detail = item.detail
+        val lowerLabel = label.lowercase()
+        val lowerDetail = detail.lowercase()
+
+        val labelMatch = com.itsaky.androidide.lsp.models.CompletionItem.matchLevel(label, prefix)
+        val detailMatch = com.itsaky.androidide.lsp.models.CompletionItem.matchLevel(detail, prefix)
+        item.matchLevel = if (labelMatch != MatchLevel.NO_MATCH) labelMatch else detailMatch
+
+        val labelStarts = lowerLabel.startsWith(normalizedPrefix)
+        val labelContains = !labelStarts && lowerLabel.contains(normalizedPrefix)
+        val detailStarts = !labelStarts && lowerDetail.startsWith(normalizedPrefix)
+        val detailContains = !labelStarts && !detailStarts && lowerDetail.contains(normalizedPrefix)
+
+        val kindPenalty =
+            when (item.completionKind) {
+                CompletionItemKind.METHOD,
+                CompletionItemKind.FUNCTION,
+                CompletionItemKind.PROPERTY,
+                CompletionItemKind.FIELD,
+                CompletionItemKind.VARIABLE -> 0
+                CompletionItemKind.CLASS, CompletionItemKind.INTERFACE, CompletionItemKind.ENUM -> 2
+                else -> 1
+            }
+
+        val matchBucket =
+            when {
+                labelStarts -> 0
+                labelContains -> 1
+                detailStarts -> 2
+                detailContains -> 3
+                else -> 4
+            }
+
+        val existingSort = item.ideSortText ?: item.ideLabel
+        item.ideSortText = "%d%d_%s".format(matchBucket, kindPenalty, existingSort)
     }
 
     override suspend fun findDefinition(params: DefinitionParams): DefinitionResult = withContext(Dispatchers.IO) {


### PR DESCRIPTION
### Motivation
- 补全结果当前把大多数项统一标记为 `PARTIAL_MATCH`，导致主标题(label)命中的项没有优先排前。 
- 类（CLASS）类型候选在普通小写输入（如 `set`）时会占据过高排名，干扰常见的函数/方法/属性候选。 
- 目标是优先匹配主标题、改进相关性排序策略，并降低不相关 Class 候选的干扰。 

### Description
- 在 `KotlinLanguageServerImpl` 中加入 `applyCompletionRanking`，基于用户 `prefix` 计算并设置每个 `CompletionItem` 的 `matchLevel` 与 `ideSortText`，以实现按主标题优先的分桶排序（label 前缀 > label 包含 > detail 前缀 > detail 包含）。
- 在同等匹配下对候选类型加权，使 `METHOD/FUNCTION/PROPERTY/FIELD/VARIABLE` 比 `CLASS/INTERFACE/ENUM` 拥有更高优先级，通过修改 `ideSortText` 达成次级排序。 
- 将原来强制把所有候选设为 `MatchLevel.PARTIAL_MATCH` 的行为移除，改为使用 `CompletionItem.matchLevel` 计算主/副标题匹配等级。 
- 在 `KotlinCompletionConverter` 的 `convertWithClasspathEnhancement` 中仅在前缀首字母为大写时才查询本地类路径（即限制 `getClasspathCompletions` 注入条件），以减少小写输入时的 Class 候选噪音。 

### Testing
- 尝试在本地环境运行 `./gradlew :lsp:kotlin:compileDebugKotlin` 进行快速编译验证。 
- 构建在当前环境中失败（Gradle/Android toolchain 返回 `25.0.1` 错误），属于本地 SDK/工具链限制，故无法在该环境完成完整二进制验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e986858870832f80296241e74545b2)