### PR TITLE
feat(apm): add USS/VSS, PSS breakdown, runtime deep signals and temperature card

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/output/EditorProcessApmFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/output/EditorProcessApmFragment.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -252,6 +253,9 @@ private fun EditorApmMonitorScreen(
       }
       item {
         RuntimeSignalsCard(snapshot = snapshot)
+      }
+      item {
+        AdvancedHookCapabilityCard(snapshot = snapshot)
       }
       item {
         HotClassActivityCard(classStats = snapshot?.hotClassStats.orEmpty())
@@ -553,48 +557,96 @@ private fun PssBreakdownCard(stats: List<EditorPssBreakdownStat>) {
 
 @Composable
 private fun RuntimeSignalsCard(snapshot: EditorProcessApmSnapshot?) {
+  val threadMax = snapshot?.topThreadStats?.maxOfOrNull { it.cpuDeltaTicks }?.coerceAtLeast(1L) ?: 1L
   Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
     Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
       Text(stringResource(ResString.string.apm_runtime_signals_title), fontWeight = FontWeight.SemiBold)
-      Text(
-          stringResource(
-              ResString.string.apm_runtime_cpu_breakdown,
-              snapshot?.cpuBreakdownStat?.userCpuMs ?: 0L,
-              snapshot?.cpuBreakdownStat?.systemCpuMs ?: 0L,
-          ),
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-          fontSize = 12.sp,
+      SignalProgressRow(
+          label = stringResource(ResString.string.apm_runtime_cpu_user),
+          value = "${snapshot?.cpuBreakdownStat?.userCpuMs ?: 0L}ms",
+          progress = ((snapshot?.cpuBreakdownStat?.userCpuMs ?: 0L) / 2000f).coerceIn(0f, 1f),
+          tint = Color(0xFF7E57C2),
       )
-      Text(
-          stringResource(
-              ResString.string.apm_runtime_io,
-              snapshot?.ioStat?.readBytes ?: 0L,
-              snapshot?.ioStat?.writeBytes ?: 0L,
-          ),
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-          fontSize = 12.sp,
+      SignalProgressRow(
+          label = stringResource(ResString.string.apm_runtime_cpu_system),
+          value = "${snapshot?.cpuBreakdownStat?.systemCpuMs ?: 0L}ms",
+          progress = ((snapshot?.cpuBreakdownStat?.systemCpuMs ?: 0L) / 2000f).coerceIn(0f, 1f),
+          tint = Color(0xFF5C6BC0),
       )
-      Text(
-          stringResource(
-              ResString.string.apm_runtime_jank,
-              formatFloat(snapshot?.frameJankStat?.frameDropPercent ?: 0.0),
-              snapshot?.frameJankStat?.jankFrameCount ?: 0L,
-              snapshot?.frameJankStat?.totalFrameCount ?: 0L,
-          ),
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-          fontSize = 12.sp,
+      SignalProgressRow(
+          label = stringResource(ResString.string.apm_runtime_io_read),
+          value = "${snapshot?.ioStat?.readBytes ?: 0L}B",
+          progress = (((snapshot?.ioStat?.readBytes ?: 0L).toFloat()) / (1024f * 1024f)).coerceIn(0f, 1f),
+          tint = Color(0xFF00897B),
+      )
+      SignalProgressRow(
+          label = stringResource(ResString.string.apm_runtime_io_write),
+          value = "${snapshot?.ioStat?.writeBytes ?: 0L}B",
+          progress = (((snapshot?.ioStat?.writeBytes ?: 0L).toFloat()) / (1024f * 1024f)).coerceIn(0f, 1f),
+          tint = Color(0xFFF57C00),
+      )
+      SignalProgressRow(
+          label = stringResource(ResString.string.apm_runtime_jank_ratio),
+          value = "${formatFloat(snapshot?.frameJankStat?.frameDropPercent ?: 0.0)}%",
+          progress = (((snapshot?.frameJankStat?.frameDropPercent ?: 0.0) / 100.0).toFloat()).coerceIn(0f, 1f),
+          tint = Color(0xFFC62828),
       )
       if (snapshot?.topThreadStats?.isNotEmpty() == true) {
         Text(stringResource(ResString.string.apm_runtime_top_threads), fontWeight = FontWeight.Medium)
         snapshot.topThreadStats.take(5).forEach { thread ->
-          Text(
-              "T${thread.tid} ${thread.name} • Δticks=${thread.cpuDeltaTicks}",
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-              fontSize = 12.sp,
+          val progress = (thread.cpuDeltaTicks.toFloat() / threadMax.toFloat()).coerceIn(0f, 1f)
+          SignalProgressRow(
+              label = "T${thread.tid} ${thread.name}",
+              value = "Δ${thread.cpuDeltaTicks}",
+              progress = progress,
+              tint = Color(0xFF3949AB),
           )
         }
       }
     }
+  }
+}
+
+@Composable
+private fun SignalProgressRow(
+    label: String,
+    value: String,
+    progress: Float,
+    tint: Color,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+      Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      Text(value, fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = tint)
+    }
+    LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth(), color = tint)
+  }
+}
+
+@Composable
+private fun AdvancedHookCapabilityCard(snapshot: EditorProcessApmSnapshot?) {
+  val stat = snapshot?.advancedHookStat
+  Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(stringResource(ResString.string.apm_hook_title), fontWeight = FontWeight.SemiBold)
+      HookStateRow("JVMTI", stat?.jvmtiReady == true)
+      HookStateRow("PLT Hook", stat?.pltHookReady == true)
+      HookStateRow("Inline Hook", stat?.inlineHookReady == true)
+      HookStateRow("malloc hook", stat?.mallocHookReady == true)
+      HookStateRow("libmemunreachable", stat?.memUnreachableReady == true)
+      stat?.notes?.take(3)?.forEach {
+        Text("• $it", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+      }
+    }
+  }
+}
+
+@Composable
+private fun HookStateRow(name: String, ready: Boolean) {
+  val tint = if (ready) Color(0xFF2E7D32) else Color(0xFFF9A825)
+  Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+    Text(name, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Text(if (ready) stringResource(ResString.string.apm_hook_ready) else stringResource(ResString.string.apm_hook_not_ready), color = tint, fontWeight = FontWeight.Bold)
   }
 }
 

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/output/EditorProcessApmFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/output/EditorProcessApmFragment.kt
@@ -57,6 +57,7 @@ import com.itsaky.androidide.activities.editor.ProjectHandlerActivity
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.lsp.IDELanguageClientImpl
 import com.itsaky.androidide.monitor.EditorHotClassStat
+import com.itsaky.androidide.monitor.EditorPssBreakdownStat
 import com.itsaky.androidide.monitor.EditorProcessApmMonitor
 import com.itsaky.androidide.monitor.EditorProcessApmSnapshot
 import com.itsaky.androidide.monitor.EditorSubsystemStat
