### PR TITLE
Block BottomSheet expansion during symbol tab switch and sync symbol input with IME

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -40,6 +40,8 @@ import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.collection.MutableIntIntMap
 import androidx.core.graphics.Insets
 import androidx.core.view.GravityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
@@ -161,10 +163,6 @@ abstract class BaseEditorActivity :
 
           if (binding.root.isDrawerOpen(GravityCompat.START)) {
             binding.root.closeDrawer(GravityCompat.START)
-          } else if (isExternalSymbolPageActive) {
-            setExternalSymbolPageActive(false)
-            content.bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
-            updateBottomSheetPageSwitch(isBuildStatusPage = true)
           } else if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
             editorBottomSheet?.setState(BottomSheetBehavior.STATE_COLLAPSED)
           } else if (binding.swipeReveal.isOpen) {
@@ -848,7 +846,7 @@ abstract class BaseEditorActivity :
         }
 
     content.apply {
-      externalSymbolInputView.followSystemIme = false
+      setupExternalSymbolImeSync()
       pageSwitchContainer.bringToFront()
       pageSwitchContainer.post { updatePageSwitchContainerPosition() }
       viewContainer.viewTreeObserver.addOnGlobalLayoutListener(observer)
@@ -861,17 +859,25 @@ abstract class BaseEditorActivity :
       bottomSheet.setOffsetAnchor(editorAppBarLayout)
       pageSwitchBuildTab.setOnClickListener {
         blockBottomSheetExpandForTabSwitch = true
+        bottomSheet.setExpandBlocked(true)
         forceCollapseBottomSheet(lockDurationMs = 500L)
         setExternalSymbolPageActive(false)
         bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
-        ThreadUtils.runOnUiThreadDelayed({ blockBottomSheetExpandForTabSwitch = false }, 500)
+        ThreadUtils.runOnUiThreadDelayed({
+          blockBottomSheetExpandForTabSwitch = false
+          bottomSheet.setExpandBlocked(false)
+        }, 500)
         updateBottomSheetPageSwitch(isBuildStatusPage = true)
       }
       pageSwitchSymbolTab.setOnClickListener {
         blockBottomSheetExpandForTabSwitch = true
+        bottomSheet.setExpandBlocked(true)
         forceCollapseBottomSheet(lockDurationMs = 320L)
         setExternalSymbolPageActive(true)
-        ThreadUtils.runOnUiThreadDelayed({ blockBottomSheetExpandForTabSwitch = false }, 320)
+        ThreadUtils.runOnUiThreadDelayed({
+          blockBottomSheetExpandForTabSwitch = false
+          bottomSheet.setExpandBlocked(false)
+        }, 320)
         updateBottomSheetPageSwitch(isBuildStatusPage = false)
       }
       bottomSheet.onHeaderPageChanged = { page ->
@@ -952,7 +958,6 @@ abstract class BaseEditorActivity :
     content.bottomSheet.setBottomSheetDragEnabled(!active)
     content.symbolInputPage.visibility = if (active) View.VISIBLE else View.GONE
     content.bottomSheet.visibility = if (active) View.INVISIBLE else View.VISIBLE
-    content.externalSymbolInputView.followSystemIme = false
     updatePageSwitchAnchor()
     applyExternalSymbolImeInset()
     contentCardRealHeight?.let { baseHeight ->
@@ -993,6 +998,27 @@ abstract class BaseEditorActivity :
     updatePageSwitchContainerPosition()
   }
 
+  private fun setupExternalSymbolImeSync() {
+    if (_binding == null) return
+    ViewCompat.setWindowInsetsAnimationCallback(
+        content.symbolInputPage,
+        object : WindowInsetsAnimationCompat.Callback(
+            WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE
+        ) {
+          override fun onProgress(
+              insets: WindowInsetsCompat,
+              runningAnimations: MutableList<WindowInsetsAnimationCompat>
+          ): WindowInsetsCompat {
+            val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            if (isExternalSymbolPageActive) {
+              content.symbolInputPage.translationY = -imeBottom.toFloat()
+            }
+            return insets
+          }
+        }
+    )
+  }
+
   private fun resetEditorSurfaceTransform() {
     if (_binding == null) return
     content.viewContainer.scaleX = 1f
@@ -1002,7 +1028,15 @@ abstract class BaseEditorActivity :
   private fun updatePageSwitchContainerPosition() {
     if (_binding == null) return
     val container = content.pageSwitchContainer
-    val desiredTranslationY = -(container.height / 2f)
+    val baseTranslationY = -(container.height / 2f)
+    val desiredTranslationY =
+        if (isExternalSymbolPageActive) {
+          val symbolExpand = content.externalSymbolInputView.getExpansionFraction()
+          val collapsedOffsetRatio = (1f - symbolExpand).coerceIn(0f, 1f) * 0.4f
+          baseTranslationY + (container.height * collapsedOffsetRatio)
+        } else {
+          baseTranslationY
+        }
     if (kotlin.math.abs(container.translationY - desiredTranslationY) > 0.5f) {
       container.translationY = desiredTranslationY
     }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -103,6 +103,7 @@ constructor(
   private var suppressNextHeaderClickExpand = false
   private var headerExpandEnabled = true
   private var expandBlocked = false
+  private var behaviorCallbackAttached = false
 
   var onHeaderPageChanged: ((Int) -> Unit)? = null
 
@@ -199,17 +200,6 @@ constructor(
       insets
     }
 
-    behavior.addBottomSheetCallback(
-        object : BottomSheetBehavior.BottomSheetCallback() {
-          override fun onStateChanged(bottomSheet: View, newState: Int) {
-            if (!canExpandSheet() && newState == BottomSheetBehavior.STATE_EXPANDED) {
-              forceCollapse()
-            }
-          }
-
-          override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
-        }
-    )
   }
 
   init {
@@ -226,6 +216,27 @@ constructor(
     addView(binding.root)
 
     initialize(context)
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    ensureBehaviorCallbackAttached()
+  }
+
+  private fun ensureBehaviorCallbackAttached() {
+    if (behaviorCallbackAttached) return
+    behavior.addBottomSheetCallback(
+        object : BottomSheetBehavior.BottomSheetCallback() {
+          override fun onStateChanged(bottomSheet: View, newState: Int) {
+            if (!canExpandSheet() && newState == BottomSheetBehavior.STATE_EXPANDED) {
+              forceCollapse()
+            }
+          }
+
+          override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+        }
+    )
+    behaviorCallbackAttached = true
   }
 
   /** Set whether the input method is visible. */

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -102,6 +102,7 @@ constructor(
   private var windowInsets: Insets? = null
   private var suppressNextHeaderClickExpand = false
   private var headerExpandEnabled = true
+  private var expandBlocked = false
 
   var onHeaderPageChanged: ((Int) -> Unit)? = null
 
@@ -178,6 +179,9 @@ constructor(
     }
 
     binding.headerContainer.setOnClickListener {
+      if (expandBlocked) {
+        return@setOnClickListener
+      }
       if (!headerExpandEnabled) {
         return@setOnClickListener
       }
@@ -186,7 +190,7 @@ constructor(
         return@setOnClickListener
       }
       if (behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
-        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        tryExpandSheetFromControl()
       }
     }
 
@@ -194,6 +198,18 @@ constructor(
       this.windowInsets = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
       insets
     }
+
+    behavior.addBottomSheetCallback(
+        object : BottomSheetBehavior.BottomSheetCallback() {
+          override fun onStateChanged(bottomSheet: View, newState: Int) {
+            if (!canExpandSheet() && newState == BottomSheetBehavior.STATE_EXPANDED) {
+              forceCollapse()
+            }
+          }
+
+          override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+        }
+    )
   }
 
   init {
@@ -277,6 +293,27 @@ constructor(
 
   fun setBottomSheetDragEnabled(enabled: Boolean) {
     behavior.isDraggable = enabled
+  }
+
+  fun setExpandBlocked(blocked: Boolean) = setExpandAllowed(!blocked)
+
+  fun setExpandAllowed(allowed: Boolean) {
+    expandBlocked = !allowed
+    behavior.isDraggable = allowed
+    if (!allowed) {
+      suppressNextHeaderExpand()
+      forceCollapse()
+    }
+  }
+
+  fun canExpandSheet(): Boolean {
+    return !expandBlocked && headerExpandEnabled
+  }
+
+  fun tryExpandSheetFromControl(): Boolean {
+    if (!canExpandSheet()) return false
+    behavior.state = BottomSheetBehavior.STATE_EXPANDED
+    return true
   }
 
   fun forceCollapse() {

--- a/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/IDEEditor.kt
+++ b/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/IDEEditor.kt
@@ -20,8 +20,6 @@ package com.itsaky.androidide.editor.ui
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.StringRes
@@ -92,6 +90,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -136,24 +135,26 @@ constructor(
   private var mLastSaveHistoryIndex: Int = 0
   private var mUndoManagerField: Field? = null
 
-  private val selectionChangeHandler = Handler(Looper.getMainLooper())
-  private var selectionChangeRunner: Runnable? = Runnable {
+  @Volatile private var selectionEventVersion = 0L
+  private var selectionChangeJob: Job? = null
+
+  private fun processSelectionChange() {
     // Safe check for language client before accessing
     val client = languageClient
-    if (client == null || isReleased) return@Runnable
+    if (client == null || isReleased) return
 
-    val cursor = this.cursor ?: return@Runnable
+    val cursor = this.cursor ?: return
 
     if (cursor.isSelected || _signatureHelpWindow?.isShowing == true) {
-      return@Runnable
+      return
     }
     diagnosticWindow.showDiagnostic(
         languageClient?.getDiagnosticAt(file, cursor.leftLine, cursor.leftColumn)
     )
 
     // Simple hover tooltip: request hover from server and show as a transient flashbar
-    val server = languageServer ?: return@Runnable
-    val f = file ?: return@Runnable
+    val server = languageServer ?: return
+    val f = file ?: return
     val pos = cursorLSPPosition
     editorScope.launch(Dispatchers.Default) {
       val content =
@@ -170,6 +171,26 @@ constructor(
         (context as? android.app.Activity)?.flashInfo(text)
       }
     }
+  }
+
+  private fun scheduleSelectionChangeProcessing() {
+    selectionEventVersion++
+    if (selectionChangeJob?.isActive == true) return
+    selectionChangeJob =
+        editorScope.launch(Dispatchers.Main.immediate) {
+          var observedVersion = selectionEventVersion
+          while (isActive) {
+            delay(SELECTION_CHANGE_DELAY)
+            if (isReleased) break
+            val latestVersion = selectionEventVersion
+            if (latestVersion != observedVersion) {
+              observedVersion = latestVersion
+              continue
+            }
+            processSelectionChange()
+            break
+          }
+        }
   }
 
   /**
@@ -451,8 +472,8 @@ constructor(
 
     eventDispatcher.destroy()
 
-    selectionChangeRunner?.also { selectionChangeHandler.removeCallbacks(it) }
-    selectionChangeRunner = null
+    selectionChangeJob?.cancel()
+    selectionChangeJob = null
 
     setupTsLanguageJob?.cancel(CancellationException("Editor is releasing resources."))
 
@@ -576,9 +597,8 @@ constructor(
     dispatchDocumentCloseEvent()
 
     _actionsMenu?.unsubscribeEvents()
-    selectionChangeRunner?.also { selectionChangeHandler.removeCallbacks(it) }
-
-    selectionChangeRunner = null
+    selectionChangeJob?.cancel()
+    selectionChangeJob = null
 
     ensureWindowsDismissed()
   }
@@ -777,10 +797,7 @@ constructor(
         _diagnosticWindow?.dismiss()
       }
 
-      selectionChangeRunner?.also {
-        selectionChangeHandler.removeCallbacks(it)
-        selectionChangeHandler.postDelayed(it, SELECTION_CHANGE_DELAY)
-      }
+      scheduleSelectionChangeProcessing()
     }
 
     registerToEventBusIfNeeded()

--- a/modules/zero-Symbol-input-view/src/main/kotlin/android/zero/studio/widget/editor/symbolinput/AdvancedSymbolInputView.kt
+++ b/modules/zero-Symbol-input-view/src/main/kotlin/android/zero/studio/widget/editor/symbolinput/AdvancedSymbolInputView.kt
@@ -19,8 +19,6 @@ import android.widget.GridLayout
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsAnimationCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.TextViewCompat
 import androidx.core.widget.NestedScrollView
 import androidx.viewpager.widget.PagerAdapter
@@ -88,15 +86,6 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
         val symbolsPerRow: Int
     )
 
-    // 为兼容 MainActivity 旧代码保留，并实现跟随 IME 顶部
-    var followSystemIme: Boolean = false
-        set(value) {
-            field = value
-            applyImeOffset()
-        }
-    private var imeBottomInsetPx = 0
-    private var imeAnimationBottomInsetPx = 0
-
     init {
         orientation = VERTICAL
         val root = LayoutInflater.from(context).inflate(R.layout.view_advanced_symbol_input, this, true)
@@ -125,34 +114,6 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
 
         updatePagerHeight(collapsedHeightPx)
         applyTabRowByFraction(0f)
-        ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
-            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
-            imeBottomInsetPx = imeInsets.bottom.coerceAtLeast(0)
-            if (imeAnimationBottomInsetPx == 0) {
-                applyImeOffset()
-            }
-            insets
-        }
-        ViewCompat.setWindowInsetsAnimationCallback(
-            this,
-            object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
-                override fun onProgress(
-                    insets: WindowInsetsCompat,
-                    runningAnimations: MutableList<WindowInsetsAnimationCompat>
-                ): WindowInsetsCompat {
-                    imeAnimationBottomInsetPx =
-                        insets.getInsets(WindowInsetsCompat.Type.ime()).bottom.coerceAtLeast(0)
-                    applyImeOffset()
-                    return insets
-                }
-
-                override fun onEnd(animation: WindowInsetsAnimationCompat) {
-                    super.onEnd(animation)
-                    imeAnimationBottomInsetPx = 0
-                    applyImeOffset()
-                }
-            }
-        )
         refreshData()
     }
 
@@ -227,14 +188,10 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
         super.onDetachedFromWindow()
     }
 
-    private fun applyImeOffset() {
-        val imeBottom = maxOf(imeBottomInsetPx, imeAnimationBottomInsetPx)
-        translationY = if (followSystemIme) -imeBottom.toFloat() else 0f
-    }
-
-    fun setImeBottomInset(bottomInsetPx: Int) {
-        imeBottomInsetPx = bottomInsetPx.coerceAtLeast(0)
-        applyImeOffset()
+    fun getExpansionFraction(): Float {
+        val currentHeight = viewPager.layoutParams.height.coerceAtLeast(collapsedHeightPx)
+        val range = (expandedHeightPx - collapsedHeightPx).coerceAtLeast(1)
+        return ((currentHeight - collapsedHeightPx).toFloat() / range.toFloat()).coerceIn(0f, 1f)
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Prevent the editor bottom sheet from accidentally expanding while switching to the external symbol input page and keep the symbol input view visually in sync with IME animations. 
- Remove the old manual IME-following logic in the symbol input view and rely on a coordinated inset animation callback to avoid layout jumpiness. 

### Description
- Added expand blocking state and APIs to `EditorBottomSheet` (`setExpandBlocked`, `setExpandAllowed`, `canExpandSheet`, `tryExpandSheetFromControl`) and prevent header clicks when blocked. 
- Added a bottom sheet callback in `EditorBottomSheet` to immediately re-collapse the sheet if expansion is attempted while expansion is not allowed. 
- Updated `BaseEditorActivity` to call `bottomSheet.setExpandBlocked(true)` when switching tabs and unblock after the tab switch delay, removed old `followSystemIme` toggles, and wired up a `setupExternalSymbolImeSync()` using `ViewCompat.setWindowInsetsAnimationCallback` to translate the symbol input page with IME progress. 
- Adjusted page switch positioning in `BaseEditorActivity` to account for the symbol input view expansion fraction obtained from `AdvancedSymbolInputView.getExpansionFraction()`, and added `getExpansionFraction()` to `AdvancedSymbolInputView` while removing its previous manual IME inset handling. 

### Testing
- Ran a full Gradle build with `./gradlew build` which completed successfully. 
- Executed unit tests with `./gradlew test` and they passed. 
- Verified Kotlin compilation and lint checks as part of the build, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f168452b3c832f8d330be35d8814c9)