### PR TITLE
Refactor editor bottom overlays and remove page-switch tabs

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -852,14 +852,26 @@ abstract class BaseEditorActivity :
 
     content.apply {
       setupExternalSymbolImeSync()
+      bottomSheet.onActionTextChanged = { text ->
+        content.bottomAction.actionText.text = text
+      }
+      bottomSheet.onActionProgressChanged = { progress ->
+        content.bottomAction.progress.setProgressCompat(progress, true)
+      }
+      bottomSheet.onStatusChanged = { text, gravity ->
+        content.buildStatus.statusText.gravity = gravity
+        content.buildStatus.statusText.text = text
+      }
       pageSwitchGestureBubble.bringToFront()
       symbolInputPage.post {
         setupPageSwitchGestureBubble()
+        syncSymbolInputPageWithBottomSheet()
         updateSymbolInputOverlayPosition()
       }
       viewContainer.viewTreeObserver.addOnGlobalLayoutListener(observer)
       bottomSheet.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updateSymbolInputOverlayPosition()
+        syncSymbolInputPageWithBottomSheet()
       }
       symbolInputPage.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updateSymbolInputOverlayPosition()
@@ -1042,17 +1054,42 @@ abstract class BaseEditorActivity :
     val h = container.height.toFloat().coerceAtLeast(1f)
     val targetY = if (expand) 0f else h
     val targetAlpha = if (expand) 1f else 0f
+    container.visibility = View.VISIBLE
     container
         .animate()
         .translationY(targetY)
         .alpha(targetAlpha)
         .setDuration(220L)
+        .withEndAction {
+          container.visibility = if (expand) View.VISIBLE else View.GONE
+          syncBubbleToHeaderTop()
+        }
         .start()
     content.pageSwitchGestureBubble
         .animate()
         .translationY(targetY)
         .setDuration(220L)
         .start()
+  }
+
+  private fun syncBubbleToHeaderTop() {
+    if (_binding == null) return
+    val container = content.headerOverlayContainer
+    content.pageSwitchGestureBubble.translationY = if (container.visibility == View.VISIBLE) {
+      container.translationY
+    } else {
+      0f
+    }
+  }
+
+  private fun syncSymbolInputPageWithBottomSheet() {
+    if (_binding == null) return
+    val lp = content.symbolInputPage.layoutParams as? CoordinatorLayout.LayoutParams ?: return
+    if (lp.anchorId != content.bottomSheet.id) {
+      lp.anchorId = content.bottomSheet.id
+      lp.anchorGravity = Gravity.TOP
+      content.symbolInputPage.layoutParams = lp
+    }
   }
 
   private fun updateSymbolInputOverlayPosition() {
@@ -1077,6 +1114,7 @@ abstract class BaseEditorActivity :
 
     // 顶部边缘同步：bubble/header/symbol input 在滑动期间统一显隐
     content.pageSwitchGestureBubble.visibility = targetVisibility
+    content.headerOverlayContainer.visibility = headerVisibility
     content.headerContainer.visibility = headerVisibility
     content.externalSymbolInputView.visibility = targetVisibility
     content.cardView.visibility = headerVisibility

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -171,7 +171,8 @@ abstract class BaseEditorActivity :
             binding.swipeReveal.close()
           } else {
             doConfirmProjectClose()
-  }
+          }
+        }
       }
 
   private val memoryUsageListener = MemoryUsageWatcher.MemoryUsageListener { memoryUsage ->

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -984,8 +984,18 @@ abstract class BaseEditorActivity :
     if (_binding == null) return
     val alpha = computePageSwitchAlpha()
     val visibility = if (alpha > 0.02f) View.VISIBLE else View.GONE
-    content.symbolInputPage.visibility = if (isExternalSymbolPageActive) View.VISIBLE else visibility
+    val targetVisibility = if (isExternalSymbolPageActive) View.VISIBLE else visibility
+    content.symbolInputPage.visibility = targetVisibility
     content.symbolInputPage.alpha = alpha
+
+    // 顶部边缘同步：bubble/header/symbol input 在滑动期间统一显隐
+    content.pageSwitchGestureBubble.visibility = targetVisibility
+    content.headerContainer.visibility = targetVisibility
+    content.externalSymbolInputView.visibility = targetVisibility
+    content.cardView.visibility = targetVisibility
+    content.border.visibility = targetVisibility
+    content.tvCursorPosition.visibility = targetVisibility
+
     content.pageSwitchGestureBubble.setArrowExpanded(!isExternalSymbolPageActive)
     content.pageSwitchGestureBubble.bringToFront()
   }

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -932,14 +932,28 @@ abstract class BaseEditorActivity :
 
   private fun applyExternalSymbolImeInset() {
     if (_binding == null) return
+    // 统一由 setupExternalSymbolImeSync() 的 WindowInsets 监听/动画回调处理位移，
+    // 这里只负责把当前 IME inset 同步给符号输入视图本身。
     val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
-    content.symbolInputPage.translationY = -targetImeInset.toFloat()
+    if (!isExternalSymbolPageActive) {
+      content.symbolInputPage.translationY = 0f
+    }
     updateSymbolInputOverlayPosition()
   }
 
   private fun setupExternalSymbolImeSync() {
     if (_binding == null) return
+    ViewCompat.setOnApplyWindowInsetsListener(content.symbolInputPage) { _, insets ->
+      val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+      latestImeBottomInset = imeBottom
+      val targetImeInset = if (isExternalSymbolPageActive) imeBottom else 0
+      content.externalSymbolInputView.setImeBottomInset(targetImeInset)
+      if (!isExternalSymbolPageActive) {
+        content.symbolInputPage.translationY = 0f
+      }
+      insets
+    }
     ViewCompat.setWindowInsetsAnimationCallback(
         content.symbolInputPage,
         object : WindowInsetsAnimationCompat.Callback(
@@ -952,7 +966,10 @@ abstract class BaseEditorActivity :
             val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
             if (isExternalSymbolPageActive) {
               content.symbolInputPage.translationY = -imeBottom.toFloat()
+            } else {
+              content.symbolInputPage.translationY = 0f
             }
+            content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
             return insets
           }
         }

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -1016,6 +1016,7 @@ abstract class BaseEditorActivity :
     val offset = (fraction * h).coerceIn(0f, h)
     container.translationY = offset
     container.alpha = (1f - (offset / h)).coerceIn(0f, 1f)
+    content.pageSwitchGestureBubble.translationY = container.translationY
   }
 
   private fun completeHeaderOverlayDrag(fraction: Float) {
@@ -1044,6 +1045,11 @@ abstract class BaseEditorActivity :
         .alpha(targetAlpha)
         .setDuration(220L)
         .start()
+    content.pageSwitchGestureBubble
+        .animate()
+        .translationY(targetY)
+        .setDuration(220L)
+        .start()
   }
 
   private fun updateSymbolInputOverlayPosition() {
@@ -1062,6 +1068,9 @@ abstract class BaseEditorActivity :
     val headerVisibility = if (hideHeaderBySymbolGesture) View.GONE else targetVisibility
     content.symbolInputPage.visibility = targetVisibility
     content.symbolInputPage.alpha = alpha
+    content.symbolInputPage.updateLayoutParams<ViewGroup.LayoutParams> {
+      height = ViewGroup.LayoutParams.WRAP_CONTENT
+    }
 
     // 顶部边缘同步：bubble/header/symbol input 在滑动期间统一显隐
     content.pageSwitchGestureBubble.visibility = targetVisibility

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -1033,16 +1033,25 @@ abstract class BaseEditorActivity :
     val alpha = computePageSwitchAlpha()
     val visibility = if (alpha > 0.02f) View.VISIBLE else View.GONE
     val targetVisibility = if (isExternalSymbolPageActive) View.VISIBLE else visibility
+    val symbolExpansion =
+        if (isExternalSymbolPageActive) {
+          content.externalSymbolInputView.getExpansionFraction().coerceIn(0f, 1f)
+        } else {
+          0f
+        }
+    // AdvancedSymbolInputView 正在上下拖拽或已完全展开时，自动隐藏 header 区域，保留 bubble。
+    val hideHeaderBySymbolGesture = symbolExpansion > 0.01f
+    val headerVisibility = if (hideHeaderBySymbolGesture) View.GONE else targetVisibility
     content.symbolInputPage.visibility = targetVisibility
     content.symbolInputPage.alpha = alpha
 
     // 顶部边缘同步：bubble/header/symbol input 在滑动期间统一显隐
     content.pageSwitchGestureBubble.visibility = targetVisibility
-    content.headerContainer.visibility = targetVisibility
+    content.headerContainer.visibility = headerVisibility
     content.externalSymbolInputView.visibility = targetVisibility
-    content.cardView.visibility = targetVisibility
-    content.border.visibility = targetVisibility
-    content.tvCursorPosition.visibility = targetVisibility
+    content.cardView.visibility = headerVisibility
+    content.border.visibility = headerVisibility
+    content.tvCursorPosition.visibility = headerVisibility
 
     content.pageSwitchGestureBubble.setArrowExpanded(!isExternalSymbolPageActive)
     content.pageSwitchGestureBubble.bringToFront()

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -104,6 +104,8 @@ import com.itsaky.androidide.viewmodel.EditorViewModel
 import com.itsaky.androidide.xml.resources.ResourceTableRegistry
 import com.itsaky.androidide.xml.versions.ApiVersionsRegistry
 import com.itsaky.androidide.xml.widgets.WidgetTableRegistry
+import io.github.rosemoe.sora.event.SelectionChangeEvent
+import io.github.rosemoe.sora.event.SubscriptionReceipt
 import java.io.File
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -212,6 +214,7 @@ abstract class BaseEditorActivity :
   private var blockBottomSheetExpandForTabSwitch = false
   private var isPageSwitchAnchorUpdatePosted = false
   private var latestImeBottomInset = 0
+  private var cursorPositionReceipt: SubscriptionReceipt<SelectionChangeEvent>? = null
 
   companion object {
 
@@ -504,6 +507,8 @@ abstract class BaseEditorActivity :
   override fun onDestroy() {
     checkIsDestroying()
     preDestroy()
+    cursorPositionReceipt?.unsubscribe()
+    cursorPositionReceipt = null
     super.onDestroy()
     postDestroy()
   }
@@ -533,6 +538,8 @@ abstract class BaseEditorActivity :
     EditorLineOperations.applyReadOnlyState(editorView.editor!!, this)
 
     editorView.onEditorSelected()
+    bindCursorPositionSync(editorView)
+    updateCursorPositionIndicator(editorView)
 
     editorViewModel.setCurrentFile(position, editorView.file)
     refreshSymbolInput(editorView)
@@ -1127,5 +1134,22 @@ abstract class BaseEditorActivity :
 
   open fun installationSessionCallback(): SessionCallback {
     return ApkInstallationSessionCallback(this).also { installationCallback = it }
+  }
+
+  private fun bindCursorPositionSync(editorView: CodeEditorView) {
+    cursorPositionReceipt?.unsubscribe()
+    val soraEditor = editorView.editor ?: return
+    cursorPositionReceipt =
+        soraEditor.subscribeEvent(SelectionChangeEvent::class.java) { _, _ ->
+          if (_binding == null || isDestroying) return@subscribeEvent
+          updateCursorPositionIndicator(editorView)
+        }
+  }
+
+  private fun updateCursorPositionIndicator(editorView: CodeEditorView) {
+    val cursor = editorView.editor?.cursor ?: return
+    val line = cursor.leftLine + 1
+    val column = cursor.leftColumn + 1
+    content.tvCursorPosition.text = "$line:$column"
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -170,8 +170,7 @@ abstract class BaseEditorActivity :
             binding.swipeReveal.close()
           } else {
             doConfirmProjectClose()
-          }
-        }
+  }
       }
 
   private val memoryUsageListener = MemoryUsageWatcher.MemoryUsageListener { memoryUsage ->
@@ -207,13 +206,10 @@ abstract class BaseEditorActivity :
 
   private var optionsMenuInvalidator: Runnable? = null
   private var isPageSwitchVisibleForCurrentPage = true
-  private var lastPageSwitchAlpha = Float.NaN
   private var bottomSheetSlideOffset = 0f
   private var blockBottomSheetExpandForTabSwitch = false
   private var isPageSwitchAnchorUpdatePosted = false
   private var latestImeBottomInset = 0
-  private var isBuildPageSwitchHidden = true
-  private var isSymbolPageSwitchHidden = true
 
   companion object {
 
@@ -317,9 +313,8 @@ abstract class BaseEditorActivity :
       if (_binding == null || isDestroying) return@runOnUiThread
       val wasRemoved = bottomSheetHeaderHideReasons.remove(reason)
       if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
-      val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetBinding.cardView.visibility = bottomSheetCardVisibilitySnapshot
-      bottomSheetBinding.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      content.cardView.visibility = bottomSheetCardVisibilitySnapshot
+      content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
     }
   }
 
