### PR TITLE
Improve bottom sheet focus/overlay behavior and external-symbol IME handling

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -30,6 +30,7 @@ import android.text.style.ClickableSpan
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
+import android.widget.RelativeLayout
 import android.view.Gravity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
@@ -214,6 +215,7 @@ abstract class BaseEditorActivity :
 
   private var optionsMenuInvalidator: Runnable? = null
   private var bottomSheetSlideOffset = 0f
+  private var isBottomSheetFocusMode = false
   private var blockBottomSheetExpandForTabSwitch = false
   private var latestImeBottomInset = 0
   private var pendingBottomSheetState: Int? = null
@@ -309,6 +311,7 @@ abstract class BaseEditorActivity :
       if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
       content.cardView.visibility = bottomSheetCardVisibilitySnapshot
       content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      updateEdgeBubbleAnchorToHeader(content.headerContainer.visibility == View.VISIBLE)
     }
   }
 
@@ -806,6 +809,8 @@ abstract class BaseEditorActivity :
             } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
               resetEditorSurfaceTransform()
             }
+            updateBottomSheetFocusMode(newState)
+            updateBindingHierarchyForMode(newState)
           }
 
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -815,7 +820,9 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              syncBottomSheetOverlayWithSlide(slideOffset)
+              updateBindingHierarchyForSlide(slideOffset)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -874,6 +881,79 @@ abstract class BaseEditorActivity :
         }
       }
       setExternalSymbolPageActive(false)
+    }
+  }
+
+
+  private fun updateBottomSheetFocusMode(state: Int) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val focused = state == BottomSheetBehavior.STATE_EXPANDED
+    if (isBottomSheetFocusMode == focused) return
+    isBottomSheetFocusMode = focused
+
+    if (focused) {
+      content.externalSymbolInputView.setImeBottomInset(0)
+      content.symbolInputPage.translationY = 0f
+      syncBottomSheetOverlayWithSlide(1f)
+    } else {
+      syncBottomSheetOverlayWithSlide(bottomSheetSlideOffset)
+    }
+  }
+
+  private fun syncBottomSheetOverlayWithSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val alpha = (1f - progress).coerceIn(0f, 1f)
+    content.headerOverlayContainer.alpha = alpha
+    content.pageSwitchGestureBubble.alpha = alpha
+    content.externalSymbolInputView.alpha = alpha
+    val visible = alpha > 0.02f
+    val targetVisibility = if (visible) View.VISIBLE else View.GONE
+    if (content.headerOverlayContainer.visibility != targetVisibility) {
+      content.headerOverlayContainer.visibility = targetVisibility
+    }
+    if (content.pageSwitchGestureBubble.visibility != targetVisibility) {
+      content.pageSwitchGestureBubble.visibility = targetVisibility
+    }
+    if (content.externalSymbolInputView.visibility != targetVisibility) {
+      content.externalSymbolInputView.visibility = targetVisibility
+    }
+  }
+
+
+  private fun updateBindingHierarchyForMode(bottomSheetState: Int) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val expanded = bottomSheetState == BottomSheetBehavior.STATE_EXPANDED
+    updateEdgeBubbleAnchorToHeader(!expanded && content.headerContainer.visibility == View.VISIBLE)
+    val overlayTargetVisibility = if (expanded) View.GONE else View.VISIBLE
+    if (content.headerOverlayContainer.visibility != overlayTargetVisibility) {
+      content.headerOverlayContainer.visibility = overlayTargetVisibility
+    }
+    if (content.externalSymbolInputView.visibility != overlayTargetVisibility) {
+      content.externalSymbolInputView.visibility = overlayTargetVisibility
+    }
+  }
+
+  private fun updateBindingHierarchyForSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val showHeaderBound = progress < 0.6f && content.headerContainer.visibility == View.VISIBLE
+    updateEdgeBubbleAnchorToHeader(showHeaderBound)
+  }
+
+  private fun updateEdgeBubbleAnchorToHeader(anchorToHeader: Boolean) {
+    if (_binding == null) return
+    content.pageSwitchGestureBubble.updateLayoutParams<RelativeLayout.LayoutParams> {
+      removeRule(RelativeLayout.ALIGN_PARENT_TOP)
+      removeRule(RelativeLayout.ABOVE)
+      removeRule(RelativeLayout.ALIGN_TOP)
+      removeRule(RelativeLayout.ALIGN_BOTTOM)
+      if (anchorToHeader) {
+        addRule(RelativeLayout.ALIGN_TOP, R.id.header_container)
+        addRule(RelativeLayout.ALIGN_BOTTOM, R.id.header_container)
+      } else {
+        addRule(RelativeLayout.ALIGN_PARENT_TOP)
+      }
     }
   }
 