@@ -210,6 +211,9 @@ private fun EditorApmMonitorScreen(
         )
       }
       item {
+        TemperatureStatusCard(snapshot = snapshot)
+      }
+      item {
         AdvancedOverviewCard(snapshot = snapshot)
       }
       item {
@@ -219,6 +223,8 @@ private fun EditorApmMonitorScreen(
         MetricGrid(
             listOf(
                 stringResource(ResString.string.apm_metric_rss) to format(snapshot?.processRssMb, "MB"),
+                stringResource(ResString.string.apm_metric_uss) to format(snapshot?.processUssMb, "MB"),
+                stringResource(ResString.string.apm_metric_vss) to format(snapshot?.processVssMb, "MB"),
                 stringResource(ResString.string.apm_metric_java_heap) to
                     "${format(snapshot?.javaHeapUsedMb, "MB")} / ${format(snapshot?.javaHeapMaxMb, "MB")}",
                 stringResource(ResString.string.apm_metric_native_heap) to format(snapshot?.nativeHeapMb, "MB"),
@@ -242,11 +248,49 @@ private fun EditorApmMonitorScreen(
         }
       }
       item {
+        PssBreakdownCard(stats = snapshot?.pssBreakdownStats.orEmpty())
+      }
+      item {
+        RuntimeSignalsCard(snapshot = snapshot)
+      }
+      item {
         HotClassActivityCard(classStats = snapshot?.hotClassStats.orEmpty())
       }
       item {
         TermuxSubsystemCard(stats = snapshot?.termuxSubsystemStats.orEmpty())
       }
+    }
+  }
+}
+
+@Composable
+private fun TemperatureStatusCard(snapshot: EditorProcessApmSnapshot?) {
+  val temp = snapshot?.deviceThermalStat?.batteryTempCelsius
+  val level = snapshot?.deviceThermalStat?.level ?: "unknown"
+  val (textColor, label) =
+      when (level) {
+        "danger" -> Color(0xFFC62828) to stringResource(ResString.string.apm_temp_state_danger)
+        "warning" -> Color(0xFFF9A825) to stringResource(ResString.string.apm_temp_state_warning)
+        "safe" -> Color(0xFF2E7D32) to stringResource(ResString.string.apm_temp_state_safe)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant to stringResource(ResString.string.apm_temp_state_unknown)
+      }
+
+  Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+      Text(stringResource(ResString.string.apm_temp_title), fontWeight = FontWeight.SemiBold)
+      Text(
+          stringResource(
+              ResString.string.apm_temp_value,
+              temp?.let { formatFloat(it) } ?: "--",
+          ),
+          fontSize = 20.sp,
+          fontWeight = FontWeight.Bold,
+          color = textColor,
+      )
+      Text(
+          stringResource(ResString.string.apm_temp_state, label),
+          color = textColor,
+      )
     }
   }
 }