@@ -328,11 +323,10 @@ abstract class BaseEditorActivity :
       if (_binding == null || isDestroying) return@runOnUiThread
       val wasAdded = bottomSheetHeaderHideReasons.add(reason)
       if (!wasAdded || bottomSheetHeaderHideReasons.size > 1) return@runOnUiThread
-      val bottomSheetBinding = content.bottomSheet.binding
-      bottomSheetCardVisibilitySnapshot = bottomSheetBinding.cardView.visibility
-      bottomSheetHeaderVisibilitySnapshot = bottomSheetBinding.headerContainer.visibility
-      bottomSheetBinding.cardView.visibility = View.INVISIBLE
-      bottomSheetBinding.headerContainer.visibility = View.INVISIBLE
+      bottomSheetCardVisibilitySnapshot = content.cardView.visibility
+      bottomSheetHeaderVisibilitySnapshot = content.headerContainer.visibility
+      content.cardView.visibility = View.INVISIBLE
+      content.headerContainer.visibility = View.INVISIBLE
     }
   }
 
@@ -815,7 +809,7 @@ abstract class BaseEditorActivity :
             } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
               resetEditorSurfaceTransform()
             }
-            updatePageSwitchContainerPosition()
+            updateSymbolInputOverlayPosition()
           }
 
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -826,7 +820,7 @@ abstract class BaseEditorActivity :
               this.bottomSheet.onSlide(slideOffset)
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
-              updatePageSwitchContainerPosition()
+              updateSymbolInputOverlayPosition()
             }
           }
         }
@@ -849,64 +843,31 @@ abstract class BaseEditorActivity :
 
     content.apply {
       setupExternalSymbolImeSync()
-      pageSwitchContainer.bringToFront()
       pageSwitchGestureBubble.bringToFront()
-      pageSwitchContainer.post {
+      symbolInputPage.post {
         setupPageSwitchGestureBubble()
-        updatePageSwitchContainerPosition()
-        updatePageSwitchContainerCollapsedState(animated = false)
+        updateSymbolInputOverlayPosition()
       }
       viewContainer.viewTreeObserver.addOnGlobalLayoutListener(observer)
       bottomSheet.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-        updatePageSwitchContainerPosition()
+        updateSymbolInputOverlayPosition()
       }
       symbolInputPage.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-        updatePageSwitchContainerPosition()
+        updateSymbolInputOverlayPosition()
       }
       bottomSheet.setOffsetAnchor(editorAppBarLayout)
-      pageSwitchBuildTab.setOnClickListener {
-        blockBottomSheetExpandForTabSwitch = true
-        bottomSheet.setExpandBlocked(true)
-        forceCollapseBottomSheet(lockDurationMs = 500L)
-        setExternalSymbolPageActive(false)
-        bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
-        ThreadUtils.runOnUiThreadDelayed({
-          blockBottomSheetExpandForTabSwitch = false
-          bottomSheet.setExpandBlocked(false)
-        }, 500)
-        updateBottomSheetPageSwitch(isBuildStatusPage = true)
-      }
-      pageSwitchSymbolTab.setOnClickListener {
-        blockBottomSheetExpandForTabSwitch = true
-        bottomSheet.setExpandBlocked(true)
-        forceCollapseBottomSheet(lockDurationMs = 320L)
-        setExternalSymbolPageActive(true)
-        ThreadUtils.runOnUiThreadDelayed({
-          blockBottomSheetExpandForTabSwitch = false
-          bottomSheet.setExpandBlocked(false)
-        }, 320)
-        updateBottomSheetPageSwitch(isBuildStatusPage = false)
-      }
       bottomSheet.onHeaderPageChanged = { page ->
         if (_binding != null) {
-          val isBuildStatusPage = page == EditorBottomSheet.CHILD_HEADER
-          val showPageSwitch = true
-          isPageSwitchVisibleForCurrentPage = showPageSwitch
-          content.pageSwitchBuildTab.isEnabled = showPageSwitch
-          content.pageSwitchSymbolTab.isEnabled = showPageSwitch
-
           when (page) {
             EditorBottomSheet.STATE_EXTERNAL_SYMBOL -> {
               if (!isExternalSymbolPageActive) {
                 setExternalSymbolPageActive(true)
               }
-              updateBottomSheetPageSwitch(isBuildStatusPage = false)
             }
             EditorBottomSheet.CHILD_HEADER -> {
               if (isExternalSymbolPageActive) {
                 setExternalSymbolPageActive(false)
               }
-              updateBottomSheetPageSwitch(isBuildStatusPage = true)
             }
             EditorBottomSheet.CHILD_ACTION -> {
               if (isExternalSymbolPageActive) {
@@ -919,18 +880,12 @@ abstract class BaseEditorActivity :
           if (!enableSwipeReveal && binding.swipeReveal.isOpen) {
             binding.swipeReveal.close()
           }
-          if (!isExternalSymbolPageActive) {
-            updateBottomSheetPageSwitch(isBuildStatusPage)
-          }
-          updatePageSwitchContainerPosition()
+          updateSymbolInputOverlayPosition()
         }
       }
       setExternalSymbolPageActive(false)
       isPageSwitchVisibleForCurrentPage = true
-      content.pageSwitchBuildTab.isEnabled = true
-      content.pageSwitchSymbolTab.isEnabled = true
-      updateBottomSheetPageSwitch(isBuildStatusPage = true)
-      updatePageSwitchContainerPosition()
+      updateSymbolInputOverlayPosition()
     }
   }
 
@@ -965,55 +920,13 @@ abstract class BaseEditorActivity :
     content.bottomSheet.setBottomSheetDragEnabled(!active)
     content.symbolInputPage.visibility = if (active) View.VISIBLE else View.GONE
     content.bottomSheet.visibility = if (active) View.INVISIBLE else View.VISIBLE
-    updatePageSwitchAnchor()
     applyExternalSymbolImeInset()
     contentCardRealHeight?.let { baseHeight ->
       binding.contentCard.updateLayoutParams<ViewGroup.LayoutParams> {
         height = if (active) baseHeight else (baseHeight - latestImeBottomInset)
       }
     }
-    updatePageSwitchContainerPosition()
-    updatePageSwitchContainerCollapsedState(animated = false)
-  }
-
-  private fun updatePageSwitchAnchor() {
-    if (_binding == null) return
-    val container = content.pageSwitchContainer
-    val layoutParams = container.layoutParams as? CoordinatorLayout.LayoutParams ?: return
-    val targetAnchorId = if (isExternalSymbolPageActive) content.symbolInputPage.id else content.bottomSheet.id
-    val targetAnchorGravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
-    val anchorChanged =
-        layoutParams.anchorId != targetAnchorId || layoutParams.anchorGravity != targetAnchorGravity
-    if (!anchorChanged) return
-    layoutParams.anchorId = targetAnchorId
-    layoutParams.anchorGravity = targetAnchorGravity
-    container.layoutParams = layoutParams
-    updatePageSwitchBubbleAnchor()
-    if (!isPageSwitchAnchorUpdatePosted) {
-      isPageSwitchAnchorUpdatePosted = true
-      container.post {
-        isPageSwitchAnchorUpdatePosted = false
-        updatePageSwitchContainerPosition()
-      }
-    }
-  }
-
-  private fun updatePageSwitchBubbleAnchor() {
-    if (_binding == null) return
-    val bubble = content.pageSwitchGestureBubble
-    val layoutParams = bubble.layoutParams as? CoordinatorLayout.LayoutParams ?: return
-    val shouldHide = if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden
-    val targetAnchorId =
-        if (shouldHide) {
-          if (isExternalSymbolPageActive) content.symbolInputPage.id else content.bottomSheet.id
-        } else {
-          content.pageSwitchContainer.id
-        }
-    val targetAnchorGravity = Gravity.TOP or Gravity.START
-    if (layoutParams.anchorId == targetAnchorId && layoutParams.anchorGravity == targetAnchorGravity) return
-    layoutParams.anchorId = targetAnchorId
-    layoutParams.anchorGravity = targetAnchorGravity
-    bubble.layoutParams = layoutParams
+    updateSymbolInputOverlayPosition()
   }
 
   private fun applyExternalSymbolImeInset() {
@@ -1021,9 +934,7 @@ abstract class BaseEditorActivity :
     val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
     content.symbolInputPage.translationY = -targetImeInset.toFloat()
-    content.pageSwitchContainer.translationY = 0f
-    updatePageSwitchAnchor()
-    updatePageSwitchContainerPosition()
+    updateSymbolInputOverlayPosition()
   }
 
   private fun setupExternalSymbolImeSync() {
@@ -1059,47 +970,24 @@ abstract class BaseEditorActivity :
     bubble.attachToSide(EdgeSnapBubbleView.Side.LEFT)
     bubble.setOnClickListener {
       if (isExternalSymbolPageActive) {
-        isSymbolPageSwitchHidden = !isSymbolPageSwitchHidden
+        setExternalSymbolPageActive(false)
+        content.bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
       } else {
-        isBuildPageSwitchHidden = !isBuildPageSwitchHidden
+        setExternalSymbolPageActive(true)
+        content.bottomSheet.showChild(EditorBottomSheet.STATE_EXTERNAL_SYMBOL)
       }
-      updatePageSwitchContainerCollapsedState(animated = true)
-      updatePageSwitchBubbleAnchor()
+      updateSymbolInputOverlayPosition()
     }
   }
 