@@ -936,6 +1016,7 @@ abstract class BaseEditorActivity :
       content.pageSwitchGestureBubble.setArrowExpanded(false)
       
       content.headerContainer.visibility = View.GONE
+      updateEdgeBubbleAnchorToHeader(false)
       content.cardView.visibility = View.GONE
       content.border.root.visibility = View.GONE
       content.tvCursorPosition.visibility = View.GONE
@@ -954,6 +1035,7 @@ abstract class BaseEditorActivity :
       content.pageSwitchGestureBubble.setArrowExpanded(true)
       
       content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      updateEdgeBubbleAnchorToHeader(content.headerContainer.visibility == View.VISIBLE)
       content.cardView.visibility = bottomSheetCardVisibilitySnapshot
       content.border.root.visibility = View.VISIBLE
       content.tvCursorPosition.visibility = View.VISIBLE
@@ -963,6 +1045,7 @@ abstract class BaseEditorActivity :
       
       updateSymbolInputPageAnchor(false)
       content.bottomSheet.resetSymbolInputPageHeight()
+      updateBindingHierarchyForSlide(bottomSheetSlideOffset)
     }
     
     content.pageSwitchGestureBubble.bringToFront()
@@ -1004,7 +1087,7 @@ abstract class BaseEditorActivity :
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
-                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtLeast(0f) else 0f
                 return bounds
             }
 
@@ -1033,7 +1116,7 @@ abstract class BaseEditorActivity :
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
         if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtLeast(0f) else 0f
             view.translationY = targetTranslationY
         } else {
             view.translationY = 0f


### PR DESCRIPTION
### Motivation
- Improve visual and interaction consistency when the editor bottom sheet expands or slides, ensuring overlays and gesture bubble anchor update correctly.
- Ensure external symbol input page behaves correctly with IME animations and insets during show/hide transitions.
- Fix incorrect clamping of IME translation calculation that produced an inverted translation sign.

### Description
- Added `isBottomSheetFocusMode` flag and new helpers `updateBottomSheetFocusMode`, `syncBottomSheetOverlayWithSlide`, `updateBindingHierarchyForMode`, `updateBindingHierarchyForSlide`, and `updateEdgeBubbleAnchorToHeader` to manage overlay alpha/visibility and bubble anchoring during bottom sheet state changes and slides.
- Wired the new helpers into the bottom sheet callbacks (`onStateChanged` and `onSlide`), into external-symbol activation/deactivation flows, and into header hide/release logic via calls to `updateEdgeBubbleAnchorToHeader` and `updateBindingHierarchyForSlide`.
- Adjusted external symbol IME translation clamping from `coerceAtMost(0f)` to `coerceAtLeast(0f)` in both the `WindowInsetsAnimationCompat.Callback` and `OnApplyWindowInsetsListener` to correct translation direction.
- Imported `RelativeLayout` and updated `pageSwitchGestureBubble` layout param updates to use `RelativeLayout.LayoutParams` so the bubble can be re-anchored to the header or top of the container.
- Consolidated overlay synchronization to set visibility and alpha for `headerOverlayContainer`, `pageSwitchGestureBubble`, and `externalSymbolInputView` based on slide progress.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62bd8955c832f9bbf51c9ec6299e7)