### PR TITLE
fix(symbol-input): apply kotlin-android plugin to zero-Symbol-input-view module

### DIFF
--- a/modules/zero-Symbol-input-view/build.gradle.kts
+++ b/modules/zero-Symbol-input-view/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.library")
+    id("kotlin-android")
 }
 
 android {


### PR DESCRIPTION
### Motivation
- Ensure Kotlin sources in the `modules/zero-Symbol-input-view` Android library are compiled and exposed so consumers (e.g. `core:app`) can access `AdvancedSymbolInputView` and its methods (`bindEditor`, `onHostResume`) and resolve downstream unresolved reference errors.

### Description
- Added `id("kotlin-android")` to `modules/zero-Symbol-input-view/build.gradle.kts` so the module's Kotlin sources are compiled by the Android Gradle plugin.

### Testing
- Ran `./gradlew :modules:zero-Symbol-input-view:compileDebugKotlin` and previously attempted `./gradlew :core:app:compileDebugKotlin`, but both could not complete due to an external Gradle/JDK parsing error (`IllegalArgumentException: 25.0.1`), so compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7131c8f0832fa77a4bf2e4c8fc5e)