-  private fun updatePageSwitchContainerCollapsedState(animated: Boolean) {
+  private fun updateSymbolInputOverlayPosition() {
     if (_binding == null) return
-    val container = content.pageSwitchContainer
-    val shouldHide = if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden
-    val hiddenShift = container.height.toFloat().coerceAtLeast(1f)
-    if (shouldHide) {
-      if (animated) {
-        container
-            .animate()
-            .alpha(0f)
-            .translationY(container.translationY + hiddenShift)
-            .setDuration(200L)
-            .withEndAction { container.visibility = View.GONE }
-            .start()
-      } else {
-        container.alpha = 0f
-        container.translationY += hiddenShift
-        container.visibility = View.GONE
-      }
-    } else {
-      container.visibility = View.VISIBLE
-      if (animated) {
-        val targetTranslationY = container.translationY
-        container.alpha = 0f
-        container.translationY = targetTranslationY + hiddenShift
-        container.animate().alpha(1f).translationY(targetTranslationY).setDuration(220L).start()
-      } else {
-        container.alpha = 1f
-      }
-    }
-    content.pageSwitchGestureBubble.setArrowExpanded(!shouldHide)
-    updatePageSwitchBubbleAnchor()
+    val alpha = computePageSwitchAlpha()
+    val visibility = if (alpha > 0.02f) View.VISIBLE else View.GONE
+    content.symbolInputPage.visibility = if (isExternalSymbolPageActive) View.VISIBLE else visibility
+    content.symbolInputPage.alpha = alpha
+    content.pageSwitchGestureBubble.setArrowExpanded(!isExternalSymbolPageActive)
+    content.pageSwitchGestureBubble.bringToFront()
   }
 
   private fun computePageSwitchAlpha(): Float {
@@ -1112,44 +1000,6 @@ abstract class BaseEditorActivity :
     } else {
       (((0.5f - bottomSheetSlideOffset) + 0.5f) * 2f).coerceIn(0f, 1f)
     }
-  }
-
-  private fun updatePageSwitchContainerPosition() {
-    if (_binding == null) return
-    val container = content.pageSwitchContainer
-    val baseTranslationY = -(container.height / 2f)
-    val desiredTranslationY =
-        if (isExternalSymbolPageActive) {
-          val symbolExpand = content.externalSymbolInputView.getExpansionFraction()
-          val collapsedOffsetRatio = (1f - symbolExpand).coerceIn(0f, 1f) * 0.4f
-          baseTranslationY + (container.height * collapsedOffsetRatio)
-        } else {
-          baseTranslationY
-        }
-    if (kotlin.math.abs(container.translationY - desiredTranslationY) > 0.5f) {
-      container.translationY = desiredTranslationY
-    }
-
-    val shouldShow = !(if (isExternalSymbolPageActive) isSymbolPageSwitchHidden else isBuildPageSwitchHidden)
-    container.visibility = if (shouldShow) View.VISIBLE else View.GONE
-    if (shouldShow) {
-      val alpha = computePageSwitchAlpha()
-      if (lastPageSwitchAlpha.isNaN() || kotlin.math.abs(lastPageSwitchAlpha - alpha) > 0.01f) {
-        container.alpha = alpha
-        lastPageSwitchAlpha = alpha
-      }
-    }
-    container.bringToFront()
-    val bubble = content.pageSwitchGestureBubble
-    bubble.setArrowExpanded(shouldShow)
-    bubble.restorePosition()
-    bubble.bringToFront()
-  }
-
-  private fun updateBottomSheetPageSwitch(isBuildStatusPage: Boolean) {
-    if (_binding == null) return
-    content.pageSwitchBuildTab.alpha = if (isBuildStatusPage) 1f else 0.55f
-    content.pageSwitchSymbolTab.alpha = if (isBuildStatusPage) 0.55f else 1f
   }
 
   private fun setupDiagnosticInfo() {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -1011,12 +1011,10 @@ abstract class BaseEditorActivity :
 
   private fun applyHeaderOverlayDrag(fraction: Float) {
     if (_binding == null) return
-    val container = content.headerOverlayContainer
-    val h = container.height.toFloat().coerceAtLeast(1f)
-    val offset = (fraction * h).coerceIn(0f, h)
-    container.translationY = offset
-    container.alpha = (1f - (offset / h)).coerceIn(0f, 1f)
-    content.pageSwitchGestureBubble.translationY = container.translationY
+    // 拖拽手势用于控制底部隐藏 tab 抽屉（bottom_sheet），不控制 header_overlay_container。
+    // 这里只做 bubble 的轻微跟手反馈。
+    val feedback = (fraction * content.pageSwitchGestureBubble.height).coerceIn(-24f, 24f)
+    content.pageSwitchGestureBubble.translationY = feedback
   }
 
   private fun completeHeaderOverlayDrag(fraction: Float) {
@@ -1028,9 +1026,7 @@ abstract class BaseEditorActivity :
         editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
       }
     }
-    val shouldCollapse = fraction > 0.25f
-    isHeaderOverlayCollapsed = shouldCollapse
-    animateHeaderOverlay(expand = !shouldCollapse)
+    content.pageSwitchGestureBubble.animate().translationY(0f).setDuration(120L).start()
   }
 
   private fun animateHeaderOverlay(expand: Boolean) {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -1068,7 +1068,7 @@ abstract class BaseEditorActivity :
     content.headerContainer.visibility = headerVisibility
     content.externalSymbolInputView.visibility = targetVisibility
     content.cardView.visibility = headerVisibility
-    content.border.visibility = headerVisibility
+    content.border.root.visibility = headerVisibility
     content.tvCursorPosition.visibility = headerVisibility
 
     content.pageSwitchGestureBubble.setArrowExpanded(!isExternalSymbolPageActive)

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -134,6 +134,7 @@ abstract class BaseEditorActivity :
   private var bottomSheetCardVisibilitySnapshot: Int = View.VISIBLE
   private var bottomSheetHeaderVisibilitySnapshot: Int = View.VISIBLE
   private var isExternalSymbolPageActive = false
+  private var isHeaderOverlayCollapsed = false
 
   var isDestroying = false
     protected set
@@ -969,15 +970,62 @@ abstract class BaseEditorActivity :
     val bubble = content.pageSwitchGestureBubble
     bubble.attachToSide(EdgeSnapBubbleView.Side.LEFT)
     bubble.setOnClickListener {
-      if (isExternalSymbolPageActive) {
-        setExternalSymbolPageActive(false)
-        content.bottomSheet.showChild(EditorBottomSheet.CHILD_HEADER)
-      } else {
-        setExternalSymbolPageActive(true)
-        content.bottomSheet.showChild(EditorBottomSheet.STATE_EXTERNAL_SYMBOL)
-      }
-      updateSymbolInputOverlayPosition()
+      toggleHeaderOverlay()
     }
+    bubble.setOnDragListener(
+        object : EdgeSnapBubbleView.OnDragListener {
+          override fun onDrag(fraction: Float) {
+            applyHeaderOverlayDrag(fraction)
+          }
+
+          override fun onRelease(fraction: Float) {
+            completeHeaderOverlayDrag(fraction)
+          }
+        }
+    )
+  }
+
+  private fun toggleHeaderOverlay() {
+    if (_binding == null) return
+    isHeaderOverlayCollapsed = !isHeaderOverlayCollapsed
+    animateHeaderOverlay(expand = !isHeaderOverlayCollapsed)
+  }
+
+  private fun applyHeaderOverlayDrag(fraction: Float) {
+    if (_binding == null) return
+    val container = content.headerOverlayContainer
+    val h = container.height.toFloat().coerceAtLeast(1f)
+    val offset = (fraction * h).coerceIn(0f, h)
+    container.translationY = offset
+    container.alpha = (1f - (offset / h)).coerceIn(0f, 1f)
+  }
+
+  private fun completeHeaderOverlayDrag(fraction: Float) {
+    if (_binding == null) return
+    if (!isExternalSymbolPageActive) {
+      if (fraction < -0.35f) {
+        editorBottomSheet?.state = BottomSheetBehavior.STATE_EXPANDED
+      } else if (fraction > 0.35f) {
+        editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
+      }
+    }
+    val shouldCollapse = fraction > 0.25f
+    isHeaderOverlayCollapsed = shouldCollapse
+    animateHeaderOverlay(expand = !shouldCollapse)
+  }
+
+  private fun animateHeaderOverlay(expand: Boolean) {
+    if (_binding == null) return
+    val container = content.headerOverlayContainer
+    val h = container.height.toFloat().coerceAtLeast(1f)
+    val targetY = if (expand) 0f else h
+    val targetAlpha = if (expand) 1f else 0f
+    container
+        .animate()
+        .translationY(targetY)
+        .alpha(targetAlpha)
+        .setDuration(220L)
+        .start()
   }
 
   private fun updateSymbolInputOverlayPosition() {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -865,13 +865,11 @@ abstract class BaseEditorActivity :
       pageSwitchGestureBubble.bringToFront()
       symbolInputPage.post {
         setupPageSwitchGestureBubble()
-        syncSymbolInputPageWithBottomSheet()
         updateSymbolInputOverlayPosition()
       }
       viewContainer.viewTreeObserver.addOnGlobalLayoutListener(observer)
       bottomSheet.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updateSymbolInputOverlayPosition()
-        syncSymbolInputPageWithBottomSheet()
       }
       symbolInputPage.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updateSymbolInputOverlayPosition()
