### PR TITLE
Optimize ToolingServerRunner process lifecycle and coroutine overhead

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -34,8 +34,8 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import org.slf4j.LoggerFactory
 
 /**
@@ -50,6 +50,7 @@ internal class ToolingServerRunner(
 
   internal var pid: Int? = null
   private var _job: Job? = null
+  @Volatile private var processRef: Process? = null
   private var _isStarted = AtomicBoolean(false)
 
   var isStarted: Boolean
@@ -72,7 +73,6 @@ internal class ToolingServerRunner(
   fun startAsync(envs: Map<String, String>) =
       runnerScope
           .launch {
-            var process: Process?
             try {
               log.info("Starting tooling API server...")
               val command =
@@ -103,7 +103,7 @@ internal class ToolingServerRunner(
                       Environment.TOOLING_API_JAR.absolutePath,
                   )
 
-              process = executeProcessAsync {
+              val process = executeProcessAsync {
                 this.command = command
 
                 // input and output is used for communication to the tooling server
@@ -112,29 +112,14 @@ internal class ToolingServerRunner(
                 this.workingDirectory = null // HOME
                 this.environment = envs
               }
+              processRef = process
 
-              pid =
-                  ReflectionUtils.getDeclaredField(process::class.java, "pid")?.get(process) as Int?
+              pid = getProcessId(process)
               pid ?: throw IllegalStateException("Unable to get process ID")
 
               val inputStream = process.inputStream
               val outputStream = process.outputStream
               val errorStream = process.errorStream
-
-              val processJob =
-                  launch(Dispatchers.IO) {
-                    try {
-                      process?.waitFor()
-                      log.info(
-                          "Tooling API process exited with code : {}",
-                          process?.exitValue() ?: "<unknown>",
-                      )
-                      process = null
-                    } finally {
-                      log.info("Destroying Tooling API process...")
-                      process?.destroyForcibly()
-                    }
-                  }
 
               val launcher =
                   ToolingApiLauncher.newClientLauncher(
@@ -159,11 +144,11 @@ internal class ToolingServerRunner(
               // release to prevent memory leak
               listener = null
 
-              // Wait(block) until the process terminates
+              // Wait(block) until RPC listener is terminated.
               val serverJob =
                   launch(Dispatchers.IO) {
                     try {
-                      future.get()
+                      runInterruptible { future.get() }
                     } catch (err: Throwable) {
                       err.ifCancelledOrInterrupted {
                         log.info("ToolingServerThread has been cancelled or interrupted.")
@@ -174,12 +159,26 @@ internal class ToolingServerRunner(
                     }
                   }
 
-              processJob.join()
-              joinAll(serverJob, processJob)
+              val exitCode = runInterruptible { process.waitFor() }
+              log.info("Tooling API process exited with code : {}", exitCode)
+              observer?.onServerExited(exitCode)
+
+              if (!future.isDone) {
+                future.cancel(true)
+              }
+              serverJob.join()
             } catch (e: Throwable) {
               if (e !is CancellationException) {
                 log.error("Unable to start tooling API server", e)
               }
+            } finally {
+              isStarted = false
+              processRef?.let {
+                log.info("Destroying Tooling API process...")
+                it.destroyForcibly()
+              }
+              processRef = null
+              pid = null
             }
           }
           .also { _job = it }
@@ -188,7 +187,20 @@ internal class ToolingServerRunner(
     this.listener = null
     this.observer = null
     this._job?.cancel(CancellationException("Cancellation was requested"))
+    this.processRef?.destroyForcibly()
+    this.processRef = null
     this.runnerScope.cancelIfActive("Cancellation was requested")
+  }
+
+  private fun getProcessId(process: Process): Int? {
+    val pidMethod = ReflectionUtils.getDeclaredMethod(Process::class.java, "pid")
+    val javaPid =
+        pidMethod?.let { method -> ReflectionUtils.invokeMethod(method, process).value as? Long }
+    if (javaPid != null && javaPid > 0L) {
+      return javaPid.toInt()
+    }
+
+    return ReflectionUtils.getDeclaredField(process::class.java, "pid")?.get(process) as Int?
   }
 
   interface Observer {


### PR DESCRIPTION
### Motivation
- Reduce CPU/memory pressure caused by coroutine churn and lingering child processes in `ToolingServerRunner.startAsync()` while preserving existing features and behavior.
- Improve cancellation responsiveness during blocking waits and ensure child tooling process is reliably torn down to avoid resource leaks.

### Description
- Reworked `startAsync()` in `core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt` to remove the extra `processJob` coroutine and use a single, simpler wait path for the tooling process. 
- Wrap blocking calls to `future.get()` and `process.waitFor()` with `runInterruptible` to make cancellation more responsive. 
- Add a `@Volatile` `processRef` to track the spawned `Process` and ensure `release()` and the `finally` block call `destroyForcibly()` to prevent orphaned processes. 
- Add `getProcessId(process)` helper that first attempts `Process.pid()` via reflection and falls back to legacy `pid` field access, and call `observer?.onServerExited(exitCode)` when the process exits. 

### Testing
- Attempted to compile Kotlin with `./gradlew :core:app:compileDebugKotlin -x lint`, but the build failed due to an environment/toolchain issue (`25.0.1`) unrelated to the code changes, so full compilation verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec82a6325c8331bb24cb9ee7468e30)