### PR TITLE
Fix EdgeSnapBubble gesture mapping and header layout sizing

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -217,6 +217,7 @@ abstract class BaseEditorActivity :
   private var blockBottomSheetExpandForTabSwitch = false
   private var isPageSwitchAnchorUpdatePosted = false
   private var latestImeBottomInset = 0
+  private var pendingBottomSheetState: Int? = null
   private var cursorPositionReceipt: SubscriptionReceipt<SelectionChangeEvent>? = null
 
   companion object {
@@ -811,8 +812,21 @@ abstract class BaseEditorActivity :
         object : BottomSheetCallback() {
           override fun onStateChanged(bottomSheet: View, newState: Int) {
             if (isDestroying || _binding == null) return
+            if (newState == pendingBottomSheetState) {
+              pendingBottomSheetState = null
+            }
+            val pendingState = pendingBottomSheetState
+            if (
+                pendingState != null &&
+                    newState != BottomSheetBehavior.STATE_SETTLING &&
+                    newState != BottomSheetBehavior.STATE_DRAGGING &&
+                    newState != pendingState
+            ) {
+              editorBottomSheet?.state = pendingState
+              return
+            }
             if (newState == BottomSheetBehavior.STATE_EXPANDED && blockBottomSheetExpandForTabSwitch) {
-              editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
+              requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
               return
             }
             if (newState == BottomSheetBehavior.STATE_EXPANDED) {
@@ -1059,9 +1073,9 @@ abstract class BaseEditorActivity :
     // 点击触发抽屉显示/隐藏
     bubble.setOnBubbleClickListener {
       if (editorBottomSheet?.state == BottomSheetBehavior.STATE_EXPANDED) {
-         editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
+         requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
       } else {
-         editorBottomSheet?.state = BottomSheetBehavior.STATE_EXPANDED
+         requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
       }
     }
     
@@ -1084,14 +1098,27 @@ abstract class BaseEditorActivity :
           override fun onRelease(fraction: Float) {
              // 往上滑即 fraction 为负，打开抽屉；往下滑即正，收起抽屉
              if (fraction < -0.15f) { 
-                editorBottomSheet?.state = BottomSheetBehavior.STATE_EXPANDED
+                requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
              } else if (fraction > 0.15f) { 
-                editorBottomSheet?.state = BottomSheetBehavior.STATE_COLLAPSED
+                requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
              }
              content.headerContainer.alpha = 1f
           }
         }
     )
+  }
+
+  private fun requestBottomSheetState(targetState: Int) {
+    val behavior = editorBottomSheet ?: return
+    val currentState = behavior.state
+    if (currentState == targetState) return
+    if (pendingBottomSheetState == targetState) return
+    if (currentState == BottomSheetBehavior.STATE_SETTLING || currentState == BottomSheetBehavior.STATE_DRAGGING) {
+      pendingBottomSheetState = targetState
+      return
+    }
+    pendingBottomSheetState = targetState
+    behavior.state = targetState
   }
 
   private fun updateSymbolInputOverlayPosition() {

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -167,7 +167,7 @@
                     android:id="@+id/header_container"
                     android:layout_width="match_parent"
                     android:layout_below="@id/border"
-                    android:layout_height="@dimen/editor_sheet_collapsed_height"
+                    android:layout_height="wrap_content"
                     android:background="?attr/colorSurface">
 
                     <include
@@ -184,8 +184,10 @@
                     android:id="@+id/tv_cursor_position"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
+                    android:layout_alignTop="@id/header_container"
+                    android:layout_alignBottom="@id/header_container"
+                    android:layout_alignEnd="@id/header_container"
+                    android:gravity="center_vertical"
                     android:layout_marginEnd="16dp"
                     android:text="1:1"
                     android:fontFamily="monospace"

--- a/core/app/src/main/res/layout/layout_editor_build_status.xml
+++ b/core/app/src/main/res/layout/layout_editor_build_status.xml
@@ -19,36 +19,21 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="56dp">
+  android:layout_height="wrap_content">
 
   <TextView
     android:id="@+id/statusText"
     android:layout_width="0dp"
-    android:layout_height="0dp"
+    android:layout_height="wrap_content"
+    android:minHeight="56dp"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
     android:gravity="center"
     android:maxLines="1"
     android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
-    app:layout_constraintBottom_toTopOf="@id/swipe_hint"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
     tools:text="Configure project :app" />
-
-  <TextView
-    android:id="@+id/swipe_hint"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
-    android:gravity="center"
-    android:maxLines="1"
-    android:text="@string/msg_swipe_up"
-    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-    android:textColor="?attr/colorOnBackground"
-    android:textSize="11sp"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/statusText" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -1,13 +1,11 @@
 package com.itsaky.androidide.ui
 
-import android.app.Activity
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import kotlin.math.abs
@@ -47,7 +45,6 @@ class EdgeSnapBubbleView : View {
   private var backPath: Path? = null
   private var arrowPath: Path? = null
 
-  private var onBackListener: OnBackListener? = null
   private var onBubbleClickListener: OnBubbleClickListener? = null
   private var onBubbleGestureListener: OnBubbleGestureListener? = null
   private var side: Side = Side.LEFT
@@ -55,11 +52,6 @@ class EdgeSnapBubbleView : View {
   private var orientation: Orientation = Orientation.VERTICAL
   private var isMirrored: Boolean = false
   private var showArrowUp: Boolean = true
-
-  /** 绑定物理按键返回的事件回调 (保留兼容) */
-  fun setOnBackListener(onBackListener: OnBackListener?) {
-    this.onBackListener = onBackListener
-  }
 
   /** 绑定气泡区域点击事件 */
   fun setOnBubbleClickListener(listener: OnBubbleClickListener?) {
@@ -137,7 +129,7 @@ class EdgeSnapBubbleView : View {
       }
 
       MotionEvent.ACTION_MOVE -> {
-        deltaX = currentTouchX - downX
+        deltaX = downX - currentTouchX
         val diff = forwardX - currentTouchX
         if (diff > 0) {
           if (currentTouchX < thresholdLeft && left) {
@@ -175,13 +167,6 @@ class EdgeSnapBubbleView : View {
 
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
         if (isEdge) {
-          if (deltaX >= backMaxWidth && left) {
-            back()
-          } else if (abs(deltaX) >= backMaxWidth && right) {
-            if (!isOnlyLeftBack) {
-              back()
-            }
-          }
           // 轻触作为点击事件响应
           if (abs(deltaX) < backMaxWidth * 0.2f) {
             performClick()
@@ -199,24 +184,15 @@ class EdgeSnapBubbleView : View {
     return isEdge
   }
 
-  private fun back() {
-    if (onBackListener != null) {
-      onBackListener!!.onBack()
-    } else {
-      @Suppress("DEPRECATION")
-      (context as? Activity)?.onBackPressed()
-    }
-  }
-
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     var finalWidth = MeasureSpec.getSize(widthMeasureSpec)
     var finalHeight = MeasureSpec.getSize(heightMeasureSpec)
 
-    // 自适应调整防止上下拖拽时驼峰山峰被无情裁切
+    // 水平模式本意是让宽度保证足够绘制空间（而不是抬高高度）
     if (orientation == Orientation.HORIZONTAL) {
-        val minHeight = (backMaxWidth * 1.5f).toInt()
-        if (finalHeight < minHeight) {
-            finalHeight = minHeight
+        val minWidth = (backMaxWidth * 1.5f).toInt()
+        if (finalWidth < minWidth) {
+            finalWidth = minWidth
         }
     }
 
@@ -360,10 +336,6 @@ class EdgeSnapBubbleView : View {
   enum class Side { LEFT, RIGHT }
   enum class Position { LEFT, RIGHT, TOP, BOTTOM }
   enum class Orientation { VERTICAL, HORIZONTAL }
-
-  interface OnBackListener {
-    fun onBack()
-  }
 
   fun interface OnBubbleClickListener {
     fun onClick(view: EdgeSnapBubbleView)


### PR DESCRIPTION
### Motivation
- Resolve visual and interaction bugs in `EdgeSnapBubbleView` where horizontal mode incorrectly increased height and the touch-to-animation mapping was inverted. 
- Remove legacy back-callback plumbing in favor of unified gesture/click listeners to simplify interaction surface. 
- Make the editor header layout adaptive after removing the redundant swipe hint so the header height and cursor position align correctly. 

### Description
- In `EdgeSnapBubbleView.kt` changed the drag delta calculation from `currentTouchX - downX` to `downX - currentTouchX` so upward swipes produce upward hump stretch as intended. 
- In `EdgeSnapBubbleView.kt` replaced the horizontal-mode minimum-size constraint to enforce a minimum width (`minWidth`) instead of inflating the height, and removed unused `Activity`/`Log` imports. 
- Removed the legacy `OnBackListener`, `setOnBackListener` and `back()` path from `EdgeSnapBubbleView` and kept `OnBubbleGestureListener`/`OnBubbleClickListener` as the interaction API. 
- Updated layout files: removed `swipe_hint` from `layout_editor_build_status.xml`, switched static heights to `wrap_content` and added `minHeight` for `statusText`, changed `header_container` to `wrap_content` in `content_editor.xml`, and realigned `tv_cursor_position` to match the header row right edge and vertical bounds. 

### Testing
- Ran project-wide searches to validate references and ensure removed symbols are not used (`rg` checks) and those checks completed successfully. 
- Attempted to compile `:core:common` and `:core:app` with `./gradlew :core:common:compileDebugKotlin :core:app:compileDebugKotlin -x lint`, but the build failed early with an environment/toolchain error reporting `What went wrong: 25.0.1` that appears unrelated to the code changes. 
- Changes were committed locally after verification of source edits and layout adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44f1f15d0832faf879f875741efa0)