### PR TITLE
Refactor page-switch bubble and external symbol page layout/gesture handling

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -924,6 +924,22 @@ abstract class BaseEditorActivity :
     )
   }
 
+
+  private fun updateSymbolInputPageAnchor(active: Boolean) {
+    if (_binding == null) return
+    content.symbolInputPage.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+      if (active) {
+        anchorId = View.NO_ID
+        anchorGravity = Gravity.NO_GRAVITY
+        gravity = Gravity.BOTTOM
+      } else {
+        anchorId = content.bottomSheet.id
+        anchorGravity = Gravity.TOP
+        gravity = Gravity.BOTTOM
+      }
+    }
+  }
+
   private fun setExternalSymbolPageActive(active: Boolean) {
     if (_binding == null) return
     isExternalSymbolPageActive = active
@@ -937,6 +953,7 @@ abstract class BaseEditorActivity :
     }
     content.bottomSheet.forceCollapse()
     content.bottomSheet.setBottomSheetDragEnabled(!active)
+    updateSymbolInputPageAnchor(active)
     content.symbolInputPage.visibility = if (active) View.VISIBLE else View.GONE
     content.bottomSheet.visibility = if (active) View.INVISIBLE else View.VISIBLE
     applyExternalSymbolImeInset()
@@ -1003,12 +1020,13 @@ abstract class BaseEditorActivity :
   private fun setupPageSwitchGestureBubble() {
     if (_binding == null) return
     val bubble = content.pageSwitchGestureBubble
-    bubble.attachToSide(EdgeSnapBubbleView.Side.LEFT)
-    bubble.setOnClickListener {
+    bubble.setPosition(EdgeSnapBubbleView.Position.TOP)
+    bubble.setOrientation(EdgeSnapBubbleView.Orientation.HORIZONTAL)
+    bubble.setOnBubbleClickListener {
       toggleHeaderOverlay()
     }
-    bubble.setOnDragListener(
-        object : EdgeSnapBubbleView.OnDragListener {
+    bubble.setOnBubbleGestureListener(
+        object : EdgeSnapBubbleView.OnBubbleGestureListener {
           override fun onDrag(fraction: Float) {
             applyHeaderOverlayDrag(fraction)
           }
@@ -1030,8 +1048,8 @@ abstract class BaseEditorActivity :
     if (_binding == null) return
     // 拖拽手势用于控制底部隐藏 tab 抽屉（bottom_sheet），不控制 header_overlay_container。
     // 这里只做 bubble 的轻微跟手反馈。
-    val feedback = (fraction * content.pageSwitchGestureBubble.height).coerceIn(-24f, 24f)
-    content.pageSwitchGestureBubble.translationY = feedback
+    // Bubble 需要始终贴合 header_container 顶部边缘，跟随 overlay 的位移。
+    content.pageSwitchGestureBubble.translationY = content.headerOverlayContainer.translationY
   }
 
   private fun completeHeaderOverlayDrag(fraction: Float) {
@@ -1043,7 +1061,7 @@ abstract class BaseEditorActivity :
         editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
       }
     }
-    content.pageSwitchGestureBubble.animate().translationY(0f).setDuration(120L).start()
+    content.pageSwitchGestureBubble.animate().translationY(content.headerOverlayContainer.translationY).setDuration(120L).start()
   }
 
   private fun animateHeaderOverlay(expand: Boolean) {
@@ -1065,7 +1083,7 @@ abstract class BaseEditorActivity :
         .start()
     content.pageSwitchGestureBubble
         .animate()
-        .translationY(targetY)
+         .translationY(targetY)
         .setDuration(220L)
         .start()
   }
@@ -1073,11 +1091,8 @@ abstract class BaseEditorActivity :
   private fun syncBubbleToHeaderTop() {
     if (_binding == null) return
     val container = content.headerOverlayContainer
-    content.pageSwitchGestureBubble.translationY = if (container.visibility == View.VISIBLE) {
-      container.translationY
-    } else {
-      0f
-    }
+    val targetY = if (isHeaderOverlayCollapsed) container.height.toFloat() else 0f
+    content.pageSwitchGestureBubble.translationY = targetY
   }
 
   private fun updateSymbolInputOverlayPosition() {

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -127,16 +127,17 @@
           android:elevation="4dp"
           android:visibility="gone">
 
-          <com.itsaky.androidide.ui.EdgeSnapBubbleView
-               android:id="@+id/page_switch_gesture_bubble"
-               android:layout_width="match_parent"
-               android:layout_height="24dp"
-               android:background="@android:color/transparent" />
-
           <RelativeLayout
                android:id="@+id/header_overlay_container"
                android:layout_width="match_parent"
                android:layout_height="wrap_content">
+
+               <com.itsaky.androidide.ui.EdgeSnapBubbleView
+                    android:id="@+id/page_switch_gesture_bubble"
+                    android:layout_width="match_parent"
+                    android:layout_height="24dp"
+                    android:layout_alignParentTop="true"
+                    android:background="@android:color/transparent" />
 
                <com.google.android.material.card.MaterialCardView
                     android:id="@+id/cardView"
@@ -157,7 +158,7 @@
                     android:layout_width="match_parent"
                     android:layout_marginBottom="2dp"
                     android:layout_height="0.5dp"
-                    android:layout_alignParentTop="true" />
+                    android:layout_below="@id/page_switch_gesture_bubble" />
 
                <ViewFlipper
                     android:id="@+id/header_container"

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -46,11 +46,49 @@ class EdgeSnapBubbleView : View {
   private var arrowPath: Path? = null
 
   private var onBackListener: OnBackListener? = null
+  private var onBubbleClickListener: OnBubbleClickListener? = null
+  private var onBubbleGestureListener: OnBubbleGestureListener? = null
   private var side: Side = Side.LEFT
+  private var position: Position = Position.LEFT
+  private var orientation: Orientation = Orientation.VERTICAL
+  private var isMirrored: Boolean = false
   private var showArrowUp: Boolean = true
 
   fun setOnBackListener(onBackListener: OnBackListener?) {
     this.onBackListener = onBackListener
+  }
+
+  fun setOnBubbleClickListener(listener: OnBubbleClickListener?) {
+    onBubbleClickListener = listener
+  }
+
+  fun setOnBubbleGestureListener(listener: OnBubbleGestureListener?) {
+    onBubbleGestureListener = listener
+  }
+
+
+  fun setPosition(newPosition: Position) {
+    position = newPosition
+    side = when (newPosition) {
+      Position.LEFT, Position.TOP -> Side.LEFT
+      Position.RIGHT, Position.BOTTOM -> Side.RIGHT
+    }
+    restorePosition()
+  }
+
+  fun setOrientation(newOrientation: Orientation) {
+    orientation = newOrientation
+    applyRenderTransform()
+  }
+
+  fun setMirrored(mirrored: Boolean) {
+    isMirrored = mirrored
+    applyRenderTransform()
+  }
+
+  private fun applyRenderTransform() {
+    rotation = if (orientation == Orientation.VERTICAL) 90f else 0f
+    scaleX = if (isMirrored) -1f else 1f
   }
 
   fun setOnlyLeftBack(onlyLeftBack: Boolean) {
@@ -144,6 +182,7 @@ class EdgeSnapBubbleView : View {
         }
         forwardX = currentX
         if (isEdge) {
+          onBubbleGestureListener?.onDrag(getDragFraction())
           invalidate()
         }
       }
@@ -161,6 +200,7 @@ class EdgeSnapBubbleView : View {
           if (abs(deltaX) < backMaxWidth * 0.2f) {
             performClick()
           }
+          onBubbleGestureListener?.onRelease(getDragFraction())
           deltaX = 0f
           invalidate()
         }
@@ -268,16 +308,40 @@ class EdgeSnapBubbleView : View {
 
   fun attachToSide(newSide: Side) {
     side = newSide
-    val parentView = parent as? View ?: return
-    x = if (side == Side.LEFT) 0f else (parentView.width - width).toFloat()
+    position = if (newSide == Side.LEFT) Position.LEFT else Position.RIGHT
+    restorePosition()
   }
 
   fun restorePosition() {
     val parentView = parent as? View ?: return
-    x = if (side == Side.LEFT) 0f else (parentView.width - width).toFloat()
+    when (position) {
+      Position.LEFT -> {
+        x = 0f
+        y = ((parentView.height - height) / 2f).coerceAtLeast(0f)
+      }
+      Position.RIGHT -> {
+        x = (parentView.width - width).toFloat()
+        y = ((parentView.height - height) / 2f).coerceAtLeast(0f)
+      }
+      Position.TOP -> {
+        x = ((parentView.width - width) / 2f).coerceAtLeast(0f)
+        y = 0f
+      }
+      Position.BOTTOM -> {
+        x = ((parentView.width - width) / 2f).coerceAtLeast(0f)
+        y = (parentView.height - height).toFloat()
+      }
+    }
+    applyRenderTransform()
+  }
+
+  private fun getDragFraction(): Float {
+    if (backMaxWidth <= 0f) return 0f
+    return (deltaX / backMaxWidth).coerceIn(-1f, 1f)
   }
 
   override fun performClick(): Boolean {
+    onBubbleClickListener?.onClick(this)
     super.performClick()
     return true
   }
@@ -290,7 +354,21 @@ class EdgeSnapBubbleView : View {
 
   enum class Side { LEFT, RIGHT }
 
+  enum class Position { LEFT, RIGHT, TOP, BOTTOM }
+
+  enum class Orientation { VERTICAL, HORIZONTAL }
+
   interface OnBackListener {
     fun onBack()
+  }
+
+  fun interface OnBubbleClickListener {
+    fun onClick(view: EdgeSnapBubbleView)
+  }
+
+  interface OnBubbleGestureListener {
+    fun onDrag(fraction: Float)
+
+    fun onRelease(fraction: Float)
   }
 }


### PR DESCRIPTION
### Motivation
- Make the page-switch bubble more flexible (position, orientation, click/gesture callbacks) and ensure it visually aligns with the header overlay during header/bottom-sheet transitions.
- Properly anchor and translate the external symbol input page when toggling external symbol mode and when IME insets change.

### Description
- Added new APIs and state to `EdgeSnapBubbleView`: `Position`, `Orientation`, click and gesture listeners (`OnBubbleClickListener`, `OnBubbleGestureListener`), mirroring, and rendering transform control, plus `setPosition`, `setOrientation`, `setMirrored`, `setOnBubbleClickListener`, and `setOnBubbleGestureListener` methods.
- Reworked `EdgeSnapBubbleView` positioning: replaced `attachToSide` with `position`/`restorePosition` logic to support left/right/top/bottom placement and centered top/bottom alignment, and exposed a `getDragFraction()` used for drag callbacks.
- Updated touch handling in `EdgeSnapBubbleView` to invoke `onDrag` and `onRelease` with a normalized drag fraction and to invoke `onClick` via `performClick()` when appropriate.
- Updated `BaseEditorActivity` to use the new bubble API (`setPosition`, `setOrientation`, `setOnBubbleClickListener`, `setOnBubbleGestureListener`) and to synchronize bubble translation with `headerOverlayContainer.translationY` during drags and animations.
- Added `updateSymbolInputPageAnchor` and wired it into `setExternalSymbolPageActive` to change the `symbolInputPage` anchor/gravity when the external symbol page becomes active or inactive, and ensured IME inset sync and overlay position updates are applied.

### Testing
- Ran project assemble with `./gradlew assemble` which completed successfully.
- Ran unit tests with `./gradlew test` and the test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36bd219c0832f96d2571e2c6eb5c8)