### PR TITLE
feat(editor): add class-level runtime CPU/memory monitor in editor sidebar

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/actions/sidebar/ClassResourceMonitorSidebarAction.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/actions/sidebar/ClassResourceMonitorSidebarAction.kt
@@ -1,0 +1,25 @@
+package com.itsaky.androidide.actions.sidebar
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import com.itsaky.androidide.R
+import com.itsaky.androidide.fragments.sidebar.ClassResourceMonitorFragment
+import kotlin.reflect.KClass
+
+/** Sidebar action for runtime class-level CPU/memory monitor. */
+class ClassResourceMonitorSidebarAction(context: Context, override val order: Int) :
+    AbstractSidebarAction() {
+
+  companion object {
+    const val ID = "ide.editor.sidebar.classResourceMonitor"
+  }
+
+  override val id: String = ID
+  override val fragmentClass: KClass<out Fragment> = ClassResourceMonitorFragment::class
+
+  init {
+    label = context.getString(R.string.class_resource_monitor)
+    icon = ContextCompat.getDrawable(context, R.drawable.ic_info)
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/TemplateListFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/TemplateListFragment.kt
@@ -33,6 +33,7 @@ import com.itsaky.androidide.templates.ITemplateProvider
 import com.itsaky.androidide.templates.ProjectTemplate
 import com.itsaky.androidide.templates.Template
 import com.itsaky.androidide.templates.TemplateCategory
+import com.itsaky.androidide.utils.ClassResourceMonitor
 import com.itsaky.androidide.viewmodel.MainViewModel
 import org.slf4j.LoggerFactory
 
@@ -82,14 +83,14 @@ class TemplateListFragment :
   }
 
   /** Sets up the TabLayout and ViewPager2 with categorized template data. */
-  private fun setupTabsAndPager() {
+  private fun setupTabsAndPager() = ClassResourceMonitor.trace(log) {
     log.debug("Setting up tabs and pager for templates.")
     val categories = templateProvider.getRegisteredCategories()
 
     if (categories.isEmpty()) {
       log.warn("No template categories are registered. The template list will be empty.")
       // Optionally, show an empty state view here.
-      return
+      return@trace
     }
 
     val pagerAdapter =
@@ -148,12 +149,14 @@ private class CategoryPageAdapter(
 
   override fun onBindViewHolder(holder: PageViewHolder, position: Int) {
     val category = categories[position]
-    val templates = templateProvider.getTemplatesFor(category).filterIsInstance<ProjectTemplate>()
+    ClassResourceMonitor.trace(CategoryPageAdapter::class.java) {
+      val templates = templateProvider.getTemplatesFor(category).filterIsInstance<ProjectTemplate>()
 
-    holder.recyclerView.apply {
-      layoutManager = GridLayoutManager(context, spanCount)
-      adapter = TemplateGridAdapter(templates, onTemplateClick)
-      setHasFixedSize(true)
+      holder.recyclerView.apply {
+        layoutManager = GridLayoutManager(context, spanCount)
+        adapter = TemplateGridAdapter(templates, onTemplateClick)
+        setHasFixedSize(true)
+      }
     }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/sidebar/ClassResourceMonitorAdapter.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/sidebar/ClassResourceMonitorAdapter.kt
@@ -1,0 +1,61 @@
+package com.itsaky.androidide.fragments.sidebar
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.itsaky.androidide.databinding.LayoutClassResourceUsageItemBinding
+
+data class ClassUsageItem(
+    val tag: String,
+    val hits: Long,
+    val totalCpuMs: String,
+    val avgCpuMs: String,
+    val totalMem: String,
+    val avgMem: String,
+    val peakMem: String,
+)
+
+class ClassResourceMonitorAdapter :
+    ListAdapter<ClassUsageItem, ClassResourceMonitorAdapter.ViewHolder>(DIFF) {
+
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    val binding =
+        LayoutClassResourceUsageItemBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false,
+        )
+    return ViewHolder(binding)
+  }
+
+  override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    holder.bind(getItem(position))
+  }
+
+  class ViewHolder(private val binding: LayoutClassResourceUsageItemBinding) :
+      RecyclerView.ViewHolder(binding.root) {
+    fun bind(item: ClassUsageItem) {
+      binding.tagName.text = item.tag
+      binding.statsLine1.text = "calls=${item.hits}  totalCPU=${item.totalCpuMs}  avgCPU=${item.avgCpuMs}"
+      binding.statsLine2.text = "totalMem=${item.totalMem}  avgMem=${item.avgMem}  peakΔ=${item.peakMem}"
+    }
+  }
+
+  companion object {
+    private val DIFF =
+        object : DiffUtil.ItemCallback<ClassUsageItem>() {
+          override fun areItemsTheSame(oldItem: ClassUsageItem, newItem: ClassUsageItem): Boolean {
+            return oldItem.tag == newItem.tag
+          }
+
+          override fun areContentsTheSame(
+              oldItem: ClassUsageItem,
+              newItem: ClassUsageItem,
+          ): Boolean {
+            return oldItem == newItem
+          }
+        }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/sidebar/ClassResourceMonitorFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/sidebar/ClassResourceMonitorFragment.kt
@@ -1,0 +1,90 @@
+package com.itsaky.androidide.fragments.sidebar
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.widget.doAfterTextChanged
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.itsaky.androidide.databinding.FragmentClassResourceMonitorBinding
+import com.itsaky.androidide.fragments.FragmentWithBinding
+import com.itsaky.androidide.utils.ClassResourceMonitor
+import java.util.Locale
+
+/** Editor drawer fragment showing class/tag based CPU and memory usage. */
+class ClassResourceMonitorFragment :
+    FragmentWithBinding<FragmentClassResourceMonitorBinding>(
+        FragmentClassResourceMonitorBinding::inflate
+    ) {
+
+  private val adapter = ClassResourceMonitorAdapter()
+  private val ticker =
+      object : Runnable {
+        override fun run() {
+          refresh()
+          view?.postDelayed(this, REFRESH_INTERVAL_MS)
+        }
+      }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    binding.usagesList.layoutManager = LinearLayoutManager(requireContext())
+    binding.usagesList.adapter = adapter
+
+    binding.searchInput.doAfterTextChanged { refresh() }
+    binding.btnReset.setOnClickListener {
+      ClassResourceMonitor.reset()
+      refresh()
+    }
+
+    refresh()
+    view.post(ticker)
+  }
+
+  override fun onDestroyView() {
+    view?.removeCallbacks(ticker)
+    super.onDestroyView()
+  }
+
+  private fun refresh() {
+    val filter = binding.searchInput.text?.toString().orEmpty().trim().lowercase(Locale.ROOT)
+    val usages =
+        ClassResourceMonitor.snapshot()
+            .asSequence()
+            .filter { it.hits > 0 }
+            .filter { filter.isEmpty() || it.tag.lowercase(Locale.ROOT).contains(filter) }
+            .map {
+              ClassUsageItem(
+                  tag = it.tag,
+                  hits = it.hits,
+                  totalCpuMs = nanosToMillis(it.totalCpuNanos),
+                  avgCpuMs = nanosToMillis(it.avgCpuNanos),
+                  totalMem = formatBytes(it.totalMemoryDeltaBytes),
+                  avgMem = formatBytes(it.avgMemoryDeltaBytes),
+                  peakMem = formatBytes(it.peakMemoryDeltaBytes),
+              )
+            }
+            .toList()
+
+    adapter.submitList(usages)
+    binding.emptyHint.visibility = if (usages.isEmpty()) View.VISIBLE else View.GONE
+  }
+
+  private fun nanosToMillis(nanos: Long): String {
+    val ms = nanos / 1_000_000.0
+    return String.format(Locale.US, "%.2f ms", ms)
+  }
+
+  private fun formatBytes(bytes: Long): String {
+    val abs = kotlin.math.abs(bytes.toDouble())
+    val sign = if (bytes < 0) "-" else ""
+    return when {
+      abs >= 1024 * 1024 -> String.format(Locale.US, "%s%.2f MB", sign, abs / (1024 * 1024.0))
+      abs >= 1024 -> String.format(Locale.US, "%s%.2f KB", sign, abs / 1024.0)
+      else -> String.format(Locale.US, "%s%d B", sign, abs.toLong())
+    }
+  }
+
+  companion object {
+    private const val REFRESH_INTERVAL_MS = 1000L
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/utils/ClassResourceMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/utils/ClassResourceMonitor.kt
@@ -1,0 +1,143 @@
+package com.itsaky.androidide.utils
+
+import android.os.Debug
+import android.os.SystemClock
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.max
+import org.slf4j.Logger
+
+/**
+ * Runtime in-process usage monitor grouped by class tag (or logger name).
+ *
+ * 说明：Android/JVM 在未使用 JVMTI/字节码插桩时，无法直接精确拿到“某个 .kt/.class 当前占用内存”。
+ * 这个监控器采用“打点区间统计”方案：在 begin/end（或 [trace]）区间内累计 CPU 时间和内存变化，
+ * 以类名/Logger 名作为标签，方便精细定位热点。
+ */
+object ClassResourceMonitor {
+
+  data class Sample(
+      val tag: String,
+      val hits: Long,
+      val totalCpuNanos: Long,
+      val avgCpuNanos: Long,
+      val totalMemoryDeltaBytes: Long,
+      val avgMemoryDeltaBytes: Long,
+      val peakMemoryDeltaBytes: Long,
+      val lastUpdatedUptimeMillis: Long,
+  )
+
+  data class Token internal constructor(
+      val id: Long,
+      val tag: String,
+      val startedAtCpuNanos: Long,
+      val startedAtUsedBytes: Long,
+  )
+
+  private data class MutableSample(
+      val tag: String,
+      val hits: AtomicLong = AtomicLong(0L),
+      val totalCpuNanos: AtomicLong = AtomicLong(0L),
+      val totalMemoryDeltaBytes: AtomicLong = AtomicLong(0L),
+      val peakMemoryDeltaBytes: AtomicLong = AtomicLong(0L),
+      val lastUpdatedUptimeMillis: AtomicLong = AtomicLong(0L),
+  )
+
+  private val nextTokenId = AtomicLong(1L)
+  private val activeTokens = ConcurrentHashMap<Long, Token>()
+  private val samples = ConcurrentHashMap<String, MutableSample>()
+
+  @JvmStatic
+  fun begin(tag: String): Token {
+    val token =
+        Token(
+            id = nextTokenId.getAndIncrement(),
+            tag = normalizeTag(tag),
+            startedAtCpuNanos = Debug.threadCpuTimeNanos(),
+            startedAtUsedBytes = usedHeapBytes(),
+        )
+    activeTokens[token.id] = token
+    return token
+  }
+
+  @JvmStatic
+  fun begin(logger: Logger): Token = begin(logger.name)
+
+  @JvmStatic
+  fun begin(clazz: Class<*>): Token = begin(clazz.name)
+
+  @JvmStatic
+  fun end(token: Token) {
+    activeTokens.remove(token.id) ?: return
+
+    val cpuDelta = (Debug.threadCpuTimeNanos() - token.startedAtCpuNanos).coerceAtLeast(0L)
+    val memDelta = usedHeapBytes() - token.startedAtUsedBytes
+
+    val sample = samples.getOrPut(token.tag) { MutableSample(tag = token.tag) }
+    sample.hits.incrementAndGet()
+    sample.totalCpuNanos.addAndGet(cpuDelta)
+    sample.totalMemoryDeltaBytes.addAndGet(memDelta)
+    sample.lastUpdatedUptimeMillis.set(SystemClock.uptimeMillis())
+
+    val memAbs = kotlin.math.abs(memDelta)
+    while (true) {
+      val current = sample.peakMemoryDeltaBytes.get()
+      if (memAbs <= current || sample.peakMemoryDeltaBytes.compareAndSet(current, max(current, memAbs))) {
+        break
+      }
+    }
+  }
+
+  @JvmStatic
+  inline fun <T> trace(tag: String, block: () -> T): T {
+    val token = begin(tag)
+    return try {
+      block()
+    } finally {
+      end(token)
+    }
+  }
+
+  @JvmStatic
+  inline fun <T> trace(logger: Logger, block: () -> T): T = trace(logger.name, block)
+
+  @JvmStatic
+  inline fun <T> trace(clazz: Class<*>, block: () -> T): T = trace(clazz.name, block)
+
+  @JvmStatic
+  fun snapshot(): List<Sample> {
+    return samples.values
+        .map {
+          val hits = it.hits.get().coerceAtLeast(1L)
+          val cpu = it.totalCpuNanos.get()
+          val mem = it.totalMemoryDeltaBytes.get()
+          Sample(
+              tag = it.tag,
+              hits = it.hits.get(),
+              totalCpuNanos = cpu,
+              avgCpuNanos = cpu / hits,
+              totalMemoryDeltaBytes = mem,
+              avgMemoryDeltaBytes = mem / hits,
+              peakMemoryDeltaBytes = it.peakMemoryDeltaBytes.get(),
+              lastUpdatedUptimeMillis = it.lastUpdatedUptimeMillis.get(),
+          )
+        }
+        .sortedByDescending { it.totalCpuNanos }
+  }
+
+  @JvmStatic
+  fun reset() {
+    activeTokens.clear()
+    samples.clear()
+  }
+
+  private fun usedHeapBytes(): Long {
+    val runtime = Runtime.getRuntime()
+    return runtime.totalMemory() - runtime.freeMemory()
+  }
+
+  private fun normalizeTag(tag: String): String {
+    val clean = tag.trim()
+    return if (clean.isEmpty()) "unknown" else clean
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -42,6 +42,7 @@ import com.itsaky.androidide.actions.FillMenuParams
 import com.itsaky.androidide.actions.SidebarActionItem
 import com.itsaky.androidide.actions.internal.DefaultActionsRegistry
 import com.itsaky.androidide.actions.sidebar.BuildVariantsSidebarAction
+import com.itsaky.androidide.actions.sidebar.ClassResourceMonitorSidebarAction
 import com.itsaky.androidide.actions.sidebar.CloseProjectSidebarAction
 import com.itsaky.androidide.actions.sidebar.DataFileTreeSidebarAction
 import com.itsaky.androidide.actions.sidebar.FileTreeSidebarAction
@@ -71,6 +72,7 @@ internal object EditorSidebarActions {
     registry.registerAction(BuildVariantsSidebarAction(context, ++order))
     registry.registerAction(TerminalSidebarAction(context, ++order))
     registry.registerAction(McpFragmentSidebarAction(context, ++order))
+    registry.registerAction(ClassResourceMonitorSidebarAction(context, ++order))
     registry.registerAction(PreferencesSidebarAction(context, ++order))
     registry.registerAction(CloseProjectSidebarAction(context, ++order))
   }

--- a/core/app/src/main/res/layout/fragment_class_resource_monitor.xml
+++ b/core/app/src/main/res/layout/fragment_class_resource_monitor.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:padding="12dp">
+
+  <com.google.android.material.textfield.TextInputLayout
+    android:id="@+id/search_layout"
+    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:hint="@string/class_resource_monitor_filter_hint"
+    app:layout_constraintEnd_toStartOf="@id/btn_reset"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <com.google.android.material.textfield.TextInputEditText
+      android:id="@+id/search_input"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:singleLine="true" />
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.button.MaterialButton
+    android:id="@+id/btn_reset"
+    style="@style/Widget.Material3.Button.OutlinedButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:text="@string/class_resource_monitor_reset"
+    app:layout_constraintBottom_toBottomOf="@id/search_layout"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="@id/search_layout" />
+
+  <com.google.android.material.textview.MaterialTextView
+    android:id="@+id/empty_hint"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp"
+    android:text="@string/class_resource_monitor_empty_hint"
+    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/search_layout" />
+
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/usages_list"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    android:layout_marginTop="8dp"
+    android:clipToPadding="false"
+    android:paddingBottom="8dp"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/empty_hint" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/app/src/main/res/layout/layout_class_resource_usage_item.xml
+++ b/core/app/src/main/res/layout/layout_class_resource_usage_item.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_marginBottom="8dp">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="10dp">
+
+    <com.google.android.material.textview.MaterialTextView
+      android:id="@+id/tag_name"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAppearance="@style/TextAppearance.Material3.TitleSmall" />
+
+    <com.google.android.material.textview.MaterialTextView
+      android:id="@+id/stats_line1"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="4dp"
+      android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+
+    <com.google.android.material.textview.MaterialTextView
+      android:id="@+id/stats_line2"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+  </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -849,4 +849,9 @@
 <string name="summary_open_source_licenses">查看开放源代码许可。</string>
 <string name="idepref_jdkVersion_title">JDK 版本</string>
 <string name="idepref_jdkVersion_summary">当前选择：%1$s（更改需重启）</string>
+
+    <string name="class_resource_monitor">类资源监控</string>
+    <string name="class_resource_monitor_filter_hint">按类名/Logger过滤</string>
+    <string name="class_resource_monitor_reset">重置</string>
+    <string name="class_resource_monitor_empty_hint">暂无采样数据。\n请在代码块外层使用 ClassResourceMonitor.trace(log) 进行统计。</string>
 </resources>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -790,4 +790,9 @@
      <string name="idepref_kotlin_chained_hints">Chained hints</string>
      <string name="idepref_kotlin_diagnostics">Diagnostics</string>
      <string name="idepref_kotlin_remove_unused_imports">Remove unused imports</string>
+
+    <string name="class_resource_monitor">Class Monitor</string>
+    <string name="class_resource_monitor_filter_hint">Filter by class/logger</string>
+    <string name="class_resource_monitor_reset">Reset</string>
+    <string name="class_resource_monitor_empty_hint">No samples yet.\nUse ClassResourceMonitor.trace(log) around code blocks to collect per-class stats.</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Provide fine-grained in-process CPU and heap-delta attribution grouped by class/logger tag (e.g. `LoggerFactory.getLogger(...)`) so developers can pinpoint hot/allocating code blocks without JVMTI or bytecode instrumentation.

### Description
- Added a runtime monitor `ClassResourceMonitor` with `begin/end` and `trace(...)` helpers for `String`, `Logger`, and `Class`, which aggregates thread CPU time and heap delta and exposes `snapshot()` / `reset()` APIs (`core/app/src/main/java/com/itsaky/androidide/utils/ClassResourceMonitor.kt`).
- UI integration: created a new editor sidebar entry and fragment to inspect samples (`ClassResourceMonitorSidebarAction`, `ClassResourceMonitorFragment`, `ClassResourceMonitorAdapter`) plus two layouts for list and item views (`fragment_class_resource_monitor.xml`, `layout_class_resource_usage_item.xml`).
- Wired the sidebar action into `EditorSidebarActions` registration and added example instrumentation to `TemplateListFragment` using `ClassResourceMonitor.trace(log)` and `trace(CategoryPageAdapter::class.java)` to demonstrate companion-object logger usage.
- Added English and zh-CN strings for the new monitor UI (`core/resources/src/main/res/values/strings.xml` and `values-zh-rCN/strings.xml`).

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin` in this environment; the build failed due to an SDK/toolchain issue (`25.0.1`) unrelated to the code changes, so no successful automated compile/test could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea88539730832f8ffdcfb194e4e5f2)