@@ -482,6 +526,72 @@ private fun HotClassActivityCard(classStats: List<EditorHotClassStat>) {
                 modifier = Modifier.weight(1f),
             )
           }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun PssBreakdownCard(stats: List<EditorPssBreakdownStat>) {
+  Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(stringResource(ResString.string.apm_pss_breakdown_title), fontWeight = FontWeight.SemiBold)
+      if (stats.isEmpty()) {
+        Text(stringResource(ResString.string.apm_waiting_data), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        return@Column
+      }
+      stats.forEach { stat ->
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+          Text(stat.category, color = MaterialTheme.colorScheme.onSurfaceVariant)
+          Text("${formatFloat(stat.pssMb)} MB", fontWeight = FontWeight.Medium)
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun RuntimeSignalsCard(snapshot: EditorProcessApmSnapshot?) {
+  Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(stringResource(ResString.string.apm_runtime_signals_title), fontWeight = FontWeight.SemiBold)
+      Text(
+          stringResource(
+              ResString.string.apm_runtime_cpu_breakdown,
+              snapshot?.cpuBreakdownStat?.userCpuMs ?: 0L,
+              snapshot?.cpuBreakdownStat?.systemCpuMs ?: 0L,
+          ),
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          fontSize = 12.sp,
+      )
+      Text(
+          stringResource(
+              ResString.string.apm_runtime_io,
+              snapshot?.ioStat?.readBytes ?: 0L,
+              snapshot?.ioStat?.writeBytes ?: 0L,
+          ),
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          fontSize = 12.sp,
+      )
+      Text(
+          stringResource(
+              ResString.string.apm_runtime_jank,
+              formatFloat(snapshot?.frameJankStat?.frameDropPercent ?: 0.0),
+              snapshot?.frameJankStat?.jankFrameCount ?: 0L,
+              snapshot?.frameJankStat?.totalFrameCount ?: 0L,
+          ),
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          fontSize = 12.sp,
+      )
+      if (snapshot?.topThreadStats?.isNotEmpty() == true) {
+        Text(stringResource(ResString.string.apm_runtime_top_threads), fontWeight = FontWeight.Medium)
+        snapshot.topThreadStats.take(5).forEach { thread ->
+          Text(
+              "T${thread.tid} ${thread.name} • Δticks=${thread.cpuDeltaTicks}",
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              fontSize = 12.sp,
+          )
         }
       }
     }

--- a/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.Context
+import android.os.Build
 import android.os.Debug
 import android.os.Handler
 import android.os.Looper
@@ -57,6 +58,7 @@ data class EditorProcessApmSnapshot(
     val topThreadStats: List<EditorThreadCpuStat>,
     val frameJankStat: EditorFrameJankStat,
     val deviceThermalStat: EditorDeviceThermalStat,
+    val advancedHookStat: EditorAdvancedHookStat,
     val healthAlerts: List<String>,
 )
 
@@ -107,6 +109,15 @@ data class EditorFrameJankStat(
 data class EditorDeviceThermalStat(
     val batteryTempCelsius: Double?,
     val level: String,
+)
+
+data class EditorAdvancedHookStat(
+    val jvmtiReady: Boolean,
+    val pltHookReady: Boolean,
+    val inlineHookReady: Boolean,
+    val mallocHookReady: Boolean,
+    val memUnreachableReady: Boolean,
+    val notes: List<String>,
 )
 
 /** Non-intrusive process-level APM monitor for editor bottom sheet dashboard. */
@@ -178,6 +189,7 @@ class EditorProcessApmMonitor(
         previousThreadCpuStat = threadCpuStat
 
         val thermalStat = readBatteryThermalStat()
+        val advancedHookStat = readAdvancedHookStat()
         val frameJankStat = frameTracker.snapshotAndReset()
         val cpuBreakdown = readCpuBreakdownStat()
         val alerts =
@@ -216,6 +228,7 @@ class EditorProcessApmMonitor(
                 topThreadStats = topThreadStats,
                 frameJankStat = frameJankStat,
                 deviceThermalStat = thermalStat,
+                advancedHookStat = advancedHookStat,
                 healthAlerts = alerts,
             )
         )
@@ -515,6 +528,45 @@ class EditorProcessApmMonitor(
     )
   }
 
+  private fun readAdvancedHookStat(): EditorAdvancedHookStat {
+    val notes = mutableListOf<String>()
+    val jvmtiReady = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+    if (jvmtiReady) {
+      notes += "JVMTI dynamic agent is supported on Android 8.0+."
+    } else {
+      notes += "JVMTI requires Android 8.0+."
+    }
+
+    val nativeLibDir = File(appContext.applicationInfo.nativeLibraryDir ?: "")
+    val pltHookReady = nativeLibDir.listFiles()?.any { it.name.contains("plthook", ignoreCase = true) } == true
+    val inlineHookReady = nativeLibDir.listFiles()?.any { it.name.contains("shadowhook", ignoreCase = true) || it.name.contains("inlinehook", ignoreCase = true) } == true
+    val mallocHookReady = (System.getenv("LIBC_HOOKS_ENABLE") == "1") || hasAnyFile("/data/local/tmp/libc_malloc_hooks.so")
+    val memUnreachableReady = hasAnyFile("/system/lib64/libmemunreachable.so", "/system/lib/libmemunreachable.so")
+
+    if (!pltHookReady) notes += "PLT Hook bridge library not detected in app native libs."
+    if (!inlineHookReady) notes += "Inline Hook bridge library not detected in app native libs."
+    if (!mallocHookReady) notes += "jemalloc/scudo malloc hook bridge not enabled."
+    if (!memUnreachableReady) notes += "libmemunreachable is unavailable on this device image."
+
+    val externalProbeScript = File(appContext.filesDir, "apm-probes/collect.sh")
+    if (externalProbeScript.exists()) {
+      notes += "External advanced probe script detected: ${externalProbeScript.absolutePath}."
+    } else {
+      notes += "Optional external probes can be mounted at files/apm-probes/collect.sh with no app source patching."
+    }
+
+    return EditorAdvancedHookStat(
+        jvmtiReady = jvmtiReady,
+        pltHookReady = pltHookReady,
+        inlineHookReady = inlineHookReady,
+        mallocHookReady = mallocHookReady,
+        memUnreachableReady = memUnreachableReady,
+        notes = notes,
+    )
+  }
+
+  private fun hasAnyFile(vararg paths: String): Boolean = paths.any { File(it).exists() }
+
   private fun buildHealthAlerts(
       cpuUsagePercent: Double,
       javaHeapUsedMb: Double,
@@ -540,9 +592,12 @@ class EditorProcessApmMonitor(
 
   private class ClassActivityTracker(private val appPackageName: String) {
     private val stats = LinkedHashMap<String, MutableHotClassStat>()
+    private val lastHitSnapshot = mutableMapOf<String, Double>()
+    private var sampleSeq = 0L
 
     fun sample(cpuDeltaMs: Double, memDeltaMb: Double): List<EditorHotClassStat> {
-      val classHits = collectAppClassHits()
+      sampleSeq++
+      val classHits = collectAppClassHitsWeighted()
       if (classHits.isEmpty()) {
         return stats.values
             .sortedByDescending { it.totalCpuMs }
@@ -550,11 +605,14 @@ class EditorProcessApmMonitor(
             .map { it.toSnapshot() }
       }
 
-      val totalHits = classHits.values.sum().coerceAtLeast(1)
+      val totalHits = classHits.values.sum().takeIf { it > 0.0 } ?: 1.0
       classHits.forEach { (className, hits) ->
-        val ratio = hits.toDouble() / totalHits.toDouble()
+        val ratio = hits / totalHits
+        val previousWeight = lastHitSnapshot[className] ?: 0.0
+        val smoothRatio = (ratio * 0.7) + (previousWeight * 0.3)
+        lastHitSnapshot[className] = smoothRatio
         val cpuShare = cpuDeltaMs * ratio
-        val memShare = memDeltaMb * ratio
+        val memShare = memDeltaMb * smoothRatio
         val item =
             stats.getOrPut(className) {
               MutableHotClassStat(
@@ -565,23 +623,28 @@ class EditorProcessApmMonitor(
                   peakMemMb = 0.0,
               )
             }
-        item.calls += hits
+        item.calls += max(1, (hits * 10.0).toInt())
         item.totalCpuMs += cpuShare
         item.totalMemMb += memShare
         item.peakMemMb = max(item.peakMemMb, memShare)
+        item.lastSeenSeq = sampleSeq
       }
 
       return stats.values
+          .filter { sampleSeq - it.lastSeenSeq <= 45L }
           .sortedByDescending { it.totalCpuMs }
           .take(MAX_HOT_CLASSES)
           .map { it.toSnapshot() }
     }
 
-    private fun collectAppClassHits(): Map<String, Int> {
-      val hits = mutableMapOf<String, Int>()
+    private fun collectAppClassHitsWeighted(): Map<String, Double> {
+      val hits = mutableMapOf<String, Double>()
       Thread.getAllStackTraces().values.forEach { stack ->
-        val frame = stack.firstOrNull { it.className.startsWith(appPackageName) } ?: return@forEach
-        hits[frame.className] = (hits[frame.className] ?: 0) + 1
+        stack.take(6).forEachIndexed { index, frame ->
+          if (!frame.className.startsWith(appPackageName)) return@forEachIndexed
+          val depthWeight = 1.0 / (index + 1).toDouble()
+          hits[frame.className] = (hits[frame.className] ?: 0.0) + depthWeight
+        }
       }
       return hits
     }
@@ -593,6 +656,7 @@ class EditorProcessApmMonitor(
       var totalCpuMs: Double,
       var totalMemMb: Double,
       var peakMemMb: Double,
+      var lastSeenSeq: Long = 0L,
   ) {
     fun toSnapshot(): EditorHotClassStat {
       val avgCpuMs = if (calls > 0) totalCpuMs / calls.toDouble() else 0.0

--- a/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
@@ -1,10 +1,15 @@
 package com.itsaky.androidide.monitor
 
 import android.app.ActivityManager
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.Context
 import android.os.Debug
+import android.os.Handler
+import android.os.Looper
 import android.os.Process
 import android.os.SystemClock
+import android.view.Choreographer
 import dalvik.system.DexFile
 import com.itsaky.androidide.utils.executioncommand.TermuxCommand
 import java.io.File
@@ -32,6 +37,8 @@ data class EditorProcessApmSnapshot(
     val cpuUsagePercent: Double,
     val processRssMb: Double,
     val processPssMb: Double,
+    val processUssMb: Double,
+    val processVssMb: Double,
     val javaHeapUsedMb: Double,
     val javaHeapMaxMb: Double,
     val nativeHeapMb: Double,
@@ -44,6 +51,12 @@ data class EditorProcessApmSnapshot(
     val classArtifactStat: EditorClassArtifactStat,
     val hotClassStats: List<EditorHotClassStat>,
     val termuxSubsystemStats: List<EditorSubsystemStat>,
+    val pssBreakdownStats: List<EditorPssBreakdownStat>,
+    val cpuBreakdownStat: EditorCpuBreakdownStat,
+    val ioStat: EditorIoStat,
+    val topThreadStats: List<EditorThreadCpuStat>,
+    val frameJankStat: EditorFrameJankStat,
+    val deviceThermalStat: EditorDeviceThermalStat,
     val healthAlerts: List<String>,
 )
 
@@ -64,6 +77,38 @@ data class EditorSubsystemStat(
     val totalRssMb: Double,
 )
 
+data class EditorPssBreakdownStat(
+    val category: String,
+    val pssMb: Double,
+)
+
+data class EditorCpuBreakdownStat(
+    val userCpuMs: Long,
+    val systemCpuMs: Long,
+)
+
+data class EditorIoStat(
+    val readBytes: Long,
+    val writeBytes: Long,
+)
+
+data class EditorThreadCpuStat(
+    val tid: Int,
+    val name: String,
+    val cpuDeltaTicks: Long,
+)
+
+data class EditorFrameJankStat(
+    val frameDropPercent: Double,
+    val jankFrameCount: Long,
+    val totalFrameCount: Long,
+)
+
+data class EditorDeviceThermalStat(
+    val batteryTempCelsius: Double?,
+    val level: String,
+)
+
 /** Non-intrusive process-level APM monitor for editor bottom sheet dashboard. */
 class EditorProcessApmMonitor(
     private val appContext: Context,
@@ -79,69 +124,105 @@ class EditorProcessApmMonitor(
     val dexStat = readDexClassStat()
     var classArtifactStat = scanClassArtifacts()
     val classActivityTracker = ClassActivityTracker(appContext.packageName)
+    val frameTracker = FrameJankTracker()
+    frameTracker.start()
     var termuxSubsystemStats: List<EditorSubsystemStat> = emptyList()
+    var pssBreakdownStats: List<EditorPssBreakdownStat> = emptyList()
+    var previousThreadCpuStat = readThreadCpuTicks()
+    var previousIoStat = readIoStat()
     var ticks = 0
 
-    while (true) {
-      val current = readCpuStat()
-      val cpuUsage = calcCpuUsage(previous, current)
-      previous = current
-      val processPssMb = readProcessPssMb()
-      val javaHeapUsedMb = readJavaHeapUsedMb()
-      val nativeHeapMb = readNativeHeapMb()
-      val processCpuMs = Process.getElapsedCpuTime()
-      val cpuDeltaMs = max(0L, processCpuMs - previousProcessCpuMs).toDouble()
-      val pssDeltaMb = (processPssMb - previousPssMb).coerceAtLeast(0.0)
-      val javaHeapDeltaMb = (javaHeapUsedMb - previousJavaHeapUsedMb).coerceAtLeast(0.0)
-      val nativeHeapDeltaMb = (nativeHeapMb - previousNativeHeapMb).coerceAtLeast(0.0)
-      val attributedMemDeltaMb = max(pssDeltaMb, max(javaHeapDeltaMb, nativeHeapDeltaMb))
-      previousProcessCpuMs = processCpuMs
-      previousPssMb = processPssMb
-      previousJavaHeapUsedMb = javaHeapUsedMb
-      previousNativeHeapMb = nativeHeapMb
+    try {
+      while (true) {
+        val current = readCpuStat()
+        val cpuUsage = calcCpuUsage(previous, current)
+        previous = current
+        val processPssMb = readProcessPssMb()
+        val processUssMb = readProcessUssMb()
+        val processVssMb = readProcessVssMb()
+        val javaHeapUsedMb = readJavaHeapUsedMb()
+        val nativeHeapMb = readNativeHeapMb()
+        val processCpuMs = Process.getElapsedCpuTime()
+        val cpuDeltaMs = max(0L, processCpuMs - previousProcessCpuMs).toDouble()
+        val pssDeltaMb = (processPssMb - previousPssMb).coerceAtLeast(0.0)
+        val javaHeapDeltaMb = (javaHeapUsedMb - previousJavaHeapUsedMb).coerceAtLeast(0.0)
+        val nativeHeapDeltaMb = (nativeHeapMb - previousNativeHeapMb).coerceAtLeast(0.0)
+        val attributedMemDeltaMb = max(pssDeltaMb, max(javaHeapDeltaMb, nativeHeapDeltaMb))
+        previousProcessCpuMs = processCpuMs
+        previousPssMb = processPssMb
+        previousJavaHeapUsedMb = javaHeapUsedMb
+        previousNativeHeapMb = nativeHeapMb
 
-      if (ticks % 15 == 0) {
-        classArtifactStat = scanClassArtifacts()
+        if (ticks % 15 == 0) {
+          classArtifactStat = scanClassArtifacts()
+        }
+        if (ticks % 3 == 0) {
+          pssBreakdownStats = readPssBreakdownStats()
+        }
+        ticks++
+
+        val hotClassStats =
+            classActivityTracker.sample(cpuDeltaMs = cpuDeltaMs, memDeltaMb = attributedMemDeltaMb)
+        if (ticks % 5 == 0) {
+          termuxSubsystemStats = readTermuxSubsystemStats()
+        }
+        val javaHeapMaxMb = readJavaHeapMaxMb()
+        val gcTimeMs = readGcTimeMs()
+        val ioStat = readIoStat()
+        val ioDeltaRead = (ioStat.readBytes - previousIoStat.readBytes).coerceAtLeast(0L)
+        val ioDeltaWrite = (ioStat.writeBytes - previousIoStat.writeBytes).coerceAtLeast(0L)
+        previousIoStat = ioStat
+
+        val threadCpuStat = readThreadCpuTicks()
+        val topThreadStats = topThreadCpuDeltas(previousThreadCpuStat, threadCpuStat)
+        previousThreadCpuStat = threadCpuStat
+
+        val thermalStat = readBatteryThermalStat()
+        val frameJankStat = frameTracker.snapshotAndReset()
+        val cpuBreakdown = readCpuBreakdownStat()
+        val alerts =
+            buildHealthAlerts(
+                cpuUsagePercent = cpuUsage,
+                javaHeapUsedMb = javaHeapUsedMb,
+                javaHeapMaxMb = javaHeapMaxMb,
+                gcTimeMs = gcTimeMs,
+                frameDropPercent = frameJankStat.frameDropPercent,
+                batteryTempC = thermalStat.batteryTempCelsius,
+            )
+
+        emit(
+            EditorProcessApmSnapshot(
+                timestampMs = System.currentTimeMillis(),
+                cpuUsagePercent = cpuUsage,
+                processRssMb = readProcessRssMb(),
+                processPssMb = processPssMb,
+                processUssMb = processUssMb,
+                processVssMb = processVssMb,
+                javaHeapUsedMb = javaHeapUsedMb,
+                javaHeapMaxMb = javaHeapMaxMb,
+                nativeHeapMb = nativeHeapMb,
+                threadCount = Thread.getAllStackTraces().size,
+                openFdCount = readOpenFdCount(),
+                gcCount = readGcCount(),
+                gcTimeMs = gcTimeMs,
+                appUptimeMs = SystemClock.elapsedRealtime(),
+                dexClassStat = dexStat,
+                classArtifactStat = classArtifactStat,
+                hotClassStats = hotClassStats,
+                termuxSubsystemStats = termuxSubsystemStats,
+                pssBreakdownStats = pssBreakdownStats,
+                cpuBreakdownStat = cpuBreakdown,
+                ioStat = EditorIoStat(readBytes = ioDeltaRead, writeBytes = ioDeltaWrite),
+                topThreadStats = topThreadStats,
+                frameJankStat = frameJankStat,
+                deviceThermalStat = thermalStat,
+                healthAlerts = alerts,
+            )
+        )
+        delay(intervalMs)
       }
-      ticks++
-
-      val hotClassStats =
-          classActivityTracker.sample(cpuDeltaMs = cpuDeltaMs, memDeltaMb = attributedMemDeltaMb)
-      if (ticks % 5 == 0) {
-        termuxSubsystemStats = readTermuxSubsystemStats()
-      }
-      val javaHeapMaxMb = readJavaHeapMaxMb()
-      val gcTimeMs = readGcTimeMs()
-      val alerts =
-          buildHealthAlerts(
-              cpuUsagePercent = cpuUsage,
-              javaHeapUsedMb = javaHeapUsedMb,
-              javaHeapMaxMb = javaHeapMaxMb,
-              gcTimeMs = gcTimeMs,
-          )
-
-      emit(
-          EditorProcessApmSnapshot(
-              timestampMs = System.currentTimeMillis(),
-              cpuUsagePercent = cpuUsage,
-              processRssMb = readProcessRssMb(),
-              processPssMb = processPssMb,
-              javaHeapUsedMb = javaHeapUsedMb,
-              javaHeapMaxMb = javaHeapMaxMb,
-              nativeHeapMb = nativeHeapMb,
-              threadCount = Thread.getAllStackTraces().size,
-              openFdCount = readOpenFdCount(),
-              gcCount = readGcCount(),
-              gcTimeMs = gcTimeMs,
-              appUptimeMs = SystemClock.elapsedRealtime(),
-              dexClassStat = dexStat,
-              classArtifactStat = classArtifactStat,
-              hotClassStats = hotClassStats,
-              termuxSubsystemStats = termuxSubsystemStats,
-              healthAlerts = alerts,
-          )
-      )
-      delay(intervalMs)
+    } finally {
+      frameTracker.stop()
     }
   }.flowOn(ioDispatcher)
 
@@ -173,6 +254,32 @@ class EditorProcessApmMonitor(
     return (pages * 4096L).toDouble() / 1024.0 / 1024.0
   }
 
+  private fun readProcessUssMb(): Double {
+    val privateKb =
+        runCatching {
+              File("/proc/self/smaps_rollup").useLines { lines ->
+                lines
+                    .mapNotNull { line ->
+                      if (line.startsWith("Private_Clean:") || line.startsWith("Private_Dirty:")) {
+                        line.substringAfter(':').trim().substringBefore(' ').toLongOrNull()
+                      } else {
+                        null
+                      }
+                    }
+                    .sum()
+              }
+            }
+            .getOrElse { 0L }
+    return privateKb.toDouble() / 1024.0
+  }
+
+  private fun readProcessVssMb(): Double {
+    val statm = File("/proc/self/statm")
+    if (!statm.exists()) return 0.0
+    val pages = statm.readText().trim().split(" ").getOrNull(0)?.toLongOrNull() ?: return 0.0
+    return (pages * 4096L).toDouble() / 1024.0 / 1024.0
+  }
+
   private fun readDexClassStat(): EditorDexClassStat {
     return runCatching {
           val sourceDir = appContext.applicationInfo.sourceDir
@@ -190,6 +297,38 @@ class EditorProcessApmMonitor(
           EditorDexClassStat(totalClassCount = total, appPackageClassCount = inApp)
         }
         .getOrElse { EditorDexClassStat(totalClassCount = 0, appPackageClassCount = 0) }
+  }
+
+  private fun readPssBreakdownStats(): List<EditorPssBreakdownStat> {
+    val categories =
+        linkedMapOf(
+            "Java Heap" to 0.0,
+            "Native Heap" to 0.0,
+            "Code" to 0.0,
+            "Stack" to 0.0,
+            "Graphics" to 0.0,
+            "Private Other" to 0.0,
+            "System" to 0.0,
+            "Unknown" to 0.0,
+        )
+    runCatching {
+          val memoryInfo = Debug.MemoryInfo()
+          Debug.getMemoryInfo(memoryInfo)
+          fun assign(key: String, kb: Int) {
+            categories[key] = (kb.toDouble() / 1024.0).coerceAtLeast(0.0)
+          }
+          fun statKb(key: String): Int = memoryInfo.getMemoryStat(key)?.toIntOrNull() ?: 0
+          assign("Java Heap", memoryInfo.dalvikPss)
+          assign("Native Heap", memoryInfo.nativePss)
+          assign("Code", statKb("summary.code"))
+          assign("Stack", statKb("summary.stack"))
+          assign("Graphics", statKb("summary.graphics"))
+          assign("Private Other", statKb("summary.private-other"))
+          assign("System", statKb("summary.system"))
+          assign("Unknown", memoryInfo.otherPss)
+        }
+        .getOrDefault(Unit)
+    return categories.map { (category, pssMb) -> EditorPssBreakdownStat(category = category, pssMb = pssMb) }
   }
 
   private fun scanClassArtifacts(): EditorClassArtifactStat {
@@ -239,6 +378,17 @@ class EditorProcessApmMonitor(
             .getOrElse { SystemClock.elapsedRealtime() }
 
     return CpuStat(processTicks = processTicks, systemTicks = max(1L, systemTicks))
+  }
+
+  private fun readCpuBreakdownStat(): EditorCpuBreakdownStat {
+    val tokens = runCatching { File("/proc/self/stat").readText().trim().split(Regex("\\s+")) }.getOrElse { emptyList() }
+    val clockTicksPerSecond = 100L
+    val userTicks = tokens.getOrNull(13)?.toLongOrNull() ?: 0L
+    val systemTicks = tokens.getOrNull(14)?.toLongOrNull() ?: 0L
+    return EditorCpuBreakdownStat(
+        userCpuMs = (userTicks * 1000L) / clockTicksPerSecond,
+        systemCpuMs = (systemTicks * 1000L) / clockTicksPerSecond,
+    )
   }
 
   private fun calcCpuUsage(previous: CpuStat, current: CpuStat): Double {
@@ -298,16 +448,87 @@ class EditorProcessApmMonitor(
         .sortedByDescending { it.totalCpuPercent }
   }
 
+  private fun readIoStat(): EditorIoStat {
+    val pairs =
+        runCatching { File("/proc/self/io").readLines() }
+            .getOrElse { emptyList() }
+            .mapNotNull { line ->
+              val split = line.split(":")
+              if (split.size == 2) split[0].trim() to split[1].trim().toLongOrNull() else null
+            }
+            .toMap()
+    return EditorIoStat(
+        readBytes = pairs["read_bytes"] ?: 0L,
+        writeBytes = pairs["write_bytes"] ?: 0L,
+    )
+  }
+
+  private fun readThreadCpuTicks(): Map<Int, ThreadCpuTick> {
+    val taskDir = File("/proc/self/task")
+    val dirs = taskDir.listFiles() ?: return emptyMap()
+    val result = mutableMapOf<Int, ThreadCpuTick>()
+    dirs.forEach { dir ->
+      val tid = dir.name.toIntOrNull() ?: return@forEach
+      val statText = runCatching { File(dir, "stat").readText() }.getOrNull() ?: return@forEach
+      val nameStart = statText.indexOf('(')
+      val nameEnd = statText.lastIndexOf(')')
+      if (nameStart < 0 || nameEnd <= nameStart) return@forEach
+      val threadName = statText.substring(nameStart + 1, nameEnd)
+      val tokens = statText.substring(nameEnd + 2).split(" ")
+      val utime = tokens.getOrNull(11)?.toLongOrNull() ?: 0L
+      val stime = tokens.getOrNull(12)?.toLongOrNull() ?: 0L
+      result[tid] = ThreadCpuTick(name = threadName, totalTicks = utime + stime)
+    }
+    return result
+  }
+
+  private fun topThreadCpuDeltas(
+      previous: Map<Int, ThreadCpuTick>,
+      current: Map<Int, ThreadCpuTick>,
+  ): List<EditorThreadCpuStat> {
+    return current.mapNotNull { (tid, currentTick) ->
+      val previousTick = previous[tid] ?: return@mapNotNull null
+      val delta = (currentTick.totalTicks - previousTick.totalTicks).coerceAtLeast(0L)
+      if (delta == 0L) return@mapNotNull null
+      EditorThreadCpuStat(tid = tid, name = currentTick.name, cpuDeltaTicks = delta)
+    }.sortedByDescending { it.cpuDeltaTicks }.take(6)
+  }
+
+  private fun readBatteryThermalStat(): EditorDeviceThermalStat {
+    val intent =
+        appContext.registerReceiver(
+            null,
+            IntentFilter(Intent.ACTION_BATTERY_CHANGED),
+        )
+    val raw = intent?.getIntExtra("temperature", -1) ?: -1
+    val celsius = if (raw > 0) raw / 10.0 else null
+    val level =
+        when {
+          celsius == null -> "unknown"
+          celsius >= 42.0 -> "danger"
+          celsius >= 38.0 -> "warning"
+          else -> "safe"
+        }
+    return EditorDeviceThermalStat(
+        batteryTempCelsius = celsius,
+        level = level,
+    )
+  }
+
   private fun buildHealthAlerts(
       cpuUsagePercent: Double,
       javaHeapUsedMb: Double,
       javaHeapMaxMb: Double,
       gcTimeMs: Long,
+      frameDropPercent: Double,
+      batteryTempC: Double?,
   ): List<String> {
     val alerts = mutableListOf<String>()
     if (cpuUsagePercent >= 85.0) alerts += "CPU sustained high load"
     if (javaHeapMaxMb > 0 && (javaHeapUsedMb / javaHeapMaxMb) >= 0.90) alerts += "OOM risk: Java heap above 90%"
     if (gcTimeMs >= 200L) alerts += "GC pause elevated"
+    if (frameDropPercent >= 20.0) alerts += "UI jank risk: dropped-frame ratio elevated"
+    if ((batteryTempC ?: 0.0) >= 42.0) alerts += "Device thermal danger: battery temperature too high"
     if (alerts.isEmpty()) alerts += "No immediate ANR/OOM signal"
     return alerts
   }
@@ -397,4 +618,63 @@ class EditorProcessApmMonitor(
       var totalCpuPercent: Double = 0.0,
       var totalRssMb: Double = 0.0,
   )
+
+  private data class ThreadCpuTick(
+      val name: String,
+      val totalTicks: Long,
+  )
+
+  private class FrameJankTracker {
+    @Volatile private var running = false
+    @Volatile private var totalFrames = 0L
+    @Volatile private var jankFrames = 0L
+    private var lastFrameNs = 0L
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val callback =
+        object : Choreographer.FrameCallback {
+          override fun doFrame(frameTimeNanos: Long) {
+            if (!running) return
+            if (lastFrameNs > 0L) {
+              val deltaMs = (frameTimeNanos - lastFrameNs) / 1_000_000.0
+              totalFrames++
+              if (deltaMs > 16.6) {
+                jankFrames++
+              }
+            }
+            lastFrameNs = frameTimeNanos
+            Choreographer.getInstance().postFrameCallback(this)
+          }
+        }
+
+    fun start() {
+      running = true
+      mainHandler.post {
+        runCatching {
+          Choreographer.getInstance().postFrameCallback(callback)
+        }
+      }
+    }
+
+    fun stop() {
+      running = false
+      mainHandler.post {
+        runCatching {
+          Choreographer.getInstance().removeFrameCallback(callback)
+        }
+      }
+    }
+
+    fun snapshotAndReset(): EditorFrameJankStat {
+      val total = totalFrames
+      val jank = jankFrames
+      totalFrames = 0L
+      jankFrames = 0L
+      val dropPercent = if (total <= 0L) 0.0 else (jank.toDouble() / total.toDouble()) * 100.0
+      return EditorFrameJankStat(
+          frameDropPercent = dropPercent,
+          jankFrameCount = jank,
+          totalFrameCount = total,
+      )
+    }
+  }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
@@ -134,7 +134,16 @@ class EditorProcessApmMonitor(
     var previousNativeHeapMb = readNativeHeapMb()
     val dexStat = readDexClassStat()
     var classArtifactStat = scanClassArtifacts()
-    val classActivityTracker = ClassActivityTracker(appContext.packageName)
+    val classActivityTracker =
+        ClassActivityTracker(
+            appPackageName = appContext.packageName,
+            ignoredClassPrefixes =
+                setOf(
+                    "com.itsaky.androidide.monitor.",
+                    "kotlinx.coroutines.",
+                    "java.util.concurrent.",
+                ),
+        )
     val frameTracker = FrameJankTracker()
     frameTracker.start()
     var termuxSubsystemStats: List<EditorSubsystemStat> = emptyList()
@@ -173,7 +182,11 @@ class EditorProcessApmMonitor(
         ticks++
 
         val hotClassStats =
-            classActivityTracker.sample(cpuDeltaMs = cpuDeltaMs, memDeltaMb = attributedMemDeltaMb)
+            if (ticks % 2 == 0) {
+              classActivityTracker.sample(cpuDeltaMs = cpuDeltaMs, memDeltaMb = attributedMemDeltaMb)
+            } else {
+              classActivityTracker.cachedTop()
+            }
         if (ticks % 5 == 0) {
           termuxSubsystemStats = readTermuxSubsystemStats()
         }
@@ -184,9 +197,15 @@ class EditorProcessApmMonitor(
         val ioDeltaWrite = (ioStat.writeBytes - previousIoStat.writeBytes).coerceAtLeast(0L)
         previousIoStat = ioStat
 
-        val threadCpuStat = readThreadCpuTicks()
-        val topThreadStats = topThreadCpuDeltas(previousThreadCpuStat, threadCpuStat)
-        previousThreadCpuStat = threadCpuStat
+        val topThreadStats =
+            if (ticks % 3 == 0) {
+              val threadCpuStat = readThreadCpuTicks()
+              val sampled = topThreadCpuDeltas(previousThreadCpuStat, threadCpuStat)
+              previousThreadCpuStat = threadCpuStat
+              sampled
+            } else {
+              emptyList()
+            }
 
         val thermalStat = readBatteryThermalStat()
         val advancedHookStat = readAdvancedHookStat()
@@ -213,7 +232,7 @@ class EditorProcessApmMonitor(
                 javaHeapUsedMb = javaHeapUsedMb,
                 javaHeapMaxMb = javaHeapMaxMb,
                 nativeHeapMb = nativeHeapMb,
-                threadCount = Thread.getAllStackTraces().size,
+                threadCount = readThreadCount(),
                 openFdCount = readOpenFdCount(),
                 gcCount = readGcCount(),
                 gcTimeMs = gcTimeMs,
@@ -495,6 +514,8 @@ class EditorProcessApmMonitor(
     return result
   }
 
+  private fun readThreadCount(): Int = File("/proc/self/task").list()?.size ?: 0
+
   private fun topThreadCpuDeltas(
       previous: Map<Int, ThreadCpuTick>,
       current: Map<Int, ThreadCpuTick>,
@@ -590,19 +611,22 @@ class EditorProcessApmMonitor(
       val systemTicks: Long,
   )
 
-  private class ClassActivityTracker(private val appPackageName: String) {
+  private class ClassActivityTracker(
+      private val appPackageName: String,
+      private val ignoredClassPrefixes: Set<String>,
+  ) {
     private val stats = LinkedHashMap<String, MutableHotClassStat>()
     private val lastHitSnapshot = mutableMapOf<String, Double>()
     private var sampleSeq = 0L
 
     fun sample(cpuDeltaMs: Double, memDeltaMb: Double): List<EditorHotClassStat> {
       sampleSeq++
+      if (cpuDeltaMs <= 0.1 && memDeltaMb <= 0.05) {
+        return cachedTop()
+      }
       val classHits = collectAppClassHitsWeighted()
       if (classHits.isEmpty()) {
-        return stats.values
-            .sortedByDescending { it.totalCpuMs }
-            .take(MAX_HOT_CLASSES)
-            .map { it.toSnapshot() }
+        return cachedTop()
       }
 
       val totalHits = classHits.values.sum().takeIf { it > 0.0 } ?: 1.0
@@ -611,8 +635,8 @@ class EditorProcessApmMonitor(
         val previousWeight = lastHitSnapshot[className] ?: 0.0
         val smoothRatio = (ratio * 0.7) + (previousWeight * 0.3)
         lastHitSnapshot[className] = smoothRatio
-        val cpuShare = cpuDeltaMs * ratio
-        val memShare = memDeltaMb * smoothRatio
+        val cpuShare = (cpuDeltaMs * ratio).coerceAtMost(cpuDeltaMs * 0.35)
+        val memShare = (memDeltaMb * smoothRatio).coerceAtMost(memDeltaMb * 0.40)
         val item =
             stats.getOrPut(className) {
               MutableHotClassStat(
@@ -628,20 +652,36 @@ class EditorProcessApmMonitor(
         item.totalMemMb += memShare
         item.peakMemMb = max(item.peakMemMb, memShare)
         item.lastSeenSeq = sampleSeq
+        item.hitWeightEma = (item.hitWeightEma * 0.6) + (smoothRatio * 0.4)
       }
 
+      stats.values.forEach { item ->
+        val inactive = sampleSeq - item.lastSeenSeq
+        if (inactive > 10) {
+          item.totalCpuMs *= 0.92
+          item.totalMemMb *= 0.90
+        }
+      }
+
+      return cachedTop()
+    }
+
+    fun cachedTop(): List<EditorHotClassStat> {
       return stats.values
           .filter { sampleSeq - it.lastSeenSeq <= 45L }
-          .sortedByDescending { it.totalCpuMs }
+          .sortedByDescending { (it.totalCpuMs * 0.75) + (it.hitWeightEma * 100.0) }
           .take(MAX_HOT_CLASSES)
           .map { it.toSnapshot() }
     }
 
     private fun collectAppClassHitsWeighted(): Map<String, Double> {
       val hits = mutableMapOf<String, Double>()
+      var threadBudget = 40
       Thread.getAllStackTraces().values.forEach { stack ->
-        stack.take(6).forEachIndexed { index, frame ->
+        if (threadBudget-- <= 0) return@forEach
+        stack.take(4).forEachIndexed { index, frame ->
           if (!frame.className.startsWith(appPackageName)) return@forEachIndexed
+          if (ignoredClassPrefixes.any { frame.className.startsWith(it) }) return@forEachIndexed
           val depthWeight = 1.0 / (index + 1).toDouble()
           hits[frame.className] = (hits[frame.className] ?: 0.0) + depthWeight
         }
@@ -657,6 +697,7 @@ class EditorProcessApmMonitor(
       var totalMemMb: Double,
       var peakMemMb: Double,
       var lastSeenSeq: Long = 0L,
+      var hitWeightEma: Double = 0.0,
   ) {
     fun toSnapshot(): EditorHotClassStat {
       val avgCpuMs = if (calls > 0) totalCpuMs / calls.toDouble() else 0.0

--- a/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
@@ -140,8 +140,6 @@ class EditorProcessApmMonitor(
             ignoredClassPrefixes =
                 setOf(
                     "com.itsaky.androidide.monitor.",
-                    "kotlinx.coroutines.",
-                    "java.util.concurrent.",
                 ),
         )
     val frameTracker = FrameJankTracker()
@@ -182,11 +180,11 @@ class EditorProcessApmMonitor(
         ticks++
 
         val hotClassStats =
-            if (ticks % 2 == 0) {
-              classActivityTracker.sample(cpuDeltaMs = cpuDeltaMs, memDeltaMb = attributedMemDeltaMb)
-            } else {
-              classActivityTracker.cachedTop()
-            }
+            classActivityTracker.sample(
+                cpuDeltaMs = cpuDeltaMs,
+                memDeltaMb = attributedMemDeltaMb,
+                fullScan = (ticks % 8 == 0),
+            )
         if (ticks % 5 == 0) {
           termuxSubsystemStats = readTermuxSubsystemStats()
         }
@@ -619,12 +617,12 @@ class EditorProcessApmMonitor(
     private val lastHitSnapshot = mutableMapOf<String, Double>()
     private var sampleSeq = 0L
 
-    fun sample(cpuDeltaMs: Double, memDeltaMb: Double): List<EditorHotClassStat> {
+    fun sample(cpuDeltaMs: Double, memDeltaMb: Double, fullScan: Boolean): List<EditorHotClassStat> {
       sampleSeq++
       if (cpuDeltaMs <= 0.1 && memDeltaMb <= 0.05) {
         return cachedTop()
       }
-      val classHits = collectAppClassHitsWeighted()
+      val classHits = collectAppClassHitsWeighted(fullScan = fullScan)
       if (classHits.isEmpty()) {
         return cachedTop()
       }
@@ -635,8 +633,9 @@ class EditorProcessApmMonitor(
         val previousWeight = lastHitSnapshot[className] ?: 0.0
         val smoothRatio = (ratio * 0.7) + (previousWeight * 0.3)
         lastHitSnapshot[className] = smoothRatio
-        val cpuShare = (cpuDeltaMs * ratio).coerceAtMost(cpuDeltaMs * 0.35)
-        val memShare = (memDeltaMb * smoothRatio).coerceAtMost(memDeltaMb * 0.40)
+        val runnerDamping = if (className.contains("ToolingServerRunner")) 0.78 else 1.0
+        val cpuShare = ((cpuDeltaMs * ratio).coerceAtMost(cpuDeltaMs * 0.35)) * runnerDamping
+        val memShare = ((memDeltaMb * smoothRatio).coerceAtMost(memDeltaMb * 0.40)) * runnerDamping
         val item =
             stats.getOrPut(className) {
               MutableHotClassStat(
@@ -654,6 +653,7 @@ class EditorProcessApmMonitor(
         item.lastSeenSeq = sampleSeq
         item.hitWeightEma = (item.hitWeightEma * 0.6) + (smoothRatio * 0.4)
       }
+      trimTrackedClasses()
 
       stats.values.forEach { item ->
         val inactive = sampleSeq - item.lastSeenSeq
@@ -675,18 +675,41 @@ class EditorProcessApmMonitor(
     }
 
     private fun collectAppClassHitsWeighted(): Map<String, Double> {
+      return collectAppClassHitsWeighted(fullScan = false)
+    }
+
+    private fun collectAppClassHitsWeighted(fullScan: Boolean): Map<String, Double> {
       val hits = mutableMapOf<String, Double>()
-      var threadBudget = 40
+      val maxFrames = if (fullScan) 12 else 6
       Thread.getAllStackTraces().values.forEach { stack ->
-        if (threadBudget-- <= 0) return@forEach
-        stack.take(4).forEachIndexed { index, frame ->
+        var threadContribution = 0.0
+        val visitedInThread = hashSetOf<String>()
+        stack.take(maxFrames).forEachIndexed { index, frame ->
           if (!frame.className.startsWith(appPackageName)) return@forEachIndexed
           if (ignoredClassPrefixes.any { frame.className.startsWith(it) }) return@forEachIndexed
+          if (!visitedInThread.add(frame.className)) return@forEachIndexed
           val depthWeight = 1.0 / (index + 1).toDouble()
-          hits[frame.className] = (hits[frame.className] ?: 0.0) + depthWeight
+          val effectiveWeight = depthWeight * (1.0 - threadContribution).coerceAtLeast(0.15)
+          hits[frame.className] = (hits[frame.className] ?: 0.0) + effectiveWeight
+          threadContribution = (threadContribution + effectiveWeight).coerceAtMost(1.0)
         }
       }
       return hits
+    }
+
+    private fun trimTrackedClasses() {
+      if (stats.size <= MAX_TRACKED_CLASSES) return
+      val survivors =
+          stats.values
+              .sortedByDescending { (it.totalCpuMs * 0.7) + (it.hitWeightEma * 120.0) + (it.lastSeenSeq * 0.05) }
+              .take(MAX_TRACKED_CLASSES)
+              .associateBy { it.className }
+      stats.keys.toList().forEach { key ->
+        if (!survivors.containsKey(key)) {
+          stats.remove(key)
+          lastHitSnapshot.remove(key)
+        }
+      }
     }
   }
 
@@ -716,6 +739,7 @@ class EditorProcessApmMonitor(
 
   private companion object {
     private const val MAX_HOT_CLASSES = 30
+    private const val MAX_TRACKED_CLASSES = 600
   }
 
   private data class MutableSubsystemAccumulator(

--- a/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/monitor/EditorProcessApmMonitor.kt
@@ -180,11 +180,15 @@ class EditorProcessApmMonitor(
         ticks++
 
         val hotClassStats =
-            classActivityTracker.sample(
-                cpuDeltaMs = cpuDeltaMs,
-                memDeltaMb = attributedMemDeltaMb,
-                fullScan = (ticks % 8 == 0),
-            )
+            if (ticks % 3 == 0 || ticks % 10 == 0) {
+              classActivityTracker.sample(
+                  cpuDeltaMs = cpuDeltaMs,
+                  memDeltaMb = attributedMemDeltaMb,
+                  fullScan = (ticks % 10 == 0),
+              )
+            } else {
+              classActivityTracker.cachedTop()
+            }
         if (ticks % 5 == 0) {
           termuxSubsystemStats = readTermuxSubsystemStats()
         }
@@ -616,9 +620,15 @@ class EditorProcessApmMonitor(
     private val stats = LinkedHashMap<String, MutableHotClassStat>()
     private val lastHitSnapshot = mutableMapOf<String, Double>()
     private var sampleSeq = 0L
+    private var lastSampleRealtimeMs = 0L
 
     fun sample(cpuDeltaMs: Double, memDeltaMb: Double, fullScan: Boolean): List<EditorHotClassStat> {
       sampleSeq++
+      val now = SystemClock.elapsedRealtime()
+      if (!fullScan && (now - lastSampleRealtimeMs) < 1400L) {
+        return cachedTop()
+      }
+      lastSampleRealtimeMs = now
       if (cpuDeltaMs <= 0.1 && memDeltaMb <= 0.05) {
         return cachedTop()
       }
@@ -629,6 +639,7 @@ class EditorProcessApmMonitor(
 
       val totalHits = classHits.values.sum().takeIf { it > 0.0 } ?: 1.0
       classHits.forEach { (className, hits) ->
+        if (shouldIgnoreClass(className)) return@forEach
         val ratio = hits / totalHits
         val previousWeight = lastHitSnapshot[className] ?: 0.0
         val smoothRatio = (ratio * 0.7) + (previousWeight * 0.3)
@@ -669,6 +680,7 @@ class EditorProcessApmMonitor(
     fun cachedTop(): List<EditorHotClassStat> {
       return stats.values
           .filter { sampleSeq - it.lastSeenSeq <= 45L }
+          .filterNot { shouldIgnoreClass(it.className) }
           .sortedByDescending { (it.totalCpuMs * 0.75) + (it.hitWeightEma * 100.0) }
           .take(MAX_HOT_CLASSES)
           .map { it.toSnapshot() }
@@ -681,12 +693,14 @@ class EditorProcessApmMonitor(
     private fun collectAppClassHitsWeighted(fullScan: Boolean): Map<String, Double> {
       val hits = mutableMapOf<String, Double>()
       val maxFrames = if (fullScan) 12 else 6
-      Thread.getAllStackTraces().values.forEach { stack ->
+      val samplerThreadId = Thread.currentThread().id
+      Thread.getAllStackTraces().forEach { (thread, stack) ->
+        if (thread.id == samplerThreadId) return@forEach
         var threadContribution = 0.0
         val visitedInThread = hashSetOf<String>()
         stack.take(maxFrames).forEachIndexed { index, frame ->
           if (!frame.className.startsWith(appPackageName)) return@forEachIndexed
-          if (ignoredClassPrefixes.any { frame.className.startsWith(it) }) return@forEachIndexed
+          if (shouldIgnoreClass(frame.className)) return@forEachIndexed
           if (!visitedInThread.add(frame.className)) return@forEachIndexed
           val depthWeight = 1.0 / (index + 1).toDouble()
           val effectiveWeight = depthWeight * (1.0 - threadContribution).coerceAtLeast(0.15)
@@ -695,6 +709,13 @@ class EditorProcessApmMonitor(
         }
       }
       return hits
+    }
+
+    private fun shouldIgnoreClass(className: String): Boolean {
+      if (ignoredClassPrefixes.any { className.startsWith(it) }) return true
+      if (className.contains("EditorProcessApmMonitor\$stream")) return true
+      if (className.contains("ClassActivityTracker")) return true
+      return false
     }
 
     private fun trimTrackedClasses() {

--- a/core/resources/src/main/res/values-ar-rSA/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ar-rSA/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-bn-rIN/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-bn-rIN/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-de-rDE/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-de-rDE/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-es-rES/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-es-rES/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-fa/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-fa/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-fr-rFR/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-fr-rFR/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-hi-rIN/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-hi-rIN/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-in-rID/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-in-rID/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-it/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-it/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-ja/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ja/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-ko/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ko/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-ml/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ml/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-night/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-night/apm_monitor_strings.xml
@@ -53,4 +53,12 @@
     <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
     <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
     <string name="apm_runtime_top_threads">Top CPU delta threads</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
 </resources>

--- a/core/resources/src/main/res/values-night/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-night/apm_monitor_strings.xml
@@ -7,6 +7,8 @@
     <string name="apm_sampling_desc">Sampling: 1s (Class scan: 15s)</string>
     <string name="apm_cpu_usage">CPU Usage (%)</string>
     <string name="apm_process_pss">Process PSS (MB)</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
     <string name="apm_metric_rss">RSS</string>
     <string name="apm_metric_java_heap">Java Heap</string>
     <string name="apm_metric_native_heap">Native Heap</string>
@@ -38,4 +40,17 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-pl/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-pl/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-pt-rBR/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-pt-rBR/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-ro-rRO/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ro-rRO/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-ru-rRU/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ru-rRU/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-ta/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-ta/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-th/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-th/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-tm-rTM/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-tm-rTM/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-tr-rTR/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-tr-rTR/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-uk/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-uk/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-vi/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-vi/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rCN/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">最小 %1$s</string>
     <string name="apm_chart_now">当前 %1$s</string>
     <string name="apm_chart_max">最大 %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rTW/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-zh-rTW/apm_monitor_strings.xml
@@ -38,4 +38,27 @@
     <string name="apm_chart_min">最小 %1$s</string>
     <string name="apm_chart_now">当前 %1$s</string>
     <string name="apm_chart_max">最大 %1$s</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>

--- a/core/resources/src/main/res/values/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values/apm_monitor_strings.xml
@@ -53,4 +53,12 @@
     <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
     <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
     <string name="apm_runtime_top_threads">Top CPU delta threads</string>
+    <string name="apm_runtime_cpu_user">CPU User time</string>
+    <string name="apm_runtime_cpu_system">CPU System time</string>
+    <string name="apm_runtime_io_read">I/O Read delta</string>
+    <string name="apm_runtime_io_write">I/O Write delta</string>
+    <string name="apm_runtime_jank_ratio">Jank drop ratio</string>
+    <string name="apm_hook_title">Advanced Hook Capability</string>
+    <string name="apm_hook_ready">Ready</string>
+    <string name="apm_hook_not_ready">Not ready</string>
 </resources>

--- a/core/resources/src/main/res/values/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values/apm_monitor_strings.xml
@@ -7,6 +7,8 @@
     <string name="apm_sampling_desc">Sampling: 1s (Class scan: 15s)</string>
     <string name="apm_cpu_usage">CPU Usage (%)</string>
     <string name="apm_process_pss">Process PSS (MB)</string>
+    <string name="apm_metric_uss">USS</string>
+    <string name="apm_metric_vss">VSS</string>
     <string name="apm_metric_rss">RSS</string>
     <string name="apm_metric_java_heap">Java Heap</string>
     <string name="apm_metric_native_heap">Native Heap</string>
@@ -38,4 +40,17 @@
     <string name="apm_chart_min">Min %1$s</string>
     <string name="apm_chart_now">Now %1$s</string>
     <string name="apm_chart_max">Max %1$s</string>
+    <string name="apm_temp_title">Device Temperature</string>
+    <string name="apm_temp_value">Battery temp: %1$s°C</string>
+    <string name="apm_temp_state">Thermal state: %1$s</string>
+    <string name="apm_temp_state_safe">Safe</string>
+    <string name="apm_temp_state_warning">Warning</string>
+    <string name="apm_temp_state_danger">Danger</string>
+    <string name="apm_temp_state_unknown">Unknown</string>
+    <string name="apm_pss_breakdown_title">PSS Breakdown (including Code/Stack/etc.)</string>
+    <string name="apm_runtime_signals_title">Runtime Deep Signals</string>
+    <string name="apm_runtime_cpu_breakdown">CPU total: user=%1$d ms, system=%2$d ms</string>
+    <string name="apm_runtime_io">I/O delta: read=%1$d bytes, write=%2$d bytes</string>
+    <string name="apm_runtime_jank">Frame drop=%1$s%% (%2$d / %3$d frames)</string>
+    <string name="apm_runtime_top_threads">Top CPU delta threads</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Surface more accurate process memory metrics (USS/VSS) and richer PSS breakdown (Code/Stack/etc.) so the editor can measure real per-process cost and memory composition. 
- Provide deeper, low-intrusion runtime signals (CPU user/system split, per-thread CPU deltas, I/O deltas, frame jank) to aid triage without requiring native agents. 
- Expose device thermal state and simple alerts in the APM UI to warn when the phone is too hot. 

### Description
- Extended `EditorProcessApmSnapshot` with USS/VSS, `EditorPssBreakdownStat`, CPU breakdown, I/O stat, top thread stats, frame jank stat and device thermal stat, and added corresponding data classes. 
- Implemented USS reading from `/proc/self/smaps_rollup`, VSS from `/proc/self/statm`, PSS breakdown using `Debug.MemoryInfo`/`getMemoryStat(...)`, CPU breakdown from `/proc/self/stat`, I/O from `/proc/self/io`, and per-thread CPU deltas from `/proc/self/task/*/stat`. 
- Added a `FrameJankTracker` using `Choreographer` to sample frame intervals and compute dropped-frame ratio and integrated battery temperature sampling (`Intent.ACTION_BATTERY_CHANGED`) into the monitor and alert rules. 
- Updated `EditorProcessApmFragment` UI to add USS/VSS tiles, a PSS breakdown card, a runtime deep-signals card (CPU split, I/O deltas, jank, top threads) and a temperature status card with green/yellow/red state text and strings added to `apm_monitor_strings.xml` and night resources. 

### Testing
- Attempted a local Kotlin compilation with `./gradlew :core:app:compileDebugKotlin --no-daemon` to validate changes, but the build failed in this environment due to an SDK/toolchain issue (`25.0.1`) unrelated to the code changes. 
- No automated unit/integration tests were added in this change, and runtime validation should be performed on-device (APK run) to confirm `Choreographer` sampling and `/proc`-based readings behave across Android versions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6319533c8331ba52639b5ba89387)