### PR TITLE
Guard editor popup updates against detached-window IllegalArgumentException

### DIFF
--- a/composite-builds/build-deps/editor/src/main/java/io/github/rosemoe/sora/widget/base/EditorPopupWindow.java
+++ b/composite-builds/build-deps/editor/src/main/java/io/github/rosemoe/sora/widget/base/EditorPopupWindow.java
@@ -236,7 +236,13 @@ public class EditorPopupWindow {
         left += locationBuffer[0];
         top += locationBuffer[1];
         if (window.isShowing()) {
-            window.update(left, top, width, height);
+            try {
+                window.update(left, top, width, height);
+            } catch (IllegalArgumentException e) {
+                // PopupWindow can become detached from WindowManager during fast attach/detach
+                // transitions. Guard against framework crashes and clean up gracefully.
+                dismiss();
+            }
         } else if (show) {
             window.setHeight(height);
             window.setWidth(width);

--- a/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/EditorActionsMenu.kt
+++ b/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/EditorActionsMenu.kt
@@ -67,6 +67,7 @@ import io.github.rosemoe.sora.widget.EditorTouchEventHandler
 import java.io.File
 import kotlin.math.max
 import kotlin.math.min
+import org.slf4j.LoggerFactory
 
 /**
  * PopupMenu for showing editor's text and code actions.
@@ -82,6 +83,7 @@ open class EditorActionsMenu(val editor: IDEEditor) :
   companion object {
 
     const val DELAY: Long = 200
+    private val log = LoggerFactory.getLogger(EditorActionsMenu::class.java)
   }
 
   private val touchHandler: EditorTouchEventHandler = editor.eventHandler
@@ -566,7 +568,11 @@ open class EditorActionsMenu(val editor: IDEEditor) :
       this.list.adapter = ActionsListAdapter(item.subMenu, true)
 
       measureActionsList()
-      popup.update(findWidestItem(), this.list.measuredHeight)
+      runCatching { popup.update(findWidestItem(), this.list.measuredHeight) }
+          .onFailure {
+            log.warn("Failed to update editor actions popup after submenu selection", it)
+            dismiss()
+          }
     }
 
     return true


### PR DESCRIPTION
### Motivation
- Crashlytics reported `IllegalArgumentException: ... PopupDecorView ... not attached to window manager` happening during rapid attach/detach and popup layout updates, so the goal is to avoid framework crashes by making popup update logic defensive.

### Description
- Wrap `PopupWindow.update(...)` in `try/catch (IllegalArgumentException)` inside `EditorPopupWindow.applyWindowAttributes()` and call `dismiss()` on failure to avoid crashing when the popup is no longer attached.
- Wrap the submenu resize call `popup.update(...)` in `EditorActionsMenu.onMenuItemSelected(...)` with `runCatching` so failures are logged and the popup is dismissed instead of propagating an exception.
- Add an `org.slf4j.LoggerFactory` logger to `EditorActionsMenu` to record warning telemetry when the guarded failure path is exercised.

### Testing
- Attempted an automated compile with `./gradlew :editor:impl:compileDebugKotlin :composite-builds:build-deps:editor:compileDebugJavaWithJavac --no-daemon`, which failed early due to missing Android SDK components (`25.0.1`), so full build verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4e2368308331b2b839376dce8a75)