### PR TITLE
Guard against null editor in EditorBottomSheet.refreshSymbolInput

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -307,7 +307,13 @@ constructor(
   }
 
   fun refreshSymbolInput(editor: CodeEditorView) {
-    binding.symbolInputView.bindEditor(editor.editor)
+    val codeEditor = editor.editor
+    if (codeEditor == null) {
+      log.warn("Cannot refresh symbol input because editor is null")
+      return
+    }
+
+    binding.symbolInputView.bindEditor(codeEditor)
     binding.symbolInputView.onHostResume()
   }
 


### PR DESCRIPTION
### Motivation
- Prevent passing a nullable `IDEEditor?` into `bindEditor()` (which expects a non-null `CodeEditor`) and avoid a potential NPE/argument-type mismatch when the editor view has no backing editor instance.

### Description
- In `core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt` added a local `val codeEditor = editor.editor`, return early with `log.warn(...)` if it is `null`, and only call `binding.symbolInputView.bindEditor(codeEditor)` when non-null.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin --no-daemon`, which failed in the container/CI due to missing Android SDK Build Tools version `25.0.1` and not due to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7728239c832f95fae70985c2d24c)