### PR TITLE
Refactor page-switch UI layering and bubble gesture behavior

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -1041,24 +1041,6 @@ abstract class BaseEditorActivity :
     content.pageSwitchSymbolTab.alpha = revealFraction
   }
 
-        bubbleAccumulatedDragY = 0f
-        bubbleLastDragEventTimeMs = SystemClock.elapsedRealtime()
-      val now = SystemClock.elapsedRealtime()
-      val dtMs = (now - bubbleLastDragEventTimeMs).coerceAtLeast(1L)
-      bubbleLastDragEventTimeMs = now
-      bubbleAccumulatedDragY += delta
-      val trigger = resources.displayMetrics.density * 24f
-      if (kotlin.math.abs(bubbleAccumulatedDragY) < trigger) return@setOnVerticalDragListener
-      val velocityPxPerSec = kotlin.math.abs(delta) / dtMs.toFloat() * 1000f
-      val velocityThreshold = resources.displayMetrics.density * 900f
-      if (bubbleAccumulatedDragY < 0 && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
-        if (velocityPxPerSec >= velocityThreshold) {
-          markUserInitiatedExpand()
-        }
-      } else if (bubbleAccumulatedDragY > 0 && behavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
-      bubbleAccumulatedDragY = 0f
-        bubbleAccumulatedDragY = 0f
-        bubbleLastDragEventTimeMs = 0L
   private fun markUserInitiatedExpand() {
     userInitiatedExpandUntilMs = SystemClock.elapsedRealtime() + 1200L
   }
@@ -1067,10 +1049,11 @@ abstract class BaseEditorActivity :
     return SystemClock.elapsedRealtime() <= userInitiatedExpandUntilMs
   }
 
+  private fun applyExternalSymbolImeInset() {
+    if (_binding == null) return
+    val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
     content.symbolInputPage.translationY = -targetImeInset.toFloat()
-    content.pageSwitchContainer.translationY = 0f
-    updatePageSwitchAnchor()
     updatePageSwitchContainerPosition()
   }
 
@@ -1108,21 +1091,39 @@ abstract class BaseEditorActivity :
       if (_binding == null) return@setOnVerticalDragListener
       if (bubbleLastDragRawY.isNaN()) {
         bubbleLastDragRawY = rawY
+        bubbleAccumulatedDragY = 0f
+        bubbleLastDragEventTimeMs = SystemClock.elapsedRealtime()
         return@setOnVerticalDragListener
       }
       val delta = rawY - bubbleLastDragRawY
       bubbleLastDragRawY = rawY
       val behavior = editorBottomSheet ?: return@setOnVerticalDragListener
       if (kotlin.math.abs(delta) < 2f) return@setOnVerticalDragListener
