### PR TITLE
Fix page switch disappearing at EditorBottomSheet top

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -208,6 +208,7 @@ abstract class BaseEditorActivity :
   private var isPageSwitchVisibleForCurrentPage = true
   private var lastPageSwitchY = Float.NaN
   private var lastPageSwitchVisible: Boolean? = null
+  private var lastPageSwitchAlpha = Float.NaN
   private var isPageSwitchPositionUpdatePosted = false
 
   companion object {
@@ -847,6 +848,7 @@ abstract class BaseEditorActivity :
       }
       bottomSheet.setOffsetAnchor(editorAppBarLayout)
       pageSwitchBuildTab.setOnClickListener {
+        content.bottomSheet.suppressNextHeaderExpand()
         setExternalSymbolPageActive(false)
         bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
         if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
@@ -950,8 +952,9 @@ abstract class BaseEditorActivity :
           content.bottomSheet.top
         }
 
+    val rawTargetY = (anchorTop - container.height).toFloat()
     val minVisibleY = content.editorAppBarLayout.bottom.toFloat()
-    val targetY = kotlin.math.max((anchorTop - container.height).toFloat(), minVisibleY)
+    val targetY = kotlin.math.max(rawTargetY, minVisibleY)
     if (lastPageSwitchY.isNaN() || kotlin.math.abs(lastPageSwitchY - targetY) > 0.5f) {
       container.y = targetY
       lastPageSwitchY = targetY
@@ -963,6 +966,12 @@ abstract class BaseEditorActivity :
       lastPageSwitchVisible = shouldShow
     }
     if (shouldShow) {
+      val overlap = (minVisibleY - rawTargetY).coerceAtLeast(0f)
+      val alpha = (1f - (overlap / container.height)).coerceIn(0f, 1f)
+      if (lastPageSwitchAlpha.isNaN() || kotlin.math.abs(lastPageSwitchAlpha - alpha) > 0.01f) {
+        container.alpha = alpha
+        lastPageSwitchAlpha = alpha
+      }
       container.bringToFront()
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -950,7 +950,8 @@ abstract class BaseEditorActivity :
           content.bottomSheet.top
         }
 
-    val targetY = (anchorTop - container.height).toFloat()
+    val minVisibleY = content.editorAppBarLayout.bottom.toFloat()
+    val targetY = kotlin.math.max((anchorTop - container.height).toFloat(), minVisibleY)
     if (lastPageSwitchY.isNaN() || kotlin.math.abs(lastPageSwitchY - targetY) > 0.5f) {
       container.y = targetY
       lastPageSwitchY = targetY

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -100,6 +100,7 @@ constructor(
   private var anchorOffset = 0
   private var isImeVisible = false
   private var windowInsets: Insets? = null
+  private var suppressNextHeaderClickExpand = false
 
   var onHeaderPageChanged: ((Int) -> Unit)? = null
 
@@ -176,6 +177,10 @@ constructor(
     }
 
     binding.headerContainer.setOnClickListener {
+      if (suppressNextHeaderClickExpand) {
+        suppressNextHeaderClickExpand = false
+        return@setOnClickListener
+      }
       if (behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
       }
@@ -260,6 +265,10 @@ constructor(
   fun showChild(index: Int) {
     binding.headerContainer.displayedChild = if (index == CHILD_ACTION) 1 else 0
     onHeaderPageChanged?.invoke(if (index == CHILD_ACTION) CHILD_ACTION else CHILD_HEADER)
+  }
+
+  fun suppressNextHeaderExpand() {
+    suppressNextHeaderClickExpand = true
   }
 
   fun setActionText(text: CharSequence) {

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -156,13 +156,15 @@
           android:id="@+id/symbol_input_page"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:background="?attr/colorSurface"
           android:layout_gravity="bottom"
           android:visibility="gone">
 
           <android.zero.studio.widget.editor.symbolinput.AdvancedSymbolInputView
                android:id="@+id/external_symbol_input_view"
                android:layout_width="match_parent"
-               android:layout_height="wrap_content" />
+               android:layout_height="wrap_content"
+               android:background="?attr/colorSurface" />
      </FrameLayout>
 
      <include

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -118,11 +118,11 @@
      <com.google.android.material.card.MaterialCardView
           android:id="@+id/page_switch_container"
           android:layout_width="220dp"
-          android:layout_height="32dp"
+          android:layout_height="24dp"
           android:layout_gravity="bottom|center_horizontal"
           android:layout_marginBottom="@dimen/editor_sheet_collapsed_height"
           app:cardBackgroundColor="#7A2E8B"
-          app:cardCornerRadius="16dp"
+          app:cardCornerRadius="12dp"
           app:cardElevation="4dp">
 
           <LinearLayout


### PR DESCRIPTION
### Motivation
- The page switch control (`page_switch_container`) could be positioned above the visible app bar when the bottom sheet moved to the top, causing it to appear then immediately disappear.
- The goal is to keep the page switch visible and anchored to the bottom of the app bar area while still following the bottom sheet / symbol panel.

### Description
- Clamp the computed Y position for `page_switch_container` so it never goes above the bottom of the editor app bar by computing `minVisibleY = content.editorAppBarLayout.bottom.toFloat()` and using `targetY = kotlin.math.max((anchorTop - container.height).toFloat(), minVisibleY)`.
- Change applied in `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` within `updatePageSwitchContainerPosition()`.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin --no-daemon`; the build failed in this environment with `What went wrong: 25.0.1`, indicating missing or incompatible Android SDK tooling, so a full build/test could not be completed here.
- No automated unit tests were added or executed as part of this change due to the environment limitation described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a98fab78832fba292dc970ff5f7b)