### PR TITLE
feat(editor): rebuild SymbolInputView as BottomSheet tabbed pager

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/adapters/SymbolInputAdapter.java
+++ b/core/app/src/main/java/com/itsaky/androidide/adapters/SymbolInputAdapter.java
@@ -111,6 +111,26 @@ public class SymbolInputAdapter extends RecyclerView.Adapter<SymbolInputAdapter.
     }
 
     final var controller = editor.getSnippetController();
+    if ("__MOVE_LEFT__".equals(text)) {
+      editor.moveSelection(SelectionMovement.LEFT);
+      return;
+    }
+
+    if ("__MOVE_UP__".equals(text)) {
+      editor.moveSelection(SelectionMovement.UP);
+      return;
+    }
+
+    if ("__MOVE_RIGHT__".equals(text)) {
+      editor.moveSelection(SelectionMovement.RIGHT);
+      return;
+    }
+
+    if ("__MOVE_DOWN__".equals(text)) {
+      editor.moveSelection(SelectionMovement.DOWN);
+      return;
+    }
+
     if ("\t".equals(text) && controller.isInSnippet()) {
       controller.shiftToNextTabStop();
       return;

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -233,6 +233,8 @@ constructor(
   }
 
   fun onSlide(sheetOffset: Float) {
+    binding.symbolInput.onBottomSheetSlide(sheetOffset)
+
     val heightScale =
         if (sheetOffset >= COLLAPSE_HEADER_AT_OFFSET) {
           ((COLLAPSE_HEADER_AT_OFFSET - sheetOffset) + COLLAPSE_HEADER_AT_OFFSET) * 2f
@@ -306,7 +308,7 @@ constructor(
       return
     }
 
-    binding.symbolInput.itemAnimator?.endAnimations()
+    binding.symbolInput.endItemAnimations()
 
     TransitionManager.beginDelayedTransition(
         binding.root,

--- a/core/app/src/main/java/com/itsaky/androidide/ui/SymbolInputView.java
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/SymbolInputView.java
@@ -19,15 +19,40 @@ package com.itsaky.androidide.ui;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import androidx.recyclerview.widget.LinearLayoutManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager2.widget.ViewPager2;
+import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator;
+import com.itsaky.androidide.R;
 import com.itsaky.androidide.adapters.SymbolInputAdapter;
 import com.itsaky.androidide.editor.ui.IDEEditor;
 import com.itsaky.androidide.models.Symbol;
 import com.itsaky.androidide.utils.Symbols;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
-public class SymbolInputView extends RecyclerView {
+public class SymbolInputView extends FrameLayout {
+
+  private static final int COLLAPSED_PAGE_HEIGHT_DP = 112;
+  private static final int EXPANDED_PAGE_HEIGHT_DP = 280;
+  private static final float TAB_REVEAL_START_OFFSET = 0.12f;
+
+  private final TabLayout tabLayout;
+  private final ViewPager2 pager;
+  private final SymbolPagerAdapter pagerAdapter;
+  private TabLayoutMediator mediator;
 
   public SymbolInputView(Context context) {
     this(context, null);
@@ -39,19 +64,195 @@ public class SymbolInputView extends RecyclerView {
 
   public SymbolInputView(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
-    setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
+    LayoutInflater.from(context).inflate(R.layout.layout_symbol_input_view, this, true);
+    tabLayout = findViewById(R.id.symbol_tabs);
+    pager = findViewById(R.id.symbol_pager);
+    pager.setOffscreenPageLimit(2);
+    pagerAdapter = new SymbolPagerAdapter();
+    pager.setAdapter(pagerAdapter);
+    onBottomSheetSlide(0f);
   }
 
   public void refresh(IDEEditor editor, List<Symbol> symbols) {
-    if (symbols == null || symbols.isEmpty()) {
-      symbols = Symbols.INSTANCE.getPlainTextSymbols();
+    List<Symbol> dynamicSymbols = symbols;
+    if (dynamicSymbols == null || dynamicSymbols.isEmpty()) {
+      dynamicSymbols = Symbols.INSTANCE.getPlainTextSymbols();
     }
 
-    final var adapter = getAdapter();
-    if (adapter instanceof SymbolInputAdapter) {
-      ((SymbolInputAdapter) adapter).refresh(editor, symbols);
-    } else {
-      setAdapter(new SymbolInputAdapter(editor));
+    List<SymbolTabSpec> configuredTabs = loadTabSpecsFromJson();
+    List<SymbolTabSpec> merged = new ArrayList<>();
+    merged.add(new SymbolTabSpec("常用", dynamicSymbols));
+    merged.addAll(configuredTabs);
+
+    pagerAdapter.refresh(editor, merged);
+
+    if (mediator != null) {
+      mediator.detach();
+    }
+    mediator = new TabLayoutMediator(tabLayout, pager, (tab, position) -> tab.setText(merged.get(position).title));
+    mediator.attach();
+  }
+
+  public void onBottomSheetSlide(float sheetOffset) {
+    float clamped = Math.max(0f, Math.min(1f, sheetOffset));
+    float reveal = Math.max(0f, (clamped - TAB_REVEAL_START_OFFSET) / (1f - TAB_REVEAL_START_OFFSET));
+
+    tabLayout.setVisibility(reveal <= 0f ? View.GONE : View.VISIBLE);
+    tabLayout.setAlpha(reveal);
+    tabLayout.setScaleX(0.92f + (0.08f * reveal));
+    tabLayout.setScaleY(0.92f + (0.08f * reveal));
+
+    int collapsedHeight = dpToPx(COLLAPSED_PAGE_HEIGHT_DP);
+    int expandedHeight = dpToPx(EXPANDED_PAGE_HEIGHT_DP);
+    int targetHeight = (int) (collapsedHeight + (expandedHeight - collapsedHeight) * clamped);
+
+    ViewGroup.LayoutParams params = pager.getLayoutParams();
+    if (params.height != targetHeight) {
+      params.height = targetHeight;
+      pager.setLayoutParams(params);
+    }
+  }
+
+  public void endItemAnimations() {
+    pagerAdapter.endItemAnimations();
+  }
+
+  private int dpToPx(int dp) {
+    return Math.round(dp * getResources().getDisplayMetrics().density);
+  }
+
+  private List<SymbolTabSpec> loadTabSpecsFromJson() {
+    try (BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(
+                getResources().openRawResource(R.raw.symbol_input_tabs), StandardCharsets.UTF_8))) {
+      StringBuilder builder = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        builder.append(line);
+      }
+
+      JSONObject root = new JSONObject(builder.toString());
+      JSONArray tabs = root.optJSONArray("tabs");
+      if (tabs == null) {
+        return new ArrayList<>();
+      }
+
+      List<SymbolTabSpec> result = new ArrayList<>();
+      for (int i = 0; i < tabs.length(); i++) {
+        JSONObject tabObject = tabs.optJSONObject(i);
+        if (tabObject == null) {
+          continue;
+        }
+
+        String title = tabObject.optString("title", "Tab " + (i + 1));
+        JSONArray symbolsArray = tabObject.optJSONArray("symbols");
+        List<Symbol> parsedSymbols = new ArrayList<>();
+        if (symbolsArray != null) {
+          for (int s = 0; s < symbolsArray.length(); s++) {
+            JSONObject symbolObject = symbolsArray.optJSONObject(s);
+            if (symbolObject == null) {
+              continue;
+            }
+
+            String label = symbolObject.optString("label", "");
+            if (label.isEmpty()) {
+              continue;
+            }
+
+            String commit = symbolObject.has("commit") ? symbolObject.optString("commit", label) : label;
+            int offset = symbolObject.has("offset") ? symbolObject.optInt("offset", commit.length()) : commit.length();
+            parsedSymbols.add(new Symbol(label, commit, offset));
+          }
+        }
+
+        if (!parsedSymbols.isEmpty()) {
+          result.add(new SymbolTabSpec(title, parsedSymbols));
+        }
+      }
+      return result;
+    } catch (Throwable ignored) {
+      return new ArrayList<>();
+    }
+  }
+
+  private static final class SymbolTabSpec {
+    final String title;
+    final List<Symbol> symbols;
+
+    SymbolTabSpec(String title, List<Symbol> symbols) {
+      this.title = title;
+      this.symbols = symbols;
+    }
+  }
+
+  private static final class SymbolPagerAdapter extends RecyclerView.Adapter<SymbolPagerAdapter.PageVH> {
+
+    private final List<SymbolTabSpec> tabs = new ArrayList<>();
+    private IDEEditor editor;
+
+    void refresh(IDEEditor editor, List<SymbolTabSpec> newTabs) {
+      this.editor = Objects.requireNonNull(editor);
+      tabs.clear();
+      tabs.addAll(newTabs);
+      notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public PageVH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+      RecyclerView recyclerView = new RecyclerView(parent.getContext());
+      recyclerView.setLayoutParams(
+          new RecyclerView.LayoutParams(
+              ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+      recyclerView.setNestedScrollingEnabled(true);
+      recyclerView.setOverScrollMode(OVER_SCROLL_NEVER);
+      recyclerView.setLayoutManager(new GridLayoutManager(parent.getContext(), 8));
+      return new PageVH(recyclerView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PageVH holder, int position) {
+      holder.recyclerView.setAdapter(new SymbolInputAdapter(editor, tabs.get(position).symbols));
+    }
+
+    @Override
+    public int getItemCount() {
+      return tabs.size();
+    }
+
+    void endItemAnimations() {
+      for (PageVH holder : new ArrayList<>(holders)) {
+        RecyclerView.ItemAnimator animator = holder.recyclerView.getItemAnimator();
+        if (animator != null) {
+          animator.endAnimations();
+        }
+      }
+    }
+
+    private final List<PageVH> holders = new ArrayList<>();
+
+    @Override
+    public void onViewAttachedToWindow(@NonNull PageVH holder) {
+      super.onViewAttachedToWindow(holder);
+      if (!holders.contains(holder)) {
+        holders.add(holder);
+      }
+    }
+
+    @Override
+    public void onViewDetachedFromWindow(@NonNull PageVH holder) {
+      super.onViewDetachedFromWindow(holder);
+      holders.remove(holder);
+    }
+
+    private static final class PageVH extends RecyclerView.ViewHolder {
+      final RecyclerView recyclerView;
+
+      PageVH(@NonNull RecyclerView itemView) {
+        super(itemView);
+        this.recyclerView = itemView;
+      }
     }
   }
 }

--- a/core/app/src/main/res/layout/layout_symbol_input_view.xml
+++ b/core/app/src/main/res/layout/layout_symbol_input_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  android:paddingStart="8dp"
+  android:paddingEnd="8dp"
+  android:paddingTop="4dp"
+  android:paddingBottom="4dp">
+
+  <com.google.android.material.tabs.TabLayout
+    android:id="@+id/symbol_tabs"
+    style="@style/AppTheme.TabLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:alpha="0"
+    android:visibility="gone"
+    app:tabGravity="start"
+    app:tabMode="scrollable" />
+
+  <androidx.viewpager2.widget.ViewPager2
+    android:id="@+id/symbol_pager"
+    android:layout_width="match_parent"
+    android:layout_height="112dp"
+    android:overScrollMode="never" />
+
+</LinearLayout>

--- a/core/app/src/main/res/raw/symbol_input_tabs.json
+++ b/core/app/src/main/res/raw/symbol_input_tabs.json
@@ -1,0 +1,83 @@
+{
+  "tabs": [
+    {
+      "title": "backup",
+      "symbols": [
+        { "label": "注释", "commit": "//", "offset": 2 },
+        { "label": "←", "commit": "__MOVE_LEFT__" },
+        { "label": "↑", "commit": "__MOVE_UP__" },
+        { "label": "→", "commit": "__MOVE_RIGHT__" },
+        { "label": "\"", "commit": "\"\"", "offset": 1 },
+        { "label": "'", "commit": "''", "offset": 1 },
+        { "label": ".", "commit": "." },
+        { "label": ",", "commit": "," },
+        { "label": "/", "commit": "/" },
+        { "label": "//", "commit": "//", "offset": 2 },
+        { "label": "↓", "commit": "__MOVE_DOWN__" },
+        { "label": ":", "commit": ":" },
+        { "label": ";", "commit": ";" },
+        { "label": "#", "commit": "#" },
+        { "label": "+", "commit": "+" },
+        { "label": "−", "commit": "-" },
+        { "label": "*", "commit": "*" },
+        { "label": "=", "commit": "=" },
+        { "label": "|", "commit": "|" },
+        { "label": "~", "commit": "~" },
+        { "label": "(", "commit": "()", "offset": 1 },
+        { "label": ")", "commit": ")" },
+        { "label": "(\"", "commit": "(\"\")", "offset": 2 },
+        { "label": "\")", "commit": "\")" },
+        { "label": "{", "commit": "{}", "offset": 1 },
+        { "label": "}", "commit": "}" },
+        { "label": "()", "commit": "()", "offset": 1 },
+        { "label": "[]", "commit": "[]", "offset": 1 },
+        { "label": "{}", "commit": "{}", "offset": 1 },
+        { "label": "<", "commit": "<" },
+        { "label": ">", "commit": ">" },
+        { "label": "\\", "commit": "\\" }
+      ]
+    },
+    {
+      "title": "特殊",
+      "symbols": [
+        { "label": "↹", "commit": "\t", "offset": 1 },
+        { "label": "@", "commit": "@" },
+        { "label": "_", "commit": "_" },
+        { "label": "?", "commit": "?" },
+        { "label": "&", "commit": "&" },
+        { "label": "!", "commit": "!" },
+        { "label": "`", "commit": "`" },
+        { "label": "$", "commit": "$" },
+        { "label": "%", "commit": "%" },
+        { "label": "^", "commit": "^" },
+        { "label": "::", "commit": "::", "offset": 2 },
+        { "label": "->", "commit": "->", "offset": 2 },
+        { "label": "=>", "commit": "=>", "offset": 2 },
+        { "label": "?.", "commit": "?.", "offset": 2 },
+        { "label": "?:", "commit": "?:", "offset": 2 },
+        { "label": "in", "commit": "in", "offset": 2 }
+      ]
+    },
+    {
+      "title": "B",
+      "symbols": [
+        { "label": "{", "commit": "{}", "offset": 1 },
+        { "label": "}", "commit": "}" },
+        { "label": "[", "commit": "[]", "offset": 1 },
+        { "label": "]", "commit": "]" },
+        { "label": "(", "commit": "()", "offset": 1 },
+        { "label": ")", "commit": ")" },
+        { "label": "<", "commit": "<>", "offset": 1 },
+        { "label": ">", "commit": ">" },
+        { "label": "\"", "commit": "\"\"", "offset": 1 },
+        { "label": "'", "commit": "''", "offset": 1 },
+        { "label": "/**", "commit": "/**\n * \n */", "offset": 6 },
+        { "label": "/* */", "commit": "/*  */", "offset": 3 },
+        { "label": "//", "commit": "//", "offset": 2 },
+        { "label": "=", "commit": "=" },
+        { "label": "==", "commit": "==", "offset": 2 },
+        { "label": "!=", "commit": "!=", "offset": 2 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Replace the single-row symbol input with a bottom-sheet friendly paged UI so the symbol area can expand/collapse with the sheet and show multiple symbol columns and tabs as in the design mockups. 
- Make symbol pages configurable via JSON so symbol sets (including movement keys) can be extended without code changes.

### Description
- Replaced the old `SymbolInputView` implementation with a new `TabLayout + ViewPager2` container implemented in `core/app/src/main/java/com/itsaky/androidide/ui/SymbolInputView.java` and a dedicated layout `core/app/src/main/res/layout/layout_symbol_input_view.xml` that hosts the `TabLayout` and `ViewPager2` pager. 
- Added JSON-driven tab definitions in `core/app/src/main/res/raw/symbol_input_tabs.json` and JSON parsing in `SymbolInputView` to build pages at runtime. 
- Added `SymbolPagerAdapter` inside `SymbolInputView` that creates paged RecyclerViews using `GridLayoutManager` to show multi-column symbol grids and exposes `onBottomSheetSlide(float)` to animate tab reveal and dynamic pager height while the bottom sheet slides. 
- Extended `SymbolInputAdapter` (`core/app/src/main/java/com/itsaky/androidide/adapters/SymbolInputAdapter.java`) to recognise movement tokens (`__MOVE_LEFT__`, `__MOVE_UP__`, `__MOVE_RIGHT__`, `__MOVE_DOWN__`) produced by the JSON tabs and invoke editor cursor moves; preserved existing tab/snippet behavior. 
- Wired `EditorBottomSheet.onSlide()` to forward sheet progress to `SymbolInputView.onBottomSheetSlide()` and replaced the previous item-animator cleanup call with `SymbolInputView.endItemAnimations()` to safely end animations when soft input state changes. 

### Testing
- Attempted to compile the Android app with `./gradlew :core:app:compileDebugJavaWithJavac :core:app:compileDebugKotlin -x lint`, but the environment fails during Gradle/Kotlin script evaluation with `IllegalArgumentException: 25.0.1` (Java/Kotlin version parsing issue), so module compilation could not complete. 
- Attempted a focused compile `./gradlew :core:app:compileDebugJavaWithJavac -x lint --stacktrace`, which reproduces the same environment failure before Kotlin/Java classes are compiled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb0da31308331aafc8f1b7dfacf98)