### PR TITLE
Fade page-switch with bottom sheet slide and add symbol input background

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -208,6 +208,8 @@ abstract class BaseEditorActivity :
   private var isPageSwitchVisibleForCurrentPage = true
   private var lastPageSwitchY = Float.NaN
   private var lastPageSwitchVisible: Boolean? = null
+  private var lastPageSwitchAlpha = Float.NaN
+  private var bottomSheetSlideOffset = 0f
   private var isPageSwitchPositionUpdatePosted = false
 
   companion object {
@@ -809,6 +811,7 @@ abstract class BaseEditorActivity :
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
             if (isDestroying || _binding == null) return
             content.apply {
+              bottomSheetSlideOffset = slideOffset
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               this.bottomSheet.onSlide(slideOffset)
               this.viewContainer.scaleX = editorScale
@@ -847,12 +850,15 @@ abstract class BaseEditorActivity :
       }
       bottomSheet.setOffsetAnchor(editorAppBarLayout)
       pageSwitchBuildTab.setOnClickListener {
-        setExternalSymbolPageActive(false)
-        bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
         if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
           editorBottomSheet?.setState(BottomSheetBehavior.STATE_COLLAPSED)
         }
-        updateBottomSheetPageSwitch(isBuildStatusPage = true)
+        pageSwitchContainer.post {
+          if (_binding == null) return@post
+          setExternalSymbolPageActive(false)
+          bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
+          updateBottomSheetPageSwitch(isBuildStatusPage = true)
+        }
       }
       pageSwitchSymbolTab.setOnClickListener {
         if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
@@ -912,6 +918,7 @@ abstract class BaseEditorActivity :
     if (_binding == null) return
     isExternalSymbolPageActive = active
     if (active) {
+      bottomSheetSlideOffset = 0f
       resetEditorSurfaceTransform()
       content.bottomSheet.onSlide(0f)
     }
@@ -962,6 +969,20 @@ abstract class BaseEditorActivity :
       lastPageSwitchVisible = shouldShow
     }
     if (shouldShow) {
+      val alpha =
+          if (isExternalSymbolPageActive) {
+            1f
+          } else if (bottomSheetSlideOffset < 0f) {
+            (1f + bottomSheetSlideOffset).coerceIn(0f, 1f)
+          } else if (bottomSheetSlideOffset <= 0.5f) {
+            1f
+          } else {
+            (((0.5f - bottomSheetSlideOffset) + 0.5f) * 2f).coerceIn(0f, 1f)
+          }
+      if (lastPageSwitchAlpha.isNaN() || kotlin.math.abs(lastPageSwitchAlpha - alpha) > 0.01f) {
+        container.alpha = alpha
+        lastPageSwitchAlpha = alpha
+      }
       container.bringToFront()
     }
   }

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -156,13 +156,15 @@
           android:id="@+id/symbol_input_page"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:background="?attr/colorSurface"
           android:layout_gravity="bottom"
           android:visibility="gone">
 
           <android.zero.studio.widget.editor.symbolinput.AdvancedSymbolInputView
                android:id="@+id/external_symbol_input_view"
                android:layout_width="match_parent"
-               android:layout_height="wrap_content" />
+               android:layout_height="wrap_content"
+               android:background="?attr/colorSurface" />
      </FrameLayout>
 
      <include


### PR DESCRIPTION
### Motivation
- Make the page-switch control fade smoothly as the editor bottom sheet is slid to avoid visual jitter and abrupt transitions.
- Ensure page-switch remains fully visible when the external symbol page is active and track alpha changes to avoid redundant updates.
- Give the external symbol input page and its input view the correct surface background to match the editor styling.

### Description
- Added `bottomSheetSlideOffset` and `lastPageSwitchAlpha` fields and update `bottomSheetSlideOffset` from `BottomSheetCallback.onSlide` to track slide progress.
- Compute and apply the page-switch `alpha` in `updatePageSwitchContainerPosition` based on `isExternalSymbolPageActive` and `bottomSheetSlideOffset`, and only set the view alpha when the change exceeds `0.01f` to reduce unnecessary redraws.
- Reset `bottomSheetSlideOffset` and call `bottomSheet.onSlide(0f)` when enabling the external symbol page in `setExternalSymbolPageActive`.
- Wrap `pageSwitchBuildTab` click handling in a `post` to ensure layout is stable before showing the bottom sheet and updating page switch state.
- Add `?attr/colorSurface` background to `symbol_input_page` and the `AdvancedSymbolInputView` in `content_editor.xml` for consistent surface coloring.

### Testing
- Ran unit tests with `./gradlew test` and static analysis with `./gradlew lint`, both completed successfully.
- Built the app with `./gradlew assembleDebug` to validate layout and runtime compile, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a98fab78832fba292dc970ff5f7b)