### PR TITLE
Fix symbol input overlay binding to bottom sheet top

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -170,8 +170,10 @@ abstract class BaseEditorActivity :
 
           if (binding.root.isDrawerOpen(GravityCompat.START)) {
             binding.root.closeDrawer(GravityCompat.START)
+          } else if (isExternalSymbolPageActive) {
+            setExternalSymbolPageActive(false)
           } else if (editorBottomSheet?.state != BottomSheetBehavior.STATE_COLLAPSED) {
-            editorBottomSheet?.setState(BottomSheetBehavior.STATE_COLLAPSED)
+            requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
           } else if (binding.swipeReveal.isOpen) {
             binding.swipeReveal.close()
           } else {
@@ -835,6 +837,7 @@ abstract class BaseEditorActivity :
               resetEditorSurfaceTransform()
             }
             updateSymbolInputOverlayPosition()
+            syncSymbolInputPageToBottomSheet()
             
             // 确保所有的幽灵错位都被重置清空
             // content.symbolInputPage.translationY = 0f
@@ -851,6 +854,7 @@ abstract class BaseEditorActivity :
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
               updateSymbolInputOverlayPosition()
+              syncSymbolInputPageToBottomSheet()
             }
           }
         }
@@ -889,9 +893,11 @@ abstract class BaseEditorActivity :
       viewContainer.viewTreeObserver.addOnGlobalLayoutListener(observer)
       bottomSheet.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updateSymbolInputOverlayPosition()
+        syncSymbolInputPageToBottomSheet()
       }
       symbolInputPage.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         updateSymbolInputOverlayPosition()
+        syncSymbolInputPageToBottomSheet()
       }
       bottomSheet.setOffsetAnchor(editorAppBarLayout)
       bottomSheet.onHeaderPageChanged = { page ->
@@ -941,15 +947,13 @@ abstract class BaseEditorActivity :
   private fun updateSymbolInputPageAnchor(active: Boolean) {
     if (_binding == null) return
     content.symbolInputPage.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-      if (active) {
-        anchorId = View.NO_ID
-        anchorGravity = Gravity.NO_GRAVITY
-        gravity = Gravity.BOTTOM
-      } else {
-        anchorId = content.bottomSheet.id
-        anchorGravity = Gravity.TOP
-        gravity = Gravity.BOTTOM
-      }
+      anchorId = View.NO_ID
+      anchorGravity = Gravity.NO_GRAVITY
+      gravity = Gravity.BOTTOM
+    }
+    content.symbolInputPage.requestLayout()
+    if (!active) {
+      content.symbolInputPage.post { syncSymbolInputPageToBottomSheet() }
     }
   }
 
@@ -976,6 +980,7 @@ abstract class BaseEditorActivity :
       }
     }
     updateSymbolInputOverlayPosition()
+    syncSymbolInputPageToBottomSheet()
     
     // 强制归零解决各种异常偏移问题
     // content.symbolInputPage.translationY = 0f
@@ -990,6 +995,18 @@ abstract class BaseEditorActivity :
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
     // content.symbolInputPage.translationY = 0f
     updateSymbolInputOverlayPosition()
+    syncSymbolInputPageToBottomSheet()
+  }
+
+  private fun syncSymbolInputPageToBottomSheet() {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val page = content.symbolInputPage
+    val sheet = content.bottomSheet
+    if (page.visibility != View.VISIBLE || page.height <= 0) return
+    val targetY = (sheet.top - page.height).toFloat()
+    if (kotlin.math.abs(page.y - targetY) > 0.5f) {
+      page.y = targetY
+    }
   }
 
   /**


### PR DESCRIPTION
### Motivation

- The `symbol_input_page` was incorrectly anchored and not reliably aligned to the top of `bottom_sheet`, causing visual jitter when the bottom sheet was repeatedly opened/closed.
- Back-press and gesture handling mixed states (external symbol page vs bottom sheet) could conflict and trigger the same jitter/unsynced positioning behaviors.

### Description

- Reworked back-press handling to close the external symbol page first and then collapse the bottom sheet through the unified `requestBottomSheetState()` pipeline by updating `BaseEditorActivity.kt`.
- Replaced reliance on `CoordinatorLayout` anchor coupling and added an explicit `syncSymbolInputPageToBottomSheet()` helper that positions `symbol_input_page` to `bottom_sheet.top - symbol_input_page.height` when the external symbol page is inactive.
- Hooked `syncSymbolInputPageToBottomSheet()` into bottom sheet callbacks (`onStateChanged`, `onSlide`), layout change listeners for `bottomSheet`/`symbolInputPage`, and into IME/external-symbol-page state transitions so the overlay continuously converges to the correct position.
- Simplified `updateSymbolInputPageAnchor()` to remove anchor toggling and added `requestLayout()`/`post`-sync to reliably rebind and avoid transient misalignment.

### Testing

- Ran `./gradlew :core:app:compileDebugKotlin` in the environment to verify Kotlin compile, which failed due to an SDK/toolchain issue (`25.0.1`) unrelated to the logic changes and not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49e9b3d68832fa7dd07762fcffbe4)