### PR TITLE
修复 page_switch_container 锚定到底部面板顶部

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -806,6 +806,7 @@ abstract class BaseEditorActivity :
             } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
               resetEditorSurfaceTransform()
             }
+            updatePageSwitchContainerPosition()
           }
 
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -957,9 +958,7 @@ abstract class BaseEditorActivity :
           content.bottomSheet.top
         }
 
-    val rawTargetY = (anchorTop - container.height).toFloat()
-    val minVisibleY = content.editorAppBarLayout.bottom.toFloat()
-    val targetY = kotlin.math.max(rawTargetY, minVisibleY)
+    val targetY = (anchorTop - container.height).toFloat().coerceAtLeast(0f)
     if (lastPageSwitchY.isNaN() || kotlin.math.abs(lastPageSwitchY - targetY) > 0.5f) {
       container.y = targetY
       lastPageSwitchY = targetY


### PR DESCRIPTION
### Motivation
- 修复 `page_switch_container` 在 BottomSheet 状态切换或切换到 `AdvancedSymbolInputView` 时未固定在活动面板顶部，导致位置滞留或被 app bar 强制下移的问题。

### Description
- 在 BottomSheet 的 `onStateChanged` 回调中新增调用 `updatePageSwitchContainerPosition()`，以在状态变化后刷新位置。
- 将页面切换控件的 Y 计算改为以活动面板顶部为锚点（`content.bottomSheet.top` 或 `content.symbolInputPage.top`），并使用 `val targetY = (anchorTop - container.height).toFloat().coerceAtLeast(0f)` 代替原先基于 `editorAppBarLayout.bottom` 的强制夹取逻辑。

### Testing
- 运行 `./gradlew :core:app:compileDebugKotlin` 进行编译测试，但在当前环境中构建失败（Android/SDK 环境问题，Gradle 报错 `25.0.1`），因此无法在此环境完成本地编译验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bd108034832fb0433859d0ee86f4)