### PR TITLE
Fix unresolved label in BaseEditorActivity status callback

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -894,8 +894,8 @@ abstract class BaseEditorActivity :
           updatePageSwitchContainerPosition()
         }
       }
-      bottomSheet.onHeaderStatusTextChanged = { text ->
-        if (_binding == null) return@onHeaderStatusTextChanged
+      bottomSheet.onHeaderStatusTextChanged = statusTextChanged@{ text ->
+        if (_binding == null) return@statusTextChanged
         editorViewModel.statusText = text
         if (!(if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden)) {
           content.pageSwitchContainer.text = text


### PR DESCRIPTION
### Motivation
- Fix a Kotlin `Unresolved label` error caused by returning to a non-existent label inside the lambda assigned to `bottomSheet.onHeaderStatusTextChanged`.

### Description
- Add an explicit lambda label `statusTextChanged@` and update the early return to `return@statusTextChanged` in `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` for the `onHeaderStatusTextChanged` assignment.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin -q`, but the build could not be completed in this environment due to a tooling/SDK issue reporting `* What went wrong: 25.0.1`, so compilation success could not be fully verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2519e6788832fa6ff5e4729b8ccf9)