-      if (delta < 0 && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
+
+      val now = SystemClock.elapsedRealtime()
+      val dtMs = (now - bubbleLastDragEventTimeMs).coerceAtLeast(1L)
+      bubbleLastDragEventTimeMs = now
+      bubbleAccumulatedDragY += delta
+      val velocityPxPerSec = kotlin.math.abs(delta) / dtMs.toFloat() * 1000f
+      val velocityThreshold = resources.displayMetrics.density * 900f
+      val dragThreshold = resources.displayMetrics.density * 24f
+      if (kotlin.math.abs(bubbleAccumulatedDragY) < dragThreshold || velocityPxPerSec < velocityThreshold) {
+        return@setOnVerticalDragListener
+      }
+
+      if (bubbleAccumulatedDragY < 0 && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
+        markUserInitiatedExpand()
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
-      } else if (delta > 0 && behavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
+      } else if (bubbleAccumulatedDragY > 0 && behavior.state != BottomSheetBehavior.STATE_COLLAPSED) {
         behavior.state = BottomSheetBehavior.STATE_COLLAPSED
       }
+      bubbleAccumulatedDragY = 0f
     }
     bubble.setOnTouchListener { _, event ->
       if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
         bubbleLastDragRawY = Float.NaN
+        bubbleAccumulatedDragY = 0f
+        bubbleLastDragEventTimeMs = 0L
       }
       false
     }

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -1217,7 +1217,8 @@ abstract class BaseEditorActivity :
   private fun onSoftInputChanged() {
     if (!isDestroying) {
       invalidateOptionsMenu()
-      if (_binding != null) content.bottomSheet.onSoftInputChanged()
+      // IME-driven symbol input translation is handled by applyExternalSymbolImeInset/setupExternalSymbolImeSync.
+      // Keep bottom-sheet state independent from IME visibility to avoid implicit UI-structure shifts.
     }
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -895,12 +895,13 @@ abstract class BaseEditorActivity :
         }
       }
       bottomSheet.onHeaderStatusTextChanged = { text ->
-        if (_binding == null) return@onHeaderStatusTextChanged
-        editorViewModel.statusText = text
-        if (!(if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden)) {
-          content.pageSwitchContainer.text = text
+        if (_binding != null) {
+          editorViewModel.statusText = text
+          if (!(if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden)) {
+            content.pageSwitchContainer.text = text
+          }
+          content.pageSwitchSymbolTab.text = text
         }
-        content.pageSwitchSymbolTab.text = text
       }
       setExternalSymbolPageActive(false)
       isPageSwitchVisibleForCurrentPage = true

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -735,6 +735,7 @@ abstract class BaseEditorActivity :
 
     setupNoEditorView()
     setupBottomSheet()
+    updateCursorInfoDisplay()
 
     if (
         !app.prefManager.getBoolean(KEY_BOTTOM_SHEET_SHOWN) &&
@@ -1195,6 +1196,20 @@ abstract class BaseEditorActivity :
     content.pageSwitchSymbolTab.text =
         if (isBuildStatusPage) getString(com.itsaky.androidide.resources.R.string.msg_swipe_up)
         else editorViewModel.statusText
+  }
+
+  fun onEditorCursorChanged() {
+    if (isDestroying || _binding == null) return
+    updateCursorInfoDisplay()
+  }
+
+  private fun updateCursorInfoDisplay() {
+    if (_binding == null) return
+    val editorView = provideCurrentEditor()
+    val cursor = editorView?.editor?.cursor
+    val line = (cursor?.leftLine ?: 0) + 1
+    val column = (cursor?.leftColumn ?: 0) + 1
+    content.pageSwitchCursorInfo.text = String.format("%d:%d UTF-8", line, column)
   }
 
   private fun setupDiagnosticInfo() {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -132,7 +132,6 @@ abstract class BaseEditorActivity :
   protected val memoryUsageWatcher = MemoryUsageWatcher()
   protected val pidToDatasetIdxMap = MutableIntIntMap(initialCapacity = 3)
   private val bottomSheetHeaderHideReasons = mutableSetOf<String>()
-  private var bottomSheetHeaderVisibilitySnapshot: Int = View.VISIBLE
   private var isExternalSymbolPageActive = false
 
   var isDestroying = false
@@ -319,21 +318,14 @@ abstract class BaseEditorActivity :
   protected fun releaseBottomSheetHeaderHide(reason: String) {
     runOnUiThread {
       if (_binding == null || isDestroying) return@runOnUiThread
-      val wasRemoved = bottomSheetHeaderHideReasons.remove(reason)
-      if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
-      val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetBinding.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      bottomSheetHeaderHideReasons.remove(reason)
     }
   }
 
   protected fun requestBottomSheetHeaderHide(reason: String) {
     runOnUiThread {
       if (_binding == null || isDestroying) return@runOnUiThread
-      val wasAdded = bottomSheetHeaderHideReasons.add(reason)
-      if (!wasAdded || bottomSheetHeaderHideReasons.size > 1) return@runOnUiThread
-      val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetHeaderVisibilitySnapshot = bottomSheetBinding.headerContainer.visibility
-      bottomSheetBinding.headerContainer.visibility = View.INVISIBLE
+      bottomSheetHeaderHideReasons.add(reason)
     }
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -713,7 +713,8 @@ abstract class BaseEditorActivity :
     editorViewModel._statusText.observe(this) {
       if (!isDestroying && _binding != null) {
         content.bottomSheet.setStatus(it.first, it.second)
-        content.pageSwitchContainer.text = it.first
+        val hidden = if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden
+        content.pageSwitchContainer.text = if (hidden) getString(com.itsaky.androidide.resources.R.string.msg_swipe_up) else it.first
       }
     }
 
@@ -785,10 +786,6 @@ abstract class BaseEditorActivity :
   }
 
   private fun appendClickableSpan(
-              if (!isUserInitiatedExpandAllowed()) {
-                editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
-                return
-              }
       sb: SpannableStringBuilder,
       @StringRes textRes: Int,
       span: ClickableSpan,
@@ -815,6 +812,10 @@ abstract class BaseEditorActivity :
           override fun onStateChanged(bottomSheet: View, newState: Int) {
             if (isDestroying || _binding == null) return
             if (newState == BottomSheetBehavior.STATE_EXPANDED && blockBottomSheetExpandForTabSwitch) {
+              editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
+              return
+            }
+            if (newState == BottomSheetBehavior.STATE_EXPANDED && !isUserInitiatedExpandAllowed() && !isExternalSymbolPageActive) {
               editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
               return
             }

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -894,6 +894,14 @@ abstract class BaseEditorActivity :
           updatePageSwitchContainerPosition()
         }
       }
+      bottomSheet.onHeaderStatusTextChanged = { text ->
+        if (_binding == null) return@onHeaderStatusTextChanged
+        editorViewModel.statusText = text
+        if (!(if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden)) {
+          content.pageSwitchContainer.text = text
+        }
+        content.pageSwitchSymbolTab.text = text
+      }
       setExternalSymbolPageActive(false)
       isPageSwitchVisibleForCurrentPage = true
       content.pageSwitchSymbolTab.text = getString(com.itsaky.androidide.resources.R.string.msg_swipe_up)
@@ -1078,18 +1086,18 @@ abstract class BaseEditorActivity :
   private fun setupPageSwitchGestureBubble() {
     if (_binding == null) return
     val bubble = content.pageSwitchGestureBubble
-    bubble.setOnVerticalDragListener { rawY ->
-      if (_binding == null) return@setOnVerticalDragListener
+    fun handleDrag(rawY: Float) {
+      if (_binding == null) return
       if (bubbleLastDragRawY.isNaN()) {
         bubbleLastDragRawY = rawY
         bubbleAccumulatedDragY = 0f
         bubbleLastDragEventTimeMs = SystemClock.elapsedRealtime()
-        return@setOnVerticalDragListener
+        return
       }
       val delta = rawY - bubbleLastDragRawY
       bubbleLastDragRawY = rawY
-      val behavior = editorBottomSheet ?: return@setOnVerticalDragListener
-      if (kotlin.math.abs(delta) < 2f) return@setOnVerticalDragListener
+      val behavior = editorBottomSheet ?: return
+      if (kotlin.math.abs(delta) < 2f) return
 
       val now = SystemClock.elapsedRealtime()
       val dtMs = (now - bubbleLastDragEventTimeMs).coerceAtLeast(1L)
@@ -1099,7 +1107,7 @@ abstract class BaseEditorActivity :
       val velocityThreshold = resources.displayMetrics.density * 900f
       val dragThreshold = resources.displayMetrics.density * 24f
       if (kotlin.math.abs(bubbleAccumulatedDragY) < dragThreshold || velocityPxPerSec < velocityThreshold) {
-        return@setOnVerticalDragListener
+        return
       }
 
       if (bubbleAccumulatedDragY < 0 && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
@@ -1110,7 +1118,11 @@ abstract class BaseEditorActivity :
       }
       bubbleAccumulatedDragY = 0f
     }
-    bubble.setOnTouchListener { _, event ->
+    bubble.setOnVerticalDragListener { rawY -> handleDrag(rawY) }
+    val dragTouchListener = View.OnTouchListener { _, event ->
+      if (event.actionMasked == MotionEvent.ACTION_MOVE) {
+        handleDrag(event.rawY)
+      }
       if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
         bubbleLastDragRawY = Float.NaN
         bubbleAccumulatedDragY = 0f
@@ -1118,6 +1130,8 @@ abstract class BaseEditorActivity :
       }
       false
     }
+    bubble.setOnTouchListener(dragTouchListener)
+    content.pageSwitchSymbolTab.setOnTouchListener(dragTouchListener)
     bubble.setOnClickListener {
       if (isExternalSymbolPageActive) {
         isSymbolPageSwitchHidden = !isSymbolPageSwitchHidden

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -28,6 +28,7 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
@@ -131,7 +132,6 @@ abstract class BaseEditorActivity :
   protected val memoryUsageWatcher = MemoryUsageWatcher()
   protected val pidToDatasetIdxMap = MutableIntIntMap(initialCapacity = 3)
   private val bottomSheetHeaderHideReasons = mutableSetOf<String>()
-  private var bottomSheetCardVisibilitySnapshot: Int = View.VISIBLE
   private var bottomSheetHeaderVisibilitySnapshot: Int = View.VISIBLE
   private var isExternalSymbolPageActive = false
 
@@ -322,7 +322,6 @@ abstract class BaseEditorActivity :
       val wasRemoved = bottomSheetHeaderHideReasons.remove(reason)
       if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
       val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetBinding.cardView.visibility = bottomSheetCardVisibilitySnapshot
       bottomSheetBinding.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
     }
   }
@@ -333,9 +332,7 @@ abstract class BaseEditorActivity :
       val wasAdded = bottomSheetHeaderHideReasons.add(reason)
       if (!wasAdded || bottomSheetHeaderHideReasons.size > 1) return@runOnUiThread
       val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetCardVisibilitySnapshot = bottomSheetBinding.cardView.visibility
       bottomSheetHeaderVisibilitySnapshot = bottomSheetBinding.headerContainer.visibility
-      bottomSheetBinding.cardView.visibility = View.INVISIBLE
       bottomSheetBinding.headerContainer.visibility = View.INVISIBLE
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -216,6 +216,7 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
       // Keep action enabled/disabled states in sync with cursor/selection changes.
       subscribeEvent(SelectionChangeEvent::class.java) { _, _ ->
         (context as? Activity?)?.invalidateOptionsMenu()
+        (context as? BaseEditorActivity)?.onEditorCursorChanged()
         if (isKeyboardVisible) {
           val cursor = this.cursor ?: return@subscribeEvent
           this.post { ensurePositionVisible(cursor.rightLine, cursor.rightColumn) }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -179,22 +179,6 @@ constructor(
       (fragment as ShareableOutputFragment).clearOutput()
     }
 
-    binding.headerContainer.setOnClickListener {
-      if (expandBlocked) {
-        return@setOnClickListener
-      }
-      if (!headerExpandEnabled) {
-        return@setOnClickListener
-      }
-      if (suppressNextHeaderClickExpand) {
-        suppressNextHeaderClickExpand = false
-        return@setOnClickListener
-      }
-      if (behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
-        tryExpandSheetFromControl()
-      }
-    }
-
     ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
       this.windowInsets = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
       insets
@@ -257,12 +241,6 @@ constructor(
             behavior.isGestureInsetBottomIgnored = isImeVisible
 
             binding.root.updatePadding(bottom = anchorOffset + insetBottom)
-            binding.headerContainer.apply {
-              updatePaddingRelative(bottom = paddingBottom + insetBottom)
-              updateLayoutParams<ViewGroup.LayoutParams> {
-                height = (collapsedHeight + insetBottom).roundToInt()
-              }
-            }
           }
         }
 
@@ -270,31 +248,10 @@ constructor(
   }
 
   fun onSlide(sheetOffset: Float) {
-    val heightScale =
-        if (sheetOffset >= COLLAPSE_HEADER_AT_OFFSET) {
-          ((COLLAPSE_HEADER_AT_OFFSET - sheetOffset) + COLLAPSE_HEADER_AT_OFFSET) * 2f
-        } else {
-          1f
-        }
-
-    val paddingScale =
-        if (!isImeVisible && sheetOffset <= COLLAPSE_HEADER_AT_OFFSET) {
-          ((1f - sheetOffset) * 2f) - 1f
-        } else {
-          0f
-        }
-
-    val padding = insetBottom * paddingScale
-    binding.headerContainer.apply {
-      updateLayoutParams<ViewGroup.LayoutParams> {
-        height = ((collapsedHeight + padding) * heightScale).roundToInt()
-      }
-      updatePaddingRelative(bottom = padding.roundToInt())
-    }
+    // Header has been migrated to BaseEditorActivity symbol-input overlay.
   }
 
   fun showChild(index: Int) {
-    binding.headerContainer.displayedChild = if (index == CHILD_ACTION) 1 else 0
     onHeaderPageChanged?.invoke(if (index == CHILD_ACTION) CHILD_ACTION else CHILD_HEADER)
   }
 
@@ -335,19 +292,15 @@ constructor(
 
   fun suspendHeaderExpandFor(durationMs: Long) {
     headerExpandEnabled = false
-    binding.headerContainer.removeCallbacks(resumeHeaderExpandRunnable)
-    binding.headerContainer.postDelayed(resumeHeaderExpandRunnable, durationMs)
+    removeCallbacks(resumeHeaderExpandRunnable)
+    postDelayed(resumeHeaderExpandRunnable, durationMs)
   }
 
   private val resumeHeaderExpandRunnable = Runnable { headerExpandEnabled = true }
 
-  fun setActionText(text: CharSequence) {
-    binding.actionText.text = text
-  }
+  fun setActionText(text: CharSequence) = Unit
 
-  fun setActionProgress(progress: Int) {
-    binding.progress.setProgressCompat(progress, true)
-  }
+  fun setActionProgress(progress: Int) = Unit
 
   fun appendApkLog(line: LogLine) {
     pagerAdapter.logFragment?.appendLog(line)
@@ -381,32 +334,9 @@ constructor(
     // Symbol input is managed externally by BaseEditorActivity.
   }
 
-  fun onSoftInputChanged() {
-    if (context !is Activity) {
-      log.error("Bottom sheet is not attached to an activity!")
-      return
-    }
+  fun onSoftInputChanged() = Unit
 
-    TransitionManager.beginDelayedTransition(
-        binding.root,
-        MaterialSharedAxis(MaterialSharedAxis.Y, false),
-    )
-
-    val activity = context as Activity
-    if (KeyboardUtils.isSoftInputVisible(activity)) {
-      onHeaderPageChanged?.invoke(STATE_EXTERNAL_SYMBOL)
-    } else {
-      binding.headerContainer.displayedChild = CHILD_HEADER
-      onHeaderPageChanged?.invoke(CHILD_HEADER)
-    }
-  }
-
-  fun setStatus(text: CharSequence, @GravityInt gravity: Int) {
-    runOnUiThread {
-      binding.statusText.gravity = gravity
-      binding.statusText.text = text
-    }
-  }
+  fun setStatus(text: CharSequence, @GravityInt gravity: Int) = Unit
 
   private fun shareFile(file: File) {
     shareFile(context, file, "text/plain")

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -106,6 +106,7 @@ constructor(
   private var behaviorCallbackAttached = false
 
   var onHeaderPageChanged: ((Int) -> Unit)? = null
+  var onHeaderStatusTextChanged: ((CharSequence) -> Unit)? = null
 
   private val insetBottom: Int
     get() = if (isImeVisible) 0 else windowInsets?.bottom ?: 0
@@ -298,7 +299,9 @@ constructor(
 
   private val resumeHeaderExpandRunnable = Runnable { headerExpandEnabled = true }
 
-  fun setActionText(text: CharSequence) = Unit
+  fun setActionText(text: CharSequence) {
+    onHeaderStatusTextChanged?.invoke(text)
+  }
 
   fun setActionProgress(progress: Int) = Unit
 
@@ -336,7 +339,9 @@ constructor(
 
   fun onSoftInputChanged() = Unit
 
-  fun setStatus(text: CharSequence, @GravityInt gravity: Int) = Unit
+  fun setStatus(text: CharSequence, @GravityInt gravity: Int) {
+    onHeaderStatusTextChanged?.invoke(text)
+  }
 
   private fun shareFile(file: File) {
     shareFile(context, file, "text/plain")

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -342,11 +342,11 @@ constructor(
   private val resumeHeaderExpandRunnable = Runnable { headerExpandEnabled = true }
 
   fun setActionText(text: CharSequence) {
-    binding.bottomAction.actionText.text = text
+    binding.actionText.text = text
   }
 
   fun setActionProgress(progress: Int) {
-    binding.bottomAction.progress.setProgressCompat(progress, true)
+    binding.progress.setProgressCompat(progress, true)
   }
 
   fun appendApkLog(line: LogLine) {
@@ -403,10 +403,8 @@ constructor(
 
   fun setStatus(text: CharSequence, @GravityInt gravity: Int) {
     runOnUiThread {
-      binding.buildStatus.let {
-        it.statusText.gravity = gravity
-        it.statusText.text = text
-      }
+      binding.statusText.gravity = gravity
+      binding.statusText.text = text
     }
   }
 

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -120,8 +120,8 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="bottom"
-          android:orientation="vertical"
-          android:background="?attr/colorSurface">
+          android:background="?attr/colorSurface"
+          android:orientation="vertical">
 
           <TextView
                android:id="@+id/page_switch_container"
@@ -131,28 +131,27 @@
                android:maxLines="1"
                android:paddingHorizontal="16dp"
                android:text="@string/msg_swipe_up"
-               android:textAppearance="@style/TextAppearance.Material3.BodyMedium"/>
+               android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
 
-          <com.itsaky.androidide.ui.EdgeSnapBubbleView
-               android:id="@+id/page_switch_gesture_bubble"
-               android:layout_width="56dp"
-               android:layout_height="220dp"
-               android:layout_gravity="center_horizontal" />
-
-          <TextView
-               android:id="@+id/page_switch_symbol_tab"
+          <FrameLayout
                android:layout_width="match_parent"
-               android:layout_height="32dp"
-               android:gravity="center"
-               android:maxLines="1"
-               android:text="@string/build_status_idle"
-               android:textAppearance="@style/TextAppearance.Material3.BodySmall"/>
+               android:layout_height="220dp">
 
-                    <TextView
-               android:id="@+id/page_switch_build_tab"
-               android:layout_width="0dp"
-               android:layout_height="0dp"
-               android:visibility="gone"/>
+               <TextView
+                    android:id="@+id/page_switch_symbol_tab"
+                    android:layout_width="match_parent"
+                    android:layout_height="32dp"
+                    android:gravity="center"
+                    android:maxLines="1"
+                    android:text="@string/build_status_idle"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+
+               <com.itsaky.androidide.ui.EdgeSnapBubbleView
+                    android:id="@+id/page_switch_gesture_bubble"
+                    android:layout_width="56dp"
+                    android:layout_height="220dp"
+                    android:layout_gravity="top|center_horizontal" />
+          </FrameLayout>
 
           <android.zero.studio.widget.editor.symbolinput.AdvancedSymbolInputView
                android:id="@+id/external_symbol_input_view"

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -137,14 +137,32 @@
                android:layout_width="match_parent"
                android:layout_height="220dp">
 
-               <TextView
-                    android:id="@+id/page_switch_symbol_tab"
+               <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="32dp"
-                    android:gravity="center"
-                    android:maxLines="1"
-                    android:text="@string/build_status_idle"
-                    android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingHorizontal="12dp">
+
+                    <TextView
+                         android:id="@+id/page_switch_symbol_tab"
+                         android:layout_width="0dp"
+                         android:layout_height="match_parent"
+                         android:layout_weight="1"
+                         android:gravity="center_vertical"
+                         android:maxLines="1"
+                         android:text="@string/build_status_idle"
+                         android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+
+                    <TextView
+                         android:id="@+id/page_switch_cursor_info"
+                         android:layout_width="wrap_content"
+                         android:layout_height="match_parent"
+                         android:gravity="center_vertical|end"
+                         android:maxLines="1"
+                         android:text="1:1 UTF-8"
+                         android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+               </LinearLayout>
 
                <com.itsaky.androidide.ui.EdgeSnapBubbleView
                     android:id="@+id/page_switch_gesture_bubble"

--- a/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="?attr/colorSurface">
@@ -14,48 +13,12 @@
     android:layout_height="0.5dp"
     android:layout_alignParentTop="true" />
 
-  <ViewFlipper
-    android:id="@+id/header_container"
-    android:layout_width="match_parent"
-    android:layout_below="@id/border"
-    android:layout_height="@dimen/editor_sheet_collapsed_height"
-    android:background="?attr/colorSurface">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/build_status"
-      android:layout_width="match_parent"
-      android:layout_height="56dp">
-      <TextView
-        android:id="@+id/statusText"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        tools:text="Build status"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/bottom_action"
-      android:layout_width="match_parent"
-      android:layout_height="56dp">
-      <com.google.android.material.progressindicator.LinearProgressIndicator
-        android:id="@+id/progress"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-      <TextView
-        android:id="@+id/action_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:gravity="center"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ViewFlipper>
-
   <com.google.android.material.tabs.TabLayout
     android:id="@+id/tabs"
     style="@style/AppTheme.TabLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_below="@id/header_container" />
+    android:layout_below="@id/border" />
 
   <androidx.legacy.widget.Space
     android:id="@+id/space_bottom"

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -6,243 +6,93 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import kotlin.math.abs
 
 /**
- * SlideBackView 一比一 Kotlin 版（按项目需求做最小改动）。
+ * Fixed-position bubble for page-switch/IDE drawer gestures.
+ * Removed: physical-back edge logic & left/right edge snapping behavior.
  */
-class EdgeSnapBubbleView : View {
+class EdgeSnapBubbleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : View(context, attrs, defStyleAttr) {
 
-  /** backView 高度 */
-  private var backViewHeight: Float = 0f
+  private val backPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+    color = 0xAA000000.toInt()
+    style = Paint.Style.FILL_AND_STROKE
+  }
+  private val arrowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+    color = Color.WHITE
+    style = Paint.Style.STROKE
+    strokeWidth = 6f
+    strokeCap = Paint.Cap.ROUND
+    strokeJoin = Paint.Join.ROUND
+  }
+  private val backPath = Path()
+  private val arrowPath = Path()
 
-  /** 边缘触发距离 */
-  private var backEdgeWidth: Float = 0f
+  private val backViewHeight = 220f * resources.displayMetrics.density
+  private val backMaxWidth = 56f * resources.displayMetrics.density
 
-  /** 最大返回触发距离 */
-  private var backMaxWidth: Float = 0f
-
-  private var thresholdLeft: Float = 0f
-  private var thresholdRight: Float = 0f
-
-  private var currentY: Float = 0f
-  private var downX: Float = 0f
-  private var isEdge: Boolean = false
-  private var deltaX: Float = 0f
-  private var mWidth: Int = 0
-  private var isOnlyLeftBack: Boolean = false
-  var left: Boolean = false
-  var right: Boolean = false
-  var forwardX: Float = 0f
-  var bufferX: Float = 0f
-
-  private var backPaint: Paint? = null
-  private var arrowPaint: Paint? = null
-  private var backPath: Path? = null
-  private var arrowPath: Path? = null
+  private var currentY: Float = backViewHeight / 2f
+  private var downRawY = 0f
+  private var showArrowUp = true
 
   private var verticalDragListener: ((Float) -> Unit)? = null
-  private var showArrowUp: Boolean = true
 
-  fun setOnlyLeftBack(onlyLeftBack: Boolean) {
-    isOnlyLeftBack = onlyLeftBack
-  }
-
-  constructor(context: Context) : this(context, null)
-
-  constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
-
-  constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-    // 原始源码通过 styleable/dimen 读取。当前模块未定义对应 attrs，改为等价默认值。
-    val density = resources.displayMetrics.density
-    backViewHeight = 220f * density
-    backEdgeWidth = 12f * density
-    backMaxWidth = 56f * density
-    init()
-  }
-
-  private fun init() {
-    backPath = Path()
-    arrowPath = Path()
-
-    backPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    backPaint!!.color = 0xAA000000.toInt()
-    backPaint!!.style = Paint.Style.FILL_AND_STROKE
-
-    arrowPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    arrowPaint!!.color = Color.WHITE
-    arrowPaint!!.style = Paint.Style.STROKE
-    arrowPaint!!.strokeWidth = 6f
-    arrowPaint!!.strokeCap = Paint.Cap.ROUND
-    arrowPaint!!.strokeJoin = Paint.Join.ROUND
-  }
-
-  override fun onTouchEvent(ev: MotionEvent): Boolean {
-    val currentX = ev.x
-    currentY = ev.y
-    when (ev.action) {
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    currentY = event.y
+    when (event.actionMasked) {
       MotionEvent.ACTION_DOWN -> {
-        downX = ev.x
-        forwardX = downX
-        // 原始逻辑保留：边缘触发。
-        if (downX <= backEdgeWidth) {
-          isEdge = true
-          left = true
-          right = false
-        } else if (downX >= width - backEdgeWidth) {
-          isEdge = true
-          right = true
-          left = false
-        }
-        // 项目需求：固定吸附在 page_switch_container 顶部边缘可直接显示与点击。
-        // 因此若未命中边缘，也允许进入左侧形态绘制和点击，不隐藏。
-        if (!isEdge) {
-          isEdge = true
-          left = true
-          right = false
-        }
+        downRawY = event.rawY
+        verticalDragListener?.invoke(event.rawY)
       }
-
-      MotionEvent.ACTION_MOVE -> {
-        deltaX = currentX - downX
-        val diff = forwardX - currentX
-        if (diff > 0) {
-          if (currentX < thresholdLeft && left) {
-            deltaX = backMaxWidth
-            deltaX -= (thresholdLeft - currentX) / 2
-            bufferX = deltaX
-            if (deltaX < 0) {
-              deltaX = 0f
-              bufferX = 0f
-            }
-          } else if (currentX > thresholdRight && right) {
-            bufferX -= diff
-            deltaX = bufferX
-          }
-        } else {
-          if (currentX < thresholdLeft && left) {
-            bufferX += abs(diff)
-            deltaX = bufferX
-          } else if (currentX > thresholdRight && right) {
-            deltaX = -backMaxWidth
-            deltaX += (currentX - thresholdRight) / 2
-            bufferX = deltaX
-            if (deltaX < -backMaxWidth) {
-              deltaX = -backMaxWidth
-              bufferX = -backMaxWidth
-            }
-          }
-        }
-        forwardX = currentX
-        if (isEdge) {
-          verticalDragListener?.invoke(ev.rawY)
-          invalidate()
-        }
-      }
-
+      MotionEvent.ACTION_MOVE -> verticalDragListener?.invoke(event.rawY)
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-        if (isEdge) {
-          // 轻触也触发点击切换。
-          if (abs(deltaX) < backMaxWidth * 0.2f) {
-            performClick()
-          }
-          deltaX = 0f
-          invalidate()
+        if (abs(event.rawY - downRawY) < resources.displayMetrics.density * 8f) {
+          performClick()
         }
-        left = false
-        right = false
-        isEdge = false
-        bufferX = 0f
       }
     }
-    return isEdge
-  }
-
-  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-    mWidth = MeasureSpec.getSize(widthMeasureSpec) + 1
-    thresholdLeft = (mWidth / 3).toFloat()
-    thresholdRight = thresholdLeft * 2
+    invalidate()
+    return true
   }
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
-    if (deltaX > backMaxWidth && left) {
-      deltaX = backMaxWidth
-    } else if (deltaX < -backMaxWidth && right) {
-      deltaX = -backMaxWidth
+    val deltaY = currentY - backViewHeight / 2f
+    val drawDelta = backMaxWidth * 0.35f
+
+    backPath.reset()
+    arrowPath.reset()
+    backPath.moveTo(0f, deltaY)
+    backPath.quadTo(0f, backViewHeight / 4 + deltaY, drawDelta / 3, backViewHeight * 3 / 8 + deltaY)
+    backPath.quadTo(drawDelta * 5 / 8, backViewHeight / 2 + deltaY, drawDelta / 3, backViewHeight * 5 / 8 + deltaY)
+    backPath.quadTo(0f, backViewHeight * 6 / 8 + deltaY, 0f, backViewHeight + deltaY)
+    canvas.drawPath(backPath, backPaint)
+
+    val midX = drawDelta / 6f
+    val topY = backViewHeight * 15f / 32f + deltaY
+    val centerY = backViewHeight * 16f / 32f + deltaY
+    val bottomY = backViewHeight * 17f / 32f + deltaY
+    val tipOffset = 15f
+    if (showArrowUp) {
+      arrowPath.moveTo(midX, centerY)
+      arrowPath.lineTo(midX + tipOffset, topY)
+      arrowPath.moveTo(midX, centerY)
+      arrowPath.lineTo(midX + tipOffset, bottomY)
+    } else {
+      arrowPath.moveTo(midX + tipOffset, centerY)
+      arrowPath.lineTo(midX, topY)
+      arrowPath.moveTo(midX + tipOffset, centerY)
+      arrowPath.lineTo(midX, bottomY)
     }
-    Log.e("onDraw", "" + deltaX)
-    val deltaY = currentY - backViewHeight / 2
-    backPath!!.reset()
-    arrowPath!!.reset()
-
-    // 保留默认可见山峰（无拖动时）
-    val drawDelta = if (deltaX == 0f) backMaxWidth * 0.35f else abs(deltaX)
-
-    if ((deltaX > 0 && left) || (deltaX == 0f && !right)) {
-      backPath!!.moveTo(0f, deltaY)
-      backPath!!.quadTo(0f, backViewHeight / 4 + deltaY, drawDelta / 3, backViewHeight * 3 / 8 + deltaY)
-      backPath!!.quadTo(drawDelta * 5 / 8, backViewHeight / 2 + deltaY, drawDelta / 3, backViewHeight * 5 / 8 + deltaY)
-      backPath!!.quadTo(0f, backViewHeight * 6 / 8 + deltaY, 0f, backViewHeight + deltaY)
-      canvas.drawPath(backPath!!, backPaint!!)
-
-      val midX = drawDelta / 6f
-      val topY = backViewHeight * 15f / 32f + deltaY
-      val centerY = backViewHeight * 16f / 32f + deltaY
-      val bottomY = backViewHeight * 17f / 32f + deltaY
-      val tipOffset = 15f * (drawDelta / (mWidth / 6f))
-      if (showArrowUp) {
-        arrowPath!!.moveTo(midX, centerY)
-        arrowPath!!.lineTo(midX + tipOffset, topY)
-        arrowPath!!.moveTo(midX, centerY)
-        arrowPath!!.lineTo(midX + tipOffset, bottomY)
-      } else {
-        arrowPath!!.moveTo(midX + tipOffset, centerY)
-        arrowPath!!.lineTo(midX, topY)
-        arrowPath!!.moveTo(midX + tipOffset, centerY)
-        arrowPath!!.lineTo(midX, bottomY)
-      }
-      canvas.drawPath(arrowPath!!, arrowPaint!!)
-    } else if (deltaX < 0 && right) {
-      if (!isOnlyLeftBack) {
-        deltaX = abs(deltaX)
-        backPath!!.moveTo(mWidth.toFloat(), deltaY)
-        backPath!!.quadTo(mWidth.toFloat(), backViewHeight / 4 + deltaY, mWidth - deltaX / 3, backViewHeight * 3 / 8 + deltaY)
-        backPath!!.quadTo(mWidth - deltaX * 5 / 8, backViewHeight / 2 + deltaY, mWidth - deltaX / 3, backViewHeight * 5 / 8 + deltaY)
-        backPath!!.quadTo(mWidth.toFloat(), backViewHeight * 6 / 8 + deltaY, mWidth.toFloat(), backViewHeight + deltaY)
-        canvas.drawPath(backPath!!, backPaint!!)
-
-        arrowPath!!.moveTo(mWidth - deltaX / 6 - 15 * (deltaX / (mWidth / 6f)), backViewHeight * 15 / 32 + deltaY)
-        arrowPath!!.lineTo(mWidth - deltaX / 6, backViewHeight * 16.1f / 32 + deltaY)
-        arrowPath!!.moveTo(mWidth - deltaX / 6, backViewHeight * 15.9f / 32 + deltaY)
-        arrowPath!!.lineTo(mWidth - deltaX / 6 - 15 * (deltaX / (mWidth / 6f)), backViewHeight * 17 / 32 + deltaY)
-        canvas.drawPath(arrowPath!!, arrowPaint!!)
-      }
-    }
-    alpha = (drawDelta / backMaxWidth).coerceIn(0.35f, 1f)
+    canvas.drawPath(arrowPath, arrowPaint)
+    alpha = 1f
   }
-
-  fun setBackViewHeight(backViewHeight: Float) {
-    this.backViewHeight = backViewHeight
-  }
-
-  fun setBackEdgeWidth(backEdgeWidth: Float) {
-    this.backEdgeWidth = backEdgeWidth
-  }
-
-  fun setBackMaxWidth(backMaxWidth: Float) {
-    this.backMaxWidth = backMaxWidth
-  }
-
-  fun getBackEdgeWidth(): Float = backEdgeWidth
-
-  fun getBackMaxWidth(): Float = backMaxWidth
-
-  fun getBackViewHeight(): Float = backViewHeight
 
   fun setOnVerticalDragListener(listener: ((Float) -> Unit)?) {
     verticalDragListener = listener
@@ -254,9 +104,7 @@ class EdgeSnapBubbleView : View {
   }
 
   fun setArrowExpanded(expanded: Boolean) {
-    // expanded=true 表示容器显示中，箭头朝上（点击后收起）
     showArrowUp = expanded
     invalidate()
   }
-
 }


### PR DESCRIPTION
### Motivation
- 重做 page-switch 区域布局，使 `AdvancedSymbolInputView` 固定位于底部并一比一复刻设计图中的层级关系，同时移除无用占位控件以简化结构。 
- 消除 `EdgeSnapBubbleView` 与原始左右/物理边缘吸附、返回触发的耦合，以便能将气泡固定吸附到顶部文本控件边缘并支持统一的显示/隐藏动画。 
- 防止 Gradle/构建状态或静默状态变化导致 IDE 抽屉自动展开的问题，通过引入“用户发起”手势门控来避免焦点抢占引起的误触发。 

### Description
- 重构布局：修改 `core/app/src/main/res/layout/content_editor.xml` 中 `symbol_input_page` 的结构，将上层状态文本与气泡放入 `FrameLayout`，并移除原始的 `page_switch_build_tab` 占位节点以简化层级。 
- 重写交互视图：替换 `core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt` 为固定位置渲染的版本，移除左右边缘和物理按键逻辑，仅保留点击与垂直拖拽回调（`setOnVerticalDragListener` / `performClick`）。 
- 手势与门控：在 `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` 中改进气泡垂直拖拽处理，使用累计位移 (`bubbleAccumulatedDragY`) 和速度阈值判断（像素/秒）来确认为“用户发起”的展开操作，并在满足条件时调用 `markUserInitiatedExpand()` 并展开/收起底部抽屉。 
- IME 与 overlay 同步：提取并新增 `applyExternalSymbolImeInset()`，统一处理外部符号页的 IME 底部 inset 同步与 `updatePageSwitchContainerPosition()` 的更新逻辑，保持 `AdvancedSymbolInputView` 与其上方的 `TextView`/`EdgeSnapBubbleView` 在输入法弹起时同步平移。 

### Testing
- 尝试通过命令行运行构建检查 `./gradlew :core:app:compileDebugKotlin -x lint` 以触发 Kotlin 编译流程（对所改 Kotlin 文件进行初步验证）。 
- 构建在本环境于工具链/SDK 层面提前失败（错误版本/环境信息：`25.0.1`），因此 Kotlin 编译阶段未能在当前 CI/容器中完成；失败是环境限制导致，非代码变更直接引起。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f229b0e594832f89b2dc64709d3731)