@@ -1079,16 +1077,6 @@ abstract class BaseEditorActivity :
       container.translationY
     } else {
       0f
-    }
-  }
-
-  private fun syncSymbolInputPageWithBottomSheet() {
-    if (_binding == null) return
-    val lp = content.symbolInputPage.layoutParams as? CoordinatorLayout.LayoutParams ?: return
-    if (lp.anchorId != content.bottomSheet.id) {
-      lp.anchorId = content.bottomSheet.id
-      lp.anchorGravity = Gravity.TOP
-      content.symbolInputPage.layoutParams = lp
     }
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -106,6 +106,9 @@ constructor(
   private var behaviorCallbackAttached = false
 
   var onHeaderPageChanged: ((Int) -> Unit)? = null
+  var onActionTextChanged: ((CharSequence) -> Unit)? = null
+  var onActionProgressChanged: ((Int) -> Unit)? = null
+  var onStatusChanged: ((CharSequence, Int) -> Unit)? = null
 
   private val insetBottom: Int
     get() = if (isImeVisible) 0 else windowInsets?.bottom ?: 0
@@ -314,11 +317,11 @@ constructor(
   private val resumeHeaderExpandRunnable = Runnable { headerExpandEnabled = true }
 
   fun setActionText(text: CharSequence) {
-    // moved to content_editor header overlay
+    onActionTextChanged?.invoke(text)
   }
 
   fun setActionProgress(progress: Int) {
-    // moved to content_editor header overlay
+    onActionProgressChanged?.invoke(progress)
   }
 
   fun appendApkLog(line: LogLine) {
@@ -373,7 +376,7 @@ constructor(
   }
 
   fun setStatus(text: CharSequence, @GravityInt gravity: Int) {
-    // moved to content_editor header overlay
+    onStatusChanged?.invoke(text, gravity)
   }
 
   private fun shareFile(file: File) {

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -239,7 +239,8 @@ constructor(
             view.viewTreeObserver.removeOnGlobalLayoutListener(this)
             anchorOffset = view.height + SizeUtils.dp2px(1f)
 
-            behavior.peekHeight = collapsedHeight.roundToInt()
+            // 默认让 tab 抽屉处于屏幕可见区域外，避免 tabs 指示器露出。
+            behavior.peekHeight = 0
             behavior.expandedOffset = anchorOffset
             behavior.isGestureInsetBottomIgnored = isImeVisible
 

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -179,22 +179,6 @@ constructor(
       (fragment as ShareableOutputFragment).clearOutput()
     }
 
-    binding.headerContainer.setOnClickListener {
-      if (expandBlocked) {
-        return@setOnClickListener
-      }
-      if (!headerExpandEnabled) {
-        return@setOnClickListener
-      }
-      if (suppressNextHeaderClickExpand) {
-        suppressNextHeaderClickExpand = false
-        return@setOnClickListener
-      }
-      if (behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
-        tryExpandSheetFromControl()
-      }
-    }
-
     ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
       this.windowInsets = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
       insets
@@ -257,12 +241,6 @@ constructor(
             behavior.isGestureInsetBottomIgnored = isImeVisible
 
             binding.root.updatePadding(bottom = anchorOffset + insetBottom)
-            binding.headerContainer.apply {
-              updatePaddingRelative(bottom = paddingBottom + insetBottom)
-              updateLayoutParams<ViewGroup.LayoutParams> {
-                height = (collapsedHeight + insetBottom).roundToInt()
-              }
-            }
           }
         }
 
@@ -285,16 +263,10 @@ constructor(
         }
 
     val padding = insetBottom * paddingScale
-    binding.headerContainer.apply {
-      updateLayoutParams<ViewGroup.LayoutParams> {
-        height = ((collapsedHeight + padding) * heightScale).roundToInt()
-      }
-      updatePaddingRelative(bottom = padding.roundToInt())
-    }
+    binding.root.updatePadding(bottom = (anchorOffset + padding).roundToInt())
   }
 
   fun showChild(index: Int) {
-    binding.headerContainer.displayedChild = if (index == CHILD_ACTION) 1 else 0
     onHeaderPageChanged?.invoke(if (index == CHILD_ACTION) CHILD_ACTION else CHILD_HEADER)
   }
 
@@ -335,18 +307,18 @@ constructor(
 
   fun suspendHeaderExpandFor(durationMs: Long) {
     headerExpandEnabled = false
-    binding.headerContainer.removeCallbacks(resumeHeaderExpandRunnable)
-    binding.headerContainer.postDelayed(resumeHeaderExpandRunnable, durationMs)
+    binding.root.removeCallbacks(resumeHeaderExpandRunnable)
+    binding.root.postDelayed(resumeHeaderExpandRunnable, durationMs)
   }
 
   private val resumeHeaderExpandRunnable = Runnable { headerExpandEnabled = true }
 
   fun setActionText(text: CharSequence) {
-    binding.bottomAction.actionText.text = text
+    // moved to content_editor header overlay
   }
 
   fun setActionProgress(progress: Int) {
-    binding.bottomAction.progress.setProgressCompat(progress, true)
+    // moved to content_editor header overlay
   }
 
   fun appendApkLog(line: LogLine) {
@@ -396,18 +368,12 @@ constructor(
     if (KeyboardUtils.isSoftInputVisible(activity)) {
       onHeaderPageChanged?.invoke(STATE_EXTERNAL_SYMBOL)
     } else {
-      binding.headerContainer.displayedChild = CHILD_HEADER
       onHeaderPageChanged?.invoke(CHILD_HEADER)
     }
   }
 
   fun setStatus(text: CharSequence, @GravityInt gravity: Int) {
-    runOnUiThread {
-      binding.buildStatus.let {
-        it.statusText.gravity = gravity
-        it.statusText.text = text
-      }
-    }
+    // moved to content_editor header overlay
   }
 
   private fun shareFile(file: File) {

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -115,67 +115,88 @@
           app:behavior_peekHeight="@dimen/editor_sheet_peek_height"
           app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
 
-     <com.google.android.material.card.MaterialCardView
-          android:id="@+id/page_switch_container"
-          android:layout_width="220dp"
-          android:layout_height="24dp"
-          app:layout_anchor="@id/bottom_sheet"
-          app:layout_anchorGravity="top|center_horizontal"
-          app:cardBackgroundColor="#7A2E8B"
-          app:cardCornerRadius="12dp"
-          app:cardElevation="4dp">
-
-          <LinearLayout
-               android:layout_width="match_parent"
-               android:layout_height="match_parent"
-               android:orientation="horizontal">
-
-               <TextView
-                    android:id="@+id/page_switch_build_tab"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/bottom_sheet_page_build"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
-                    android:textColor="@android:color/white" />
-
-               <TextView
-                    android:id="@+id/page_switch_symbol_tab"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/bottom_sheet_page_symbols"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
-                    android:textColor="#B3FFFFFF" />
-          </LinearLayout>
-     </com.google.android.material.card.MaterialCardView>
-
-     <com.itsaky.androidide.ui.EdgeSnapBubbleView
-          android:id="@+id/page_switch_gesture_bubble"
-          android:layout_width="56dp"
-          android:layout_height="220dp"
-          app:layout_anchor="@id/page_switch_container"
-          app:layout_anchorGravity="top|start"
-          android:layout_marginStart="-40dp"
-          android:layout_marginTop="-98dp" />
-
-
-     <FrameLayout
+     <LinearLayout
           android:id="@+id/symbol_input_page"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:background="?attr/colorSurface"
           android:layout_gravity="bottom"
+          android:orientation="vertical"
+          android:elevation="4dp"
           android:visibility="gone">
+
+          <com.itsaky.androidide.ui.EdgeSnapBubbleView
+               android:id="@+id/page_switch_gesture_bubble"
+               android:layout_width="match_parent"
+               android:layout_height="24dp"
+               android:background="@android:color/transparent" />
+
+          <RelativeLayout
+               android:layout_width="match_parent"
+               android:layout_height="wrap_content">
+
+               <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:cardCornerRadius="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    app:strokeWidth="0dp"
+                    app:cardElevation="0dp"
+                    android:scaleX="0.9"
+                    android:scaleY="0.9"
+                    app:cardBackgroundColor="?attr/colorSurface" />
+
+               <include
+                    android:id="@+id/border"
+                    layout="@layout/layout_divider_horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_marginBottom="2dp"
+                    android:layout_height="0.5dp"
+                    android:layout_alignParentTop="true" />
+
+               <ViewFlipper
+                    android:id="@+id/header_container"
+                    android:layout_width="match_parent"
+                    android:layout_below="@id/border"
+                    android:layout_height="@dimen/editor_sheet_collapsed_height"
+                    android:background="?attr/colorSurface">
+
+                    <include
+                         layout="@layout/layout_editor_build_status"
+                         android:id="@+id/build_status" />
+
+                    <include
+                         layout="@layout/layout_editor_bottom_action"
+                         android:id="@+id/bottom_action" />
+
+               </ViewFlipper>
+
+               <TextView
+                    android:id="@+id/tv_cursor_position"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true"
+                    android:layout_marginEnd="16dp"
+                    android:text="1:1"
+                    android:fontFamily="monospace"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="?attr/colorOutline" />
+          </RelativeLayout>
+
+          <View
+               android:layout_width="match_parent"
+               android:layout_height="0.5dp"
+               android:background="?attr/colorOutlineVariant" />
 
           <android.zero.studio.widget.editor.symbolinput.AdvancedSymbolInputView
                android:id="@+id/external_symbol_input_view"
                android:layout_width="match_parent"
                android:layout_height="wrap_content"
                android:background="?attr/colorSurface" />
-     </FrameLayout>
+     </LinearLayout>
 
      <include
           android:id="@+id/diagnosticInfo"

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -132,6 +132,7 @@
                android:background="@android:color/transparent" />
 
           <RelativeLayout
+               android:id="@+id/header_overlay_container"
                android:layout_width="match_parent"
                android:layout_height="wrap_content">
 

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -121,6 +121,8 @@
           android:layout_height="wrap_content"
           android:background="?attr/colorSurface"
           android:layout_gravity="bottom"
+          app:layout_anchor="@id/bottom_sheet"
+          app:layout_anchorGravity="top"
           android:orientation="vertical"
           android:elevation="4dp"
           android:visibility="gone">

--- a/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
@@ -24,12 +24,54 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="?attr/colorSurface">
+
+  <com.google.android.material.card.MaterialCardView
+    android:id="@+id/cardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="24dp"
+    android:layout_marginLeft="16dp"
+    android:layout_marginRight="16dp"
+    app:strokeWidth="0dp"
+    app:cardElevation="0dp"
+    android:scaleX="0.9"
+    android:scaleY="0.9"
+    app:cardBackgroundColor="?attr/colorSurface"
+    android:visibility="gone" />
+
+  <include
+    android:id="@+id/border"
+    layout="@layout/layout_divider_horizontal"
+    android:layout_width="match_parent"
+    android:layout_marginBottom="2dp"
+    android:layout_height="0.5dp"
+    android:layout_alignParentTop="true"
+    android:visibility="gone" />
+
+  <ViewFlipper
+    android:id="@+id/header_container"
+    android:layout_width="match_parent"
+    android:layout_below="@id/border"
+    android:layout_height="@dimen/editor_sheet_collapsed_height"
+    android:background="?attr/colorSurface"
+    android:visibility="gone">
+
+    <include
+      layout="@layout/layout_editor_build_status"
+      android:id="@+id/build_status" />
+
+    <include
+      layout="@layout/layout_editor_bottom_action"
+      android:id="@+id/bottom_action" />
+
+  </ViewFlipper>
   
   <com.google.android.material.tabs.TabLayout
     android:id="@+id/tabs"
     style="@style/AppTheme.TabLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:layout_below="@id/header_container" />
 
   <androidx.legacy.widget.Space
     android:id="@+id/space_bottom"

--- a/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
@@ -25,51 +25,11 @@
   android:layout_height="match_parent"
   android:background="?attr/colorSurface">
   
-  <com.google.android.material.card.MaterialCardView
-    android:id="@+id/cardView"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:cardCornerRadius="24dp"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    app:strokeWidth="0dp"
-    app:cardElevation="0dp"
-    android:scaleX="0.9"
-    android:scaleY="0.9"
-    app:cardBackgroundColor="?attr/colorSurface">
-  </com.google.android.material.card.MaterialCardView>
-  <include
-    android:id="@+id/border"
-    layout="@layout/layout_divider_horizontal"
-    android:layout_width="match_parent"
-    android:layout_marginBottom="2dp"
-    android:layout_height="0.5dp"
-    android:layout_alignParentTop="true" />
-
-  <ViewFlipper
-    android:id="@+id/header_container"
-    android:layout_width="match_parent"
-    android:layout_below="@id/border"
-    android:layout_height="@dimen/editor_sheet_collapsed_height"
-    android:background="?attr/colorSurface">
-
-    <include
-      layout="@layout/layout_editor_build_status"
-      android:id="@+id/build_status"/>
-
-    <include
-      layout="@layout/layout_editor_bottom_action"
-      android:id="@+id/bottom_action"/>
-
-  </ViewFlipper>
-
-
   <com.google.android.material.tabs.TabLayout
     android:id="@+id/tabs"
     style="@style/AppTheme.TabLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_below="@id/header_container" />
+    android:layout_height="wrap_content" />
 
   <androidx.legacy.widget.Space
     android:id="@+id/space_bottom"

--- a/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_sheet.xml
@@ -25,53 +25,11 @@
   android:layout_height="match_parent"
   android:background="?attr/colorSurface">
 
-  <com.google.android.material.card.MaterialCardView
-    android:id="@+id/cardView"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:cardCornerRadius="24dp"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    app:strokeWidth="0dp"
-    app:cardElevation="0dp"
-    android:scaleX="0.9"
-    android:scaleY="0.9"
-    app:cardBackgroundColor="?attr/colorSurface"
-    android:visibility="gone" />
-
-  <include
-    android:id="@+id/border"
-    layout="@layout/layout_divider_horizontal"
-    android:layout_width="match_parent"
-    android:layout_marginBottom="2dp"
-    android:layout_height="0.5dp"
-    android:layout_alignParentTop="true"
-    android:visibility="gone" />
-
-  <ViewFlipper
-    android:id="@+id/header_container"
-    android:layout_width="match_parent"
-    android:layout_below="@id/border"
-    android:layout_height="@dimen/editor_sheet_collapsed_height"
-    android:background="?attr/colorSurface"
-    android:visibility="gone">
-
-    <include
-      layout="@layout/layout_editor_build_status"
-      android:id="@+id/build_status" />
-
-    <include
-      layout="@layout/layout_editor_bottom_action"
-      android:id="@+id/bottom_action" />
-
-  </ViewFlipper>
-  
   <com.google.android.material.tabs.TabLayout
     android:id="@+id/tabs"
     style="@style/AppTheme.TabLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_below="@id/header_container" />
+    android:layout_height="wrap_content" />
 
   <androidx.legacy.widget.Space
     android:id="@+id/space_bottom"

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -13,7 +13,7 @@ import android.view.View
 import kotlin.math.abs
 
 /**
- * SlideBackView 一比一 Kotlin 版（按项目需求做最小改动）。
+ * 小米全面屏手势返回上一级手势同款
  */
 class EdgeSnapBubbleView : View {
 

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -6,30 +6,33 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.util.AttributeSet
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import kotlin.math.abs
 
 /**
- * 顶部横向 Snap Bubble（用于切换/收起，不再承担系统返回行为）。
+ * 横向顶部吸附的 Snap Bubble。
  */
 class EdgeSnapBubbleView : View {
 
-  /** backView 高度 */
   private var backViewHeight: Float = 0f
-
-  /** 边缘触发距离 */
   private var backEdgeWidth: Float = 0f
-
-  /** 最大返回触发距离 */
   private var backMaxWidth: Float = 0f
 
-  private var downY: Float = 0f
+  private var thresholdLeft: Float = 0f
+  private var thresholdRight: Float = 0f
+
+  private var currentY: Float = 0f
   private var downX: Float = 0f
-  private var deltaY: Float = 0f
+  private var isEdge: Boolean = false
   private var deltaX: Float = 0f
-  private var tracking = false
-  private var triggerDistance: Float = 0f
-  private var dragStartTranslationX: Float = 0f
+  private var mWidth: Int = 0
+  private var isOnlyLeftBack: Boolean = false
+  var left: Boolean = false
+  var right: Boolean = false
+  var forwardX: Float = 0f
+  var bufferX: Float = 0f
 
   private var backPaint: Paint? = null
   private var arrowPaint: Paint? = null
@@ -37,15 +40,14 @@ class EdgeSnapBubbleView : View {
   private var arrowPath: Path? = null
 
   private var onBackListener: OnBackListener? = null
-  private var onDragListener: OnDragListener? = null
   private var showArrowUp: Boolean = true
 
   fun setOnBackListener(onBackListener: OnBackListener?) {
     this.onBackListener = onBackListener
   }
 
-  fun setOnDragListener(onDragListener: OnDragListener?) {
-    this.onDragListener = onDragListener
+  fun setOnlyLeftBack(onlyLeftBack: Boolean) {
+    isOnlyLeftBack = onlyLeftBack
   }
 
   constructor(context: Context) : this(context, null)
@@ -53,12 +55,10 @@ class EdgeSnapBubbleView : View {
   constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
 
   constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-    // 原始源码通过 styleable/dimen 读取。当前模块未定义对应 attrs，改为等价默认值。
     val density = resources.displayMetrics.density
     backViewHeight = 24f * density
     backEdgeWidth = 12f * density
-    backMaxWidth = 20f * density
-    triggerDistance = 14f * density
+    backMaxWidth = 56f * density
     init()
   }
 
@@ -79,99 +79,128 @@ class EdgeSnapBubbleView : View {
   }
 
   override fun onTouchEvent(ev: MotionEvent): Boolean {
+    val currentX = ev.x
+    currentY = ev.y
     when (ev.action) {
       MotionEvent.ACTION_DOWN -> {
-        downY = ev.y
         downX = ev.x
-        deltaY = 0f
-        deltaX = 0f
-        tracking = true
-        dragStartTranslationX = translationX
-        parent.requestDisallowInterceptTouchEvent(true)
-        invalidate()
+        forwardX = downX
+        isEdge = true
+        left = true
+        right = false
       }
 
       MotionEvent.ACTION_MOVE -> {
-        if (!tracking) return false
-        deltaY = (ev.y - downY).coerceIn(-backMaxWidth, backMaxWidth)
-        deltaX = ev.x - downX
-        val parentView = parent as? View
-        if (parentView != null) {
-          val minX = -left.toFloat()
-          val maxX = (parentView.width - right).toFloat()
-          translationX = (dragStartTranslationX + deltaX).coerceIn(minX, maxX)
+        deltaX = currentX - downX
+        val diff = forwardX - currentX
+        if (diff > 0) {
+          if (currentX < thresholdLeft && left) {
+            deltaX = backMaxWidth
+            deltaX -= (thresholdLeft - currentX) / 2
+            bufferX = deltaX
+            if (deltaX < 0) {
+              deltaX = 0f
+              bufferX = 0f
+            }
+          } else if (currentX > thresholdRight && right) {
+            bufferX -= diff
+            deltaX = bufferX
+          }
+        } else {
+          if (currentX < thresholdLeft && left) {
+            bufferX += abs(diff)
+            deltaX = bufferX
+          } else if (currentX > thresholdRight && right) {
+            deltaX = -backMaxWidth
+            deltaX += (currentX - thresholdRight) / 2
+            bufferX = deltaX
+            if (deltaX < -backMaxWidth) {
+              deltaX = -backMaxWidth
+              bufferX = -backMaxWidth
+            }
+          }
         }
-        onDragListener?.onDrag(deltaY / backMaxWidth)
-        invalidate()
+        forwardX = currentX
+        if (isEdge) invalidate()
       }
 
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-        if (tracking) {
-          val draggedEnough = kotlin.math.abs(deltaY) >= triggerDistance
-          if (draggedEnough || ev.action == MotionEvent.ACTION_UP) {
+        if (isEdge) {
+          if (deltaX >= backMaxWidth && left) {
+            back()
+          } else if (abs(deltaX) >= backMaxWidth && right) {
+            if (!isOnlyLeftBack) {
+              back()
+            }
+          }
+          if (abs(deltaX) < backMaxWidth * 0.2f) {
             performClick()
           }
-          onDragListener?.onRelease(deltaY / backMaxWidth)
-          deltaY = 0f
-          tracking = false
-          parent.requestDisallowInterceptTouchEvent(false)
+          deltaX = 0f
           invalidate()
         }
+        left = false
+        right = false
+        isEdge = false
+        bufferX = 0f
       }
     }
-    return true
+    return isEdge
+  }
+
+  private fun back() {
+    // 仅回调业务逻辑，不再触发系统返回上一级。
+    onBackListener?.onBack()
+    performClick()
   }
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    mWidth = MeasureSpec.getSize(widthMeasureSpec) + 1
+    thresholdLeft = (mWidth / 3).toFloat()
+    thresholdRight = thresholdLeft * 2
   }
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
+    if (deltaX > backMaxWidth && left) {
+      deltaX = backMaxWidth
+    } else if (deltaX < -backMaxWidth && right) {
+      deltaX = -backMaxWidth
+    }
+    Log.e("onDraw", "$deltaX")
+
     backPath!!.reset()
     arrowPath!!.reset()
 
-    val w = width.toFloat()
-    val h = height.toFloat().coerceAtLeast(1f)
-    val pull = kotlin.math.abs(deltaY).coerceAtMost(backMaxWidth)
-    val bump = (backMaxWidth * 0.35f + pull * 0.95f).coerceAtMost(backMaxWidth)
+    val drawDelta = if (deltaX == 0f) backMaxWidth * 0.35f else abs(deltaX)
+    val widthF = width.toFloat()
+    val heightF = height.toFloat().coerceAtLeast(1f)
 
+    val humpHeight = (drawDelta / backMaxWidth * (heightF * 0.7f)).coerceAtLeast(heightF * 0.35f)
     backPath!!.moveTo(0f, 0f)
-    backPath!!.lineTo(w, 0f)
-    backPath!!.lineTo(w, h)
-    backPath!!.cubicTo(
-        w * 0.86f,
-        h - bump * 0.25f,
-        w * 0.68f,
-        h - bump,
-        w * 0.5f,
-        h - bump
-    )
-    backPath!!.cubicTo(
-        w * 0.32f,
-        h - bump,
-        w * 0.14f,
-        h - bump * 0.25f,
-        0f,
-        h
-    )
+    backPath!!.lineTo(widthF, 0f)
+    backPath!!.lineTo(widthF, heightF)
+    backPath!!.quadTo(widthF * 0.75f, heightF - humpHeight, widthF * 0.5f, heightF - humpHeight)
+    backPath!!.quadTo(widthF * 0.25f, heightF - humpHeight, 0f, heightF)
     backPath!!.close()
     canvas.drawPath(backPath!!, backPaint!!)
 
-    val cx = w / 2f
-    val cy = h / 2f + bump * 0.15f
-    val arrow = (h * 0.22f).coerceAtLeast(4f)
+    val centerX = widthF / 2f
+    val centerY = heightF / 2f
+    val arrowHalf = (heightF * 0.22f).coerceAtLeast(4f)
     if (showArrowUp) {
-      arrowPath!!.moveTo(cx - arrow, cy + arrow * 0.25f)
-      arrowPath!!.lineTo(cx, cy - arrow)
-      arrowPath!!.lineTo(cx + arrow, cy + arrow * 0.25f)
+      arrowPath!!.moveTo(centerX - arrowHalf, centerY + arrowHalf * 0.35f)
+      arrowPath!!.lineTo(centerX, centerY - arrowHalf)
+      arrowPath!!.lineTo(centerX + arrowHalf, centerY + arrowHalf * 0.35f)
     } else {
-      arrowPath!!.moveTo(cx - arrow, cy - arrow * 0.25f)
-      arrowPath!!.lineTo(cx, cy + arrow)
-      arrowPath!!.lineTo(cx + arrow, cy - arrow * 0.25f)
+      arrowPath!!.moveTo(centerX - arrowHalf, centerY - arrowHalf * 0.35f)
+      arrowPath!!.lineTo(centerX, centerY + arrowHalf)
+      arrowPath!!.lineTo(centerX + arrowHalf, centerY - arrowHalf * 0.35f)
     }
     canvas.drawPath(arrowPath!!, arrowPaint!!)
-    alpha = 1f
+
+    alpha = (drawDelta / backMaxWidth).coerceIn(0.35f, 1f)
   }
 
   fun setBackViewHeight(backViewHeight: Float) {
@@ -197,12 +226,9 @@ class EdgeSnapBubbleView : View {
   }
 
   fun restorePosition() {
-    val parentView = parent as? View
+    // 固定在 header_container 顶部边缘（父容器顶部）
     x = 0f
     y = 0f
-    if (parentView != null) {
-      translationX = translationX.coerceIn(-left.toFloat(), (parentView.width - right).toFloat())
-    }
   }
 
   override fun performClick(): Boolean {
@@ -211,7 +237,6 @@ class EdgeSnapBubbleView : View {
   }
 
   fun setArrowExpanded(expanded: Boolean) {
-    // expanded=true 表示容器显示中，箭头朝上（点击后收起）
     showArrowUp = expanded
     invalidate()
   }
@@ -220,10 +245,5 @@ class EdgeSnapBubbleView : View {
 
   interface OnBackListener {
     fun onBack()
-  }
-
-  interface OnDragListener {
-    fun onDrag(fraction: Float)
-    fun onRelease(fraction: Float)
   }
 }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -24,9 +24,12 @@ class EdgeSnapBubbleView : View {
   private var backMaxWidth: Float = 0f
 
   private var downY: Float = 0f
+  private var downX: Float = 0f
   private var deltaY: Float = 0f
+  private var deltaX: Float = 0f
   private var tracking = false
   private var triggerDistance: Float = 0f
+  private var dragStartTranslationX: Float = 0f
 
   private var backPaint: Paint? = null
   private var arrowPaint: Paint? = null
@@ -79,8 +82,11 @@ class EdgeSnapBubbleView : View {
     when (ev.action) {
       MotionEvent.ACTION_DOWN -> {
         downY = ev.y
+        downX = ev.x
         deltaY = 0f
+        deltaX = 0f
         tracking = true
+        dragStartTranslationX = translationX
         parent.requestDisallowInterceptTouchEvent(true)
         invalidate()
       }
@@ -88,6 +94,13 @@ class EdgeSnapBubbleView : View {
       MotionEvent.ACTION_MOVE -> {
         if (!tracking) return false
         deltaY = (ev.y - downY).coerceIn(-backMaxWidth, backMaxWidth)
+        deltaX = ev.x - downX
+        val parentView = parent as? View
+        if (parentView != null) {
+          val minX = -left.toFloat()
+          val maxX = (parentView.width - right).toFloat()
+          translationX = (dragStartTranslationX + deltaX).coerceIn(minX, maxX)
+        }
         onDragListener?.onDrag(deltaY / backMaxWidth)
         invalidate()
       }
@@ -120,13 +133,28 @@ class EdgeSnapBubbleView : View {
 
     val w = width.toFloat()
     val h = height.toFloat().coerceAtLeast(1f)
-    val bump = (backMaxWidth * 0.5f + kotlin.math.abs(deltaY) * 0.6f).coerceAtMost(backMaxWidth)
+    val pull = kotlin.math.abs(deltaY).coerceAtMost(backMaxWidth)
+    val bump = (backMaxWidth * 0.35f + pull * 0.95f).coerceAtMost(backMaxWidth)
 
     backPath!!.moveTo(0f, 0f)
     backPath!!.lineTo(w, 0f)
     backPath!!.lineTo(w, h)
-    backPath!!.quadTo(w * 0.75f, h - bump, w * 0.5f, h - bump)
-    backPath!!.quadTo(w * 0.25f, h - bump, 0f, h)
+    backPath!!.cubicTo(
+        w * 0.86f,
+        h - bump * 0.25f,
+        w * 0.68f,
+        h - bump,
+        w * 0.5f,
+        h - bump
+    )
+    backPath!!.cubicTo(
+        w * 0.32f,
+        h - bump,
+        w * 0.14f,
+        h - bump * 0.25f,
+        0f,
+        h
+    )
     backPath!!.close()
     canvas.drawPath(backPath!!, backPaint!!)
 
@@ -169,8 +197,12 @@ class EdgeSnapBubbleView : View {
   }
 
   fun restorePosition() {
+    val parentView = parent as? View
     x = 0f
     y = 0f
+    if (parentView != null) {
+      translationX = translationX.coerceIn(-left.toFloat(), (parentView.width - right).toFloat())
+    }
   }
 
   override fun performClick(): Boolean {

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -34,10 +34,15 @@ class EdgeSnapBubbleView : View {
   private var arrowPath: Path? = null
 
   private var onBackListener: OnBackListener? = null
+  private var onDragListener: OnDragListener? = null
   private var showArrowUp: Boolean = true
 
   fun setOnBackListener(onBackListener: OnBackListener?) {
     this.onBackListener = onBackListener
+  }
+
+  fun setOnDragListener(onDragListener: OnDragListener?) {
+    this.onDragListener = onDragListener
   }
 
   constructor(context: Context) : this(context, null)
@@ -83,6 +88,7 @@ class EdgeSnapBubbleView : View {
       MotionEvent.ACTION_MOVE -> {
         if (!tracking) return false
         deltaY = (ev.y - downY).coerceIn(-backMaxWidth, backMaxWidth)
+        onDragListener?.onDrag(deltaY / backMaxWidth)
         invalidate()
       }
 
@@ -92,6 +98,7 @@ class EdgeSnapBubbleView : View {
           if (draggedEnough || ev.action == MotionEvent.ACTION_UP) {
             performClick()
           }
+          onDragListener?.onRelease(deltaY / backMaxWidth)
           deltaY = 0f
           tracking = false
           parent.requestDisallowInterceptTouchEvent(false)
@@ -181,5 +188,10 @@ class EdgeSnapBubbleView : View {
 
   interface OnBackListener {
     fun onBack()
+  }
+
+  interface OnDragListener {
+    fun onDrag(fraction: Float)
+    fun onRelease(fraction: Float)
   }
 }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -40,10 +40,15 @@ class EdgeSnapBubbleView : View {
   private var arrowPath: Path? = null
 
   private var onBackListener: OnBackListener? = null
+  private var onDragListener: OnDragListener? = null
   private var showArrowUp: Boolean = true
 
   fun setOnBackListener(onBackListener: OnBackListener?) {
     this.onBackListener = onBackListener
+  }
+
+  fun setOnDragListener(onDragListener: OnDragListener?) {
+    this.onDragListener = onDragListener
   }
 
   fun setOnlyLeftBack(onlyLeftBack: Boolean) {
@@ -121,6 +126,7 @@ class EdgeSnapBubbleView : View {
           }
         }
         forwardX = currentX
+        onDragListener?.onDrag((deltaX / backMaxWidth).coerceIn(-1f, 1f))
         if (isEdge) invalidate()
       }
 
@@ -136,6 +142,7 @@ class EdgeSnapBubbleView : View {
           if (abs(deltaX) < backMaxWidth * 0.2f) {
             performClick()
           }
+          onDragListener?.onRelease((deltaX / backMaxWidth).coerceIn(-1f, 1f))
           deltaX = 0f
           invalidate()
         }
@@ -245,5 +252,10 @@ class EdgeSnapBubbleView : View {
 
   interface OnBackListener {
     fun onBack()
+  }
+
+  interface OnDragListener {
+    fun onDrag(fraction: Float)
+    fun onRelease(fraction: Float)
   }
 }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -1,5 +1,6 @@
 package com.itsaky.androidide.ui
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
@@ -12,12 +13,17 @@ import android.view.View
 import kotlin.math.abs
 
 /**
- * 横向顶部吸附的 Snap Bubble。
+ * SlideBackView 一比一 Kotlin 版（按项目需求做最小改动）。
  */
 class EdgeSnapBubbleView : View {
 
+  /** backView 高度 */
   private var backViewHeight: Float = 0f
+
+  /** 边缘触发距离 */
   private var backEdgeWidth: Float = 0f
+
+  /** 最大返回触发距离 */
   private var backMaxWidth: Float = 0f
 
   private var thresholdLeft: Float = 0f
@@ -40,15 +46,11 @@ class EdgeSnapBubbleView : View {
   private var arrowPath: Path? = null
 
   private var onBackListener: OnBackListener? = null
-  private var onDragListener: OnDragListener? = null
+  private var side: Side = Side.LEFT
   private var showArrowUp: Boolean = true
 
   fun setOnBackListener(onBackListener: OnBackListener?) {
     this.onBackListener = onBackListener
-  }
-
-  fun setOnDragListener(onDragListener: OnDragListener?) {
-    this.onDragListener = onDragListener
   }
 
   fun setOnlyLeftBack(onlyLeftBack: Boolean) {
@@ -60,8 +62,9 @@ class EdgeSnapBubbleView : View {
   constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
 
   constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+    // 原始源码通过 styleable/dimen 读取。当前模块未定义对应 attrs，改为等价默认值。
     val density = resources.displayMetrics.density
-    backViewHeight = 24f * density
+    backViewHeight = 220f * density
     backEdgeWidth = 12f * density
     backMaxWidth = 56f * density
     init()
@@ -90,9 +93,23 @@ class EdgeSnapBubbleView : View {
       MotionEvent.ACTION_DOWN -> {
         downX = ev.x
         forwardX = downX
-        isEdge = true
-        left = true
-        right = false
+        // 原始逻辑保留：边缘触发。
+        if (downX <= backEdgeWidth) {
+          isEdge = true
+          left = true
+          right = false
+        } else if (downX >= width - backEdgeWidth) {
+          isEdge = true
+          right = true
+          left = false
+        }
+        // 项目需求：固定吸附在 page_switch_container 顶部边缘可直接显示与点击。
+        // 因此若未命中边缘，也允许进入左侧形态绘制和点击，不隐藏。
+        if (!isEdge) {
+          isEdge = true
+          left = true
+          right = false
+        }
       }
 
       MotionEvent.ACTION_MOVE -> {
@@ -126,8 +143,9 @@ class EdgeSnapBubbleView : View {
           }
         }
         forwardX = currentX
-        onDragListener?.onDrag((deltaX / backMaxWidth).coerceIn(-1f, 1f))
-        if (isEdge) invalidate()
+        if (isEdge) {
+          invalidate()
+        }
       }
 
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
@@ -139,10 +157,10 @@ class EdgeSnapBubbleView : View {
               back()
             }
           }
+          // 轻触也触发点击切换。
           if (abs(deltaX) < backMaxWidth * 0.2f) {
             performClick()
           }
-          onDragListener?.onRelease((deltaX / backMaxWidth).coerceIn(-1f, 1f))
           deltaX = 0f
           invalidate()
         }
@@ -156,9 +174,13 @@ class EdgeSnapBubbleView : View {
   }
 
   private fun back() {
-    // 仅回调业务逻辑，不再触发系统返回上一级。
-    onBackListener?.onBack()
-    performClick()
+    if (onBackListener != null) {
+      onBackListener!!.onBack()
+    } else {
+      @Suppress("DEPRECATION")
+      (context as? Activity)?.onBackPressed()
+      performClick()
+    }
   }
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -175,38 +197,54 @@ class EdgeSnapBubbleView : View {
     } else if (deltaX < -backMaxWidth && right) {
       deltaX = -backMaxWidth
     }
-    Log.e("onDraw", "$deltaX")
-
+    Log.e("onDraw", "" + deltaX)
+    val deltaY = currentY - backViewHeight / 2
     backPath!!.reset()
     arrowPath!!.reset()
 
+    // 保留默认可见山峰（无拖动时）
     val drawDelta = if (deltaX == 0f) backMaxWidth * 0.35f else abs(deltaX)
-    val widthF = width.toFloat()
-    val heightF = height.toFloat().coerceAtLeast(1f)
 
-    val humpHeight = (drawDelta / backMaxWidth * (heightF * 0.7f)).coerceAtLeast(heightF * 0.35f)
-    backPath!!.moveTo(0f, 0f)
-    backPath!!.lineTo(widthF, 0f)
-    backPath!!.lineTo(widthF, heightF)
-    backPath!!.quadTo(widthF * 0.75f, heightF - humpHeight, widthF * 0.5f, heightF - humpHeight)
-    backPath!!.quadTo(widthF * 0.25f, heightF - humpHeight, 0f, heightF)
-    backPath!!.close()
-    canvas.drawPath(backPath!!, backPaint!!)
+    if ((deltaX > 0 && left) || (deltaX == 0f && !right)) {
+      backPath!!.moveTo(0f, deltaY)
+      backPath!!.quadTo(0f, backViewHeight / 4 + deltaY, drawDelta / 3, backViewHeight * 3 / 8 + deltaY)
+      backPath!!.quadTo(drawDelta * 5 / 8, backViewHeight / 2 + deltaY, drawDelta / 3, backViewHeight * 5 / 8 + deltaY)
+      backPath!!.quadTo(0f, backViewHeight * 6 / 8 + deltaY, 0f, backViewHeight + deltaY)
+      canvas.drawPath(backPath!!, backPaint!!)
 
-    val centerX = widthF / 2f
-    val centerY = heightF / 2f
-    val arrowHalf = (heightF * 0.22f).coerceAtLeast(4f)
-    if (showArrowUp) {
-      arrowPath!!.moveTo(centerX - arrowHalf, centerY + arrowHalf * 0.35f)
-      arrowPath!!.lineTo(centerX, centerY - arrowHalf)
-      arrowPath!!.lineTo(centerX + arrowHalf, centerY + arrowHalf * 0.35f)
-    } else {
-      arrowPath!!.moveTo(centerX - arrowHalf, centerY - arrowHalf * 0.35f)
-      arrowPath!!.lineTo(centerX, centerY + arrowHalf)
-      arrowPath!!.lineTo(centerX + arrowHalf, centerY - arrowHalf * 0.35f)
+      val midX = drawDelta / 6f
+      val topY = backViewHeight * 15f / 32f + deltaY
+      val centerY = backViewHeight * 16f / 32f + deltaY
+      val bottomY = backViewHeight * 17f / 32f + deltaY
+      val tipOffset = 15f * (drawDelta / (mWidth / 6f))
+      if (showArrowUp) {
+        arrowPath!!.moveTo(midX, centerY)
+        arrowPath!!.lineTo(midX + tipOffset, topY)
+        arrowPath!!.moveTo(midX, centerY)
+        arrowPath!!.lineTo(midX + tipOffset, bottomY)
+      } else {
+        arrowPath!!.moveTo(midX + tipOffset, centerY)
+        arrowPath!!.lineTo(midX, topY)
+        arrowPath!!.moveTo(midX + tipOffset, centerY)
+        arrowPath!!.lineTo(midX, bottomY)
+      }
+      canvas.drawPath(arrowPath!!, arrowPaint!!)
+    } else if (deltaX < 0 && right) {
+      if (!isOnlyLeftBack) {
+        deltaX = abs(deltaX)
+        backPath!!.moveTo(mWidth.toFloat(), deltaY)
+        backPath!!.quadTo(mWidth.toFloat(), backViewHeight / 4 + deltaY, mWidth - deltaX / 3, backViewHeight * 3 / 8 + deltaY)
+        backPath!!.quadTo(mWidth - deltaX * 5 / 8, backViewHeight / 2 + deltaY, mWidth - deltaX / 3, backViewHeight * 5 / 8 + deltaY)
+        backPath!!.quadTo(mWidth.toFloat(), backViewHeight * 6 / 8 + deltaY, mWidth.toFloat(), backViewHeight + deltaY)
+        canvas.drawPath(backPath!!, backPaint!!)
+
+        arrowPath!!.moveTo(mWidth - deltaX / 6 - 15 * (deltaX / (mWidth / 6f)), backViewHeight * 15 / 32 + deltaY)
+        arrowPath!!.lineTo(mWidth - deltaX / 6, backViewHeight * 16.1f / 32 + deltaY)
+        arrowPath!!.moveTo(mWidth - deltaX / 6, backViewHeight * 15.9f / 32 + deltaY)
+        arrowPath!!.lineTo(mWidth - deltaX / 6 - 15 * (deltaX / (mWidth / 6f)), backViewHeight * 17 / 32 + deltaY)
+        canvas.drawPath(arrowPath!!, arrowPaint!!)
+      }
     }
-    canvas.drawPath(arrowPath!!, arrowPaint!!)
-
     alpha = (drawDelta / backMaxWidth).coerceIn(0.35f, 1f)
   }
 
@@ -229,13 +267,14 @@ class EdgeSnapBubbleView : View {
   fun getBackViewHeight(): Float = backViewHeight
 
   fun attachToSide(newSide: Side) {
-    restorePosition()
+    side = newSide
+    val parentView = parent as? View ?: return
+    x = if (side == Side.LEFT) 0f else (parentView.width - width).toFloat()
   }
 
   fun restorePosition() {
-    // 固定在 header_container 顶部边缘（父容器顶部）
-    x = 0f
-    y = 0f
+    val parentView = parent as? View ?: return
+    x = if (side == Side.LEFT) 0f else (parentView.width - width).toFloat()
   }
 
   override fun performClick(): Boolean {
@@ -244,6 +283,7 @@ class EdgeSnapBubbleView : View {
   }
 
   fun setArrowExpanded(expanded: Boolean) {
+    // expanded=true 表示容器显示中，箭头朝上（点击后收起）
     showArrowUp = expanded
     invalidate()
   }
@@ -252,10 +292,5 @@ class EdgeSnapBubbleView : View {
 
   interface OnBackListener {
     fun onBack()
-  }
-
-  interface OnDragListener {
-    fun onDrag(fraction: Float)
-    fun onRelease(fraction: Float)
   }
 }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -1,19 +1,16 @@
 package com.itsaky.androidide.ui
 
-import android.app.Activity
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
-import kotlin.math.abs
 
 /**
- * SlideBackView 一比一 Kotlin 版（按项目需求做最小改动）。
+ * 顶部横向 Snap Bubble（用于切换/收起，不再承担系统返回行为）。
  */
 class EdgeSnapBubbleView : View {
 
@@ -26,19 +23,10 @@ class EdgeSnapBubbleView : View {
   /** 最大返回触发距离 */
   private var backMaxWidth: Float = 0f
 
-  private var thresholdLeft: Float = 0f
-  private var thresholdRight: Float = 0f
-
-  private var currentY: Float = 0f
-  private var downX: Float = 0f
-  private var isEdge: Boolean = false
-  private var deltaX: Float = 0f
-  private var mWidth: Int = 0
-  private var isOnlyLeftBack: Boolean = false
-  var left: Boolean = false
-  var right: Boolean = false
-  var forwardX: Float = 0f
-  var bufferX: Float = 0f
+  private var downY: Float = 0f
+  private var deltaY: Float = 0f
+  private var tracking = false
+  private var triggerDistance: Float = 0f
 
   private var backPaint: Paint? = null
   private var arrowPaint: Paint? = null
@@ -46,15 +34,10 @@ class EdgeSnapBubbleView : View {
   private var arrowPath: Path? = null
 
   private var onBackListener: OnBackListener? = null
-  private var side: Side = Side.LEFT
   private var showArrowUp: Boolean = true
 
   fun setOnBackListener(onBackListener: OnBackListener?) {
     this.onBackListener = onBackListener
-  }
-
-  fun setOnlyLeftBack(onlyLeftBack: Boolean) {
-    isOnlyLeftBack = onlyLeftBack
   }
 
   constructor(context: Context) : this(context, null)
@@ -64,9 +47,10 @@ class EdgeSnapBubbleView : View {
   constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
     // 原始源码通过 styleable/dimen 读取。当前模块未定义对应 attrs，改为等价默认值。
     val density = resources.displayMetrics.density
-    backViewHeight = 220f * density
+    backViewHeight = 24f * density
     backEdgeWidth = 12f * density
-    backMaxWidth = 56f * density
+    backMaxWidth = 20f * density
+    triggerDistance = 14f * density
     init()
   }
 
@@ -87,165 +71,72 @@ class EdgeSnapBubbleView : View {
   }
 
   override fun onTouchEvent(ev: MotionEvent): Boolean {
-    val currentX = ev.x
-    currentY = ev.y
     when (ev.action) {
       MotionEvent.ACTION_DOWN -> {
-        downX = ev.x
-        forwardX = downX
-        // 原始逻辑保留：边缘触发。
-        if (downX <= backEdgeWidth) {
-          isEdge = true
-          left = true
-          right = false
-        } else if (downX >= width - backEdgeWidth) {
-          isEdge = true
-          right = true
-          left = false
-        }
-        // 项目需求：固定吸附在 page_switch_container 顶部边缘可直接显示与点击。
-        // 因此若未命中边缘，也允许进入左侧形态绘制和点击，不隐藏。
-        if (!isEdge) {
-          isEdge = true
-          left = true
-          right = false
-        }
+        downY = ev.y
+        deltaY = 0f
+        tracking = true
+        parent.requestDisallowInterceptTouchEvent(true)
+        invalidate()
       }
 
       MotionEvent.ACTION_MOVE -> {
-        deltaX = currentX - downX
-        val diff = forwardX - currentX
-        if (diff > 0) {
-          if (currentX < thresholdLeft && left) {
-            deltaX = backMaxWidth
-            deltaX -= (thresholdLeft - currentX) / 2
-            bufferX = deltaX
-            if (deltaX < 0) {
-              deltaX = 0f
-              bufferX = 0f
-            }
-          } else if (currentX > thresholdRight && right) {
-            bufferX -= diff
-            deltaX = bufferX
-          }
-        } else {
-          if (currentX < thresholdLeft && left) {
-            bufferX += abs(diff)
-            deltaX = bufferX
-          } else if (currentX > thresholdRight && right) {
-            deltaX = -backMaxWidth
-            deltaX += (currentX - thresholdRight) / 2
-            bufferX = deltaX
-            if (deltaX < -backMaxWidth) {
-              deltaX = -backMaxWidth
-              bufferX = -backMaxWidth
-            }
-          }
-        }
-        forwardX = currentX
-        if (isEdge) {
-          invalidate()
-        }
+        if (!tracking) return false
+        deltaY = (ev.y - downY).coerceIn(-backMaxWidth, backMaxWidth)
+        invalidate()
       }
 
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-        if (isEdge) {
-          if (deltaX >= backMaxWidth && left) {
-            back()
-          } else if (abs(deltaX) >= backMaxWidth && right) {
-            if (!isOnlyLeftBack) {
-              back()
-            }
-          }
-          // 轻触也触发点击切换。
-          if (abs(deltaX) < backMaxWidth * 0.2f) {
+        if (tracking) {
+          val draggedEnough = kotlin.math.abs(deltaY) >= triggerDistance
+          if (draggedEnough || ev.action == MotionEvent.ACTION_UP) {
             performClick()
           }
-          deltaX = 0f
+          deltaY = 0f
+          tracking = false
+          parent.requestDisallowInterceptTouchEvent(false)
           invalidate()
         }
-        left = false
-        right = false
-        isEdge = false
-        bufferX = 0f
       }
     }
-    return isEdge
-  }
-
-  private fun back() {
-    if (onBackListener != null) {
-      onBackListener!!.onBack()
-    } else {
-      @Suppress("DEPRECATION")
-      (context as? Activity)?.onBackPressed()
-      performClick()
-    }
+    return true
   }
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-    mWidth = MeasureSpec.getSize(widthMeasureSpec) + 1
-    thresholdLeft = (mWidth / 3).toFloat()
-    thresholdRight = thresholdLeft * 2
   }
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
-    if (deltaX > backMaxWidth && left) {
-      deltaX = backMaxWidth
-    } else if (deltaX < -backMaxWidth && right) {
-      deltaX = -backMaxWidth
-    }
-    Log.e("onDraw", "" + deltaX)
-    val deltaY = currentY - backViewHeight / 2
     backPath!!.reset()
     arrowPath!!.reset()
 
-    // 保留默认可见山峰（无拖动时）
-    val drawDelta = if (deltaX == 0f) backMaxWidth * 0.35f else abs(deltaX)
+    val w = width.toFloat()
+    val h = height.toFloat().coerceAtLeast(1f)
+    val bump = (backMaxWidth * 0.5f + kotlin.math.abs(deltaY) * 0.6f).coerceAtMost(backMaxWidth)
 
-    if ((deltaX > 0 && left) || (deltaX == 0f && !right)) {
-      backPath!!.moveTo(0f, deltaY)
-      backPath!!.quadTo(0f, backViewHeight / 4 + deltaY, drawDelta / 3, backViewHeight * 3 / 8 + deltaY)
-      backPath!!.quadTo(drawDelta * 5 / 8, backViewHeight / 2 + deltaY, drawDelta / 3, backViewHeight * 5 / 8 + deltaY)
-      backPath!!.quadTo(0f, backViewHeight * 6 / 8 + deltaY, 0f, backViewHeight + deltaY)
-      canvas.drawPath(backPath!!, backPaint!!)
+    backPath!!.moveTo(0f, 0f)
+    backPath!!.lineTo(w, 0f)
+    backPath!!.lineTo(w, h)
+    backPath!!.quadTo(w * 0.75f, h - bump, w * 0.5f, h - bump)
+    backPath!!.quadTo(w * 0.25f, h - bump, 0f, h)
+    backPath!!.close()
+    canvas.drawPath(backPath!!, backPaint!!)
 
-      val midX = drawDelta / 6f
-      val topY = backViewHeight * 15f / 32f + deltaY
-      val centerY = backViewHeight * 16f / 32f + deltaY
-      val bottomY = backViewHeight * 17f / 32f + deltaY
-      val tipOffset = 15f * (drawDelta / (mWidth / 6f))
-      if (showArrowUp) {
-        arrowPath!!.moveTo(midX, centerY)
-        arrowPath!!.lineTo(midX + tipOffset, topY)
-        arrowPath!!.moveTo(midX, centerY)
-        arrowPath!!.lineTo(midX + tipOffset, bottomY)
-      } else {
-        arrowPath!!.moveTo(midX + tipOffset, centerY)
-        arrowPath!!.lineTo(midX, topY)
-        arrowPath!!.moveTo(midX + tipOffset, centerY)
-        arrowPath!!.lineTo(midX, bottomY)
-      }
-      canvas.drawPath(arrowPath!!, arrowPaint!!)
-    } else if (deltaX < 0 && right) {
-      if (!isOnlyLeftBack) {
-        deltaX = abs(deltaX)
-        backPath!!.moveTo(mWidth.toFloat(), deltaY)
-        backPath!!.quadTo(mWidth.toFloat(), backViewHeight / 4 + deltaY, mWidth - deltaX / 3, backViewHeight * 3 / 8 + deltaY)
-        backPath!!.quadTo(mWidth - deltaX * 5 / 8, backViewHeight / 2 + deltaY, mWidth - deltaX / 3, backViewHeight * 5 / 8 + deltaY)
-        backPath!!.quadTo(mWidth.toFloat(), backViewHeight * 6 / 8 + deltaY, mWidth.toFloat(), backViewHeight + deltaY)
-        canvas.drawPath(backPath!!, backPaint!!)
-
-        arrowPath!!.moveTo(mWidth - deltaX / 6 - 15 * (deltaX / (mWidth / 6f)), backViewHeight * 15 / 32 + deltaY)
-        arrowPath!!.lineTo(mWidth - deltaX / 6, backViewHeight * 16.1f / 32 + deltaY)
-        arrowPath!!.moveTo(mWidth - deltaX / 6, backViewHeight * 15.9f / 32 + deltaY)
-        arrowPath!!.lineTo(mWidth - deltaX / 6 - 15 * (deltaX / (mWidth / 6f)), backViewHeight * 17 / 32 + deltaY)
-        canvas.drawPath(arrowPath!!, arrowPaint!!)
-      }
+    val cx = w / 2f
+    val cy = h / 2f + bump * 0.15f
+    val arrow = (h * 0.22f).coerceAtLeast(4f)
+    if (showArrowUp) {
+      arrowPath!!.moveTo(cx - arrow, cy + arrow * 0.25f)
+      arrowPath!!.lineTo(cx, cy - arrow)
+      arrowPath!!.lineTo(cx + arrow, cy + arrow * 0.25f)
+    } else {
+      arrowPath!!.moveTo(cx - arrow, cy - arrow * 0.25f)
+      arrowPath!!.lineTo(cx, cy + arrow)
+      arrowPath!!.lineTo(cx + arrow, cy - arrow * 0.25f)
     }
-    alpha = (drawDelta / backMaxWidth).coerceIn(0.35f, 1f)
+    canvas.drawPath(arrowPath!!, arrowPaint!!)
+    alpha = 1f
   }
 
   fun setBackViewHeight(backViewHeight: Float) {
@@ -267,14 +158,12 @@ class EdgeSnapBubbleView : View {
   fun getBackViewHeight(): Float = backViewHeight
 
   fun attachToSide(newSide: Side) {
-    side = newSide
-    val parentView = parent as? View ?: return
-    x = if (side == Side.LEFT) 0f else (parentView.width - width).toFloat()
+    restorePosition()
   }
 
   fun restorePosition() {
-    val parentView = parent as? View ?: return
-    x = if (side == Side.LEFT) 0f else (parentView.width - width).toFloat()
+    x = 0f
+    y = 0f
   }
 
   override fun performClick(): Boolean {


### PR DESCRIPTION
### Motivation
- Replace the legacy bottom page-switch UI with a unified, top-edge bound overlay to match the new design mock and simplify overlay behavior. 
- Eliminate the duplicated `page_switch_*` controls and their anchor complexity so `EdgeSnapBubbleView`, header and symbol input are arranged in a single, predictable stack.

### Description
- Removed the `page_switch_container`, `page_switch_build_tab`, and `page_switch_symbol_tab` layout elements from `content_editor.xml` and removed their anchor usage. 
- Migrated `cardView`/`border`/`header_container`/`build_status`/`bottom_action` and the right-side `tv_cursor_position` into a new `symbol_input_page` stack and moved `EdgeSnapBubbleView` to the top of that stack in `content_editor.xml`. 
- Removed the `android:layout_below="@id/header_container"` dependency from `layout_editor_bottom_sheet.xml` and simplified that layout to not rely on the removed header block. 
- Reworked `BaseEditorActivity` to remove page-switch state and helpers and to introduce `updateSymbolInputOverlayPosition()` (replacing page-switch positioning logic), updated IME sync and bubble click behavior, and migrated header visibility handling to reference the new `symbol_input_page` content bindings.

### Testing
- Attempted to compile Kotlin with `./gradlew :core:app:compileDebugKotlin -x lint`, but the build failed before compilation due to an environment/toolchain issue (`25.0.1`) unrelated to the code changes. 
- No automated unit or integration tests were executed because the compile step could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3189dc1a8832f88236e45d3705ab2)