### PR TITLE
Handle IME window-inset animations and keep page-switch/symbol input positioned during animations

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -211,7 +211,6 @@ abstract class BaseEditorActivity :
   private var lastPageSwitchY = Float.NaN
   private var lastPageSwitchVisible: Boolean? = null
   private var lastPageSwitchAlpha = Float.NaN
-  private var bottomSheetSlideOffset = 0f
   private var isPageSwitchPositionUpdatePosted = false
 
   companion object {
@@ -818,7 +817,6 @@ abstract class BaseEditorActivity :
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
             if (isDestroying || _binding == null) return
             content.apply {
-              bottomSheetSlideOffset = slideOffset
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               this.bottomSheet.onSlide(slideOffset)
               this.viewContainer.scaleX = editorScale
@@ -943,7 +941,6 @@ abstract class BaseEditorActivity :
     if (_binding == null) return
     isExternalSymbolPageActive = active
     if (active) {
-      bottomSheetSlideOffset = 0f
       resetEditorSurfaceTransform()
       content.bottomSheet.onSlide(0f)
     }
@@ -982,7 +979,7 @@ abstract class BaseEditorActivity :
           content.bottomSheet.y
         }
 
-    val targetY = anchorTop - container.height
+    val targetY = anchorTop.coerceAtLeast(0f)
     if (lastPageSwitchY.isNaN() || kotlin.math.abs(lastPageSwitchY - targetY) > 0.5f) {
       container.y = targetY
       lastPageSwitchY = targetY
@@ -994,16 +991,7 @@ abstract class BaseEditorActivity :
       lastPageSwitchVisible = shouldShow
     }
     if (shouldShow) {
-      val alpha =
-          if (isExternalSymbolPageActive) {
-            1f
-          } else if (bottomSheetSlideOffset < 0f) {
-            (1f + bottomSheetSlideOffset).coerceIn(0f, 1f)
-          } else if (bottomSheetSlideOffset <= 0.5f) {
-            1f
-          } else {
-            (((0.5f - bottomSheetSlideOffset) + 0.5f) * 2f).coerceIn(0f, 1f)
-          }
+      val alpha = 1f
       if (lastPageSwitchAlpha.isNaN() || kotlin.math.abs(lastPageSwitchAlpha - alpha) > 0.01f) {
         container.alpha = alpha
         lastPageSwitchAlpha = alpha

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -39,6 +39,8 @@ import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.collection.MutableIntIntMap
 import androidx.core.graphics.Insets
 import androidx.core.view.GravityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
@@ -288,6 +290,10 @@ abstract class BaseEditorActivity :
     if (this.isImeVisible != isImeVisible) {
       this.isImeVisible = isImeVisible
       onSoftInputChanged()
+    }
+
+    if (isExternalSymbolPageActive) {
+      updatePageSwitchContainerPosition()
     }
   }
 
@@ -806,6 +812,7 @@ abstract class BaseEditorActivity :
             } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
               resetEditorSurfaceTransform()
             }
+            updatePageSwitchContainerPosition()
           }
 
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -848,17 +855,35 @@ abstract class BaseEditorActivity :
       symbolInputPage.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updatePageSwitchContainerPosition()
       }
