### PR TITLE
fix: 恢复编辑器底部面板 SymbolInputView 可见性

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -125,7 +125,6 @@ abstract class BaseEditorActivity :
   protected val memoryUsageWatcher = MemoryUsageWatcher()
   protected val pidToDatasetIdxMap = MutableIntIntMap(initialCapacity = 3)
   private val bottomSheetHeaderHideReasons = mutableSetOf<String>()
-  private var bottomSheetCardVisibilitySnapshot: Int = View.VISIBLE
   private var bottomSheetHeaderVisibilitySnapshot: Int = View.VISIBLE
 
   var isDestroying = false
@@ -301,7 +300,6 @@ abstract class BaseEditorActivity :
       val wasRemoved = bottomSheetHeaderHideReasons.remove(reason)
       if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
       val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetBinding.cardView.visibility = bottomSheetCardVisibilitySnapshot
       bottomSheetBinding.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
     }
   }
@@ -312,9 +310,7 @@ abstract class BaseEditorActivity :
       val wasAdded = bottomSheetHeaderHideReasons.add(reason)
       if (!wasAdded || bottomSheetHeaderHideReasons.size > 1) return@runOnUiThread
       val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetCardVisibilitySnapshot = bottomSheetBinding.cardView.visibility
       bottomSheetHeaderVisibilitySnapshot = bottomSheetBinding.headerContainer.visibility
-      bottomSheetBinding.cardView.visibility = View.INVISIBLE
       bottomSheetBinding.headerContainer.visibility = View.INVISIBLE
     }
   }

--- a/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
@@ -20,24 +20,10 @@
 <RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="?attr/colorSurface">
   
-  <com.google.android.material.card.MaterialCardView
-    android:id="@+id/cardView"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:cardCornerRadius="24dp"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    app:strokeWidth="0dp"
-    app:cardElevation="0dp"
-    android:scaleX="0.9"
-    android:scaleY="0.9"
-    app:cardBackgroundColor="?attr/colorSurface">
-  </com.google.android.material.card.MaterialCardView>
   <include
     android:id="@+id/border"
     layout="@layout/layout_divider_horizontal"


### PR DESCRIPTION
### Motivation
- 修复编辑器中 `SymbolInputView` 在底部面板中不可见的问题，该问题由之前向 `layout_editor_bottom_sheet.xml` 中引入的 `MaterialCardView` 容器及相关绑定逻辑导致视图层级/绑定不一致。 

### Description
- 从 `core/app/src/main/res/layout/layout_editor_bottom_sheet.xml` 中移除先前引入的 `MaterialCardView`，恢复底部面板头部为直接包含 `ViewFlipper`（含 `SymbolInputView`）的结构。 
- 从布局中移除不再使用的 `xmlns:app` 声明以避免不必要的属性依赖。 
- 清理 `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` 中对已移除 `cardView` 的快照字段 `bottomSheetCardVisibilitySnapshot` 及其读写/切换逻辑，仅保留并使用 `headerContainer` 的显示/隐藏控制。 
- 保持底部面板切换、IME 可见性检测与 `SymbolInputView` 刷新逻辑不变，确保软键盘弹出时仍会展示符号输入视图（通过 `headerContainer` 切换）。

### Testing
- 在当前环境尝试编译：执行 `./gradlew :core:app:compileDebugKotlin`，构建失败（非代码逻辑错误），Gradle/SDK 报错指向 Android 构建组件版本问题（输出含 `25.0.1` 错误）。
- 已通过静态检查与代码浏览验证：确认 `SymbolInputView` 的 `include` 行恢复在 `ViewFlipper` 中并且不再有对 `cardView` 的引用。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef45126a04832fa8494dd43113879d)