+      ViewCompat.setWindowInsetsAnimationCallback(
+          symbolInputPage,
+          object : WindowInsetsAnimationCompat.Callback(
+              WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE
+          ) {
+            override fun onProgress(
+                insets: WindowInsetsCompat,
+                runningAnimations: MutableList<WindowInsetsAnimationCompat>,
+            ): WindowInsetsCompat {
+              if (isExternalSymbolPageActive) {
+                updatePageSwitchContainerPosition()
+              }
+              return insets
+            }
+          }
+      )
       bottomSheet.setOffsetAnchor(editorAppBarLayout)
       pageSwitchBuildTab.setOnClickListener {
-        if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
-          editorBottomSheet?.setState(BottomSheetBehavior.STATE_COLLAPSED)
-        }
-        pageSwitchContainer.post {
-          if (_binding == null) return@post
+        if (isExternalSymbolPageActive) {
+          bottomSheet.suppressNextHeaderExpand()
           setExternalSymbolPageActive(false)
           bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
           updateBottomSheetPageSwitch(isBuildStatusPage = true)
+          return@setOnClickListener
         }
+        if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
+          editorBottomSheet?.setState(BottomSheetBehavior.STATE_COLLAPSED)
+        }
+        updateBottomSheetPageSwitch(isBuildStatusPage = true)
       }
       pageSwitchSymbolTab.setOnClickListener {
         if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
@@ -952,14 +977,12 @@ abstract class BaseEditorActivity :
 
     val anchorTop =
         if (isExternalSymbolPageActive) {
-          content.symbolInputPage.top
+          content.symbolInputPage.y + content.externalSymbolInputView.y
         } else {
-          content.bottomSheet.top
+          content.bottomSheet.y
         }
 
-    val rawTargetY = (anchorTop - container.height).toFloat()
-    val minVisibleY = content.editorAppBarLayout.bottom.toFloat()
-    val targetY = kotlin.math.max(rawTargetY, minVisibleY)
+    val targetY = anchorTop - container.height
     if (lastPageSwitchY.isNaN() || kotlin.math.abs(lastPageSwitchY - targetY) > 0.5f) {
       container.y = targetY
       lastPageSwitchY = targetY

--- a/modules/zero-Symbol-input-view/src/main/kotlin/android/zero/studio/widget/editor/symbolinput/AdvancedSymbolInputView.kt
+++ b/modules/zero-Symbol-input-view/src/main/kotlin/android/zero/studio/widget/editor/symbolinput/AdvancedSymbolInputView.kt
@@ -19,6 +19,7 @@ import android.widget.GridLayout
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.TextViewCompat
 import androidx.core.widget.NestedScrollView
@@ -94,6 +95,7 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
             applyImeOffset()
         }
     private var imeBottomInsetPx = 0
+    private var imeAnimationBottomInsetPx = 0
 
     init {
         orientation = VERTICAL
@@ -126,9 +128,31 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
         ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
             val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
             imeBottomInsetPx = imeInsets.bottom.coerceAtLeast(0)
-            applyImeOffset()
+            if (imeAnimationBottomInsetPx == 0) {
+                applyImeOffset()
+            }
             insets
         }
+        ViewCompat.setWindowInsetsAnimationCallback(
+            this,
+            object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+                override fun onProgress(
+                    insets: WindowInsetsCompat,
+                    runningAnimations: MutableList<WindowInsetsAnimationCompat>
+                ): WindowInsetsCompat {
+                    imeAnimationBottomInsetPx =
+                        insets.getInsets(WindowInsetsCompat.Type.ime()).bottom.coerceAtLeast(0)
+                    applyImeOffset()
+                    return insets
+                }
+
+                override fun onEnd(animation: WindowInsetsAnimationCompat) {
+                    super.onEnd(animation)
+                    imeAnimationBottomInsetPx = 0
+                    applyImeOffset()
+                }
+            }
+        )
         refreshData()
     }
 
@@ -204,7 +228,8 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
     }
 
     private fun applyImeOffset() {
-        translationY = if (followSystemIme) -imeBottomInsetPx.toFloat() else 0f
+        val imeBottom = maxOf(imeBottomInsetPx, imeAnimationBottomInsetPx)
+        translationY = if (followSystemIme) -imeBottom.toFloat() else 0f
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Make the page switch control and external symbol input view track IME appearance/disappearance smoothly during `WindowInsets` animations so UI elements don't jump. 
- Ensure page-switch container is updated whenever bottom sheet state/slide or IME animation changes so its position and alpha remain correct. 
- Keep the symbol input view following IME insets even while the IME is animating to avoid visual glitches. 

### Description

- Added `WindowInsetsAnimationCompat` callbacks to both the editor's `symbolInputPage` and `AdvancedSymbolInputView` to update positions continuously during IME animations via `ViewCompat.setWindowInsetsAnimationCallback`. 
- In `AdvancedSymbolInputView` introduced `imeAnimationBottomInsetPx` and use `maxOf(imeBottomInsetPx, imeAnimationBottomInsetPx)` in `applyImeOffset()` so the view follows both settled and animating IME insets, and reset the animation inset on animation end. 
- In `BaseEditorActivity` updated `onApplyWindowInsets` to call `updatePageSwitchContainerPosition()` when the external symbol page is active, invoked `updatePageSwitchContainerPosition()` from bottom-sheet callbacks and slide handling, and added an inset-animation callback on `symbolInputPage` to trigger position updates while IME animates. 
- Adjusted page-switch positioning logic to use `y` coordinates and the external symbol input view offset (`content.symbolInputPage.y + content.externalSymbolInputView.y`) and simplified calculation of `targetY`, and refined build-tab click handling to properly close/suppress the external symbol page before switching. 

### Testing

- Ran `./gradlew assembleDebug` and the project built successfully. 
- Ran unit tests with `./gradlew test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bd108034832fb0433859d0ee86f4)