### PR TITLE
feat(modules): add reusable JDWP client module

### DIFF
--- a/modules/jdwp-client/README.md
+++ b/modules/jdwp-client/README.md
@@ -1,38 +1,31 @@
-# JDWP Client 模块
+# JDWP Client（全功能架构版）
 
-该模块现在已按“扩展建议”一次性落地为可直接用于 Termux IPC/跨进程调试的完整客户端骨架。
+## 协议分层（已落地）
 
-## 已实现能力（当前版本）
+1. Transport 层：`JdwpTransport` / `SocketJdwpTransport`
+2. Packetize 层：`JdwpCodec` + `JdwpBuffer`
+3. JDWP Commands 层：`JdwpClient`（Set 1/2/9/11/15 等）
+4. JDI-like 层：`JdwpSymbolRepository`（类/方法缓存解析）
 
-- 连接与握手
-  - 标准 `JDWP-Handshake`。
-- 传输层
-  - `JdwpTransport` 抽象。
-  - `SocketJdwpTransport`（支持 TCP socket，可直接用于 IPC 转发链路末端）。
-- 协议编解码
-  - 完整 command packet 编码。
-  - reply/event packet 自动识别与解析。
-  - 大端序二进制读写工具 `JdwpBuffer`。
-- 异步收包循环（已实现）
-  - 后台事件泵线程持续收包。
-  - 请求/回复通过 `id` 自动匹配。
-  - 支持注册 event listener 接收异步事件。
-- VM / Class / Symbol 查询
-  - `VirtualMachine.Version`
-  - `VirtualMachine.AllThreads`
-  - `VirtualMachine.Suspend` / `Resume`
-  - `VirtualMachine.ClassesBySignature`
-  - `ReferenceType.Fields`
-  - `ReferenceType.Methods`
-  - `ObjectReference.ReferenceType`
-  - `ObjectReference.GetValues`
-- EventRequest
-  - `EventRequest.Set`（当前提供 VM_DEATH 快捷注册）
-  - `EventRequest.Clear`
-- 错误处理
-  - JDWP 错误码映射 + 异常抛出。
+## 核心能力
 
-## 快速示例
+- 严格握手：`JDWP-Handshake` 14 字节双向校验。
+- 异步收包：后台 pump + `CompletableFuture` 按 Packet ID 匹配回复。
+- Event 处理：支持 event listener 与 EventRequest.Set / Clear。
+- IDSizes：握手后自动调用 `VirtualMachine.IDSizes`，按目标 JVM 动态 ID 长度解析。
+- 符号链路：`ClassesBySignature -> Methods/Fields`。
+- 对象读写：`ObjectReference.GetValues / SetValues`。
+- 远程方法调用：`ObjectReference.InvokeMethod`（支持 options，如 `INVOKE_SINGLE_THREADED`）。
+
+## 已实现命令（摘要）
+
+- VM(Set=1): `Version`, `AllThreads`, `IDSizes`, `Suspend`, `Resume`, `ClassesBySignature`
+- ReferenceType(Set=2): `Fields`, `Methods`
+- ObjectReference(Set=9): `ReferenceType`, `GetValues`, `SetValues`, `InvokeMethod`
+- ThreadReference(Set=11): `Name`, `Status`
+- EventRequest(Set=15): `Set`, `Clear`
+
+## 使用示例
 
 ```kotlin
 SocketJdwpTransport("127.0.0.1", 5005).use { transport ->
@@ -40,27 +33,15 @@ SocketJdwpTransport("127.0.0.1", 5005).use { transport ->
     client.connectAndHandshake()
 
     client.setEventListener { event ->
-      println("JDWP event: set=${event.commandSet}, cmd=${event.command}")
+      println("event: set=${event.commandSet}, cmd=${event.command}")
     }
 
-    val version = client.vmVersion()
-    val threads = client.allThreads()
-    val firstThread = threads.firstOrNull()?.let(client::threadInfo)
+    val repo = JdwpSymbolRepository(client)
+    val cls = repo.resolveClass("Lcom/example/Main;")
+    val method = repo.resolveMethod(cls, "run")
 
-    val classes = client.classesBySignature("Lcom/example/Main;")
-    val methods = classes.firstOrNull()?.let { client.methods(it.typeId) }
-
-    println(version)
-    println(firstThread)
-    println(methods)
+    println(client.vmVersion())
+    println(method)
   }
 }
 ```
-
-## 集成建议（core/app 或 termux 层）
-
-- 将 `JdwpTransport` 作为可替换依赖注入：
-  - 本地调试用 `SocketJdwpTransport`。
-  - Termux 会话链路可封装自定义 transport（Unix domain socket / 本地代理隧道）。
-- 在上层提供符号服务（Class/Method/Field/Object）缓存，避免重复 round-trip。
-- 若要进一步覆盖“方法调用/断点/单步”等高级能力，可在当前结构上继续新增对应 command set API。

--- a/modules/jdwp-client/README.md
+++ b/modules/jdwp-client/README.md
@@ -1,21 +1,36 @@
 # JDWP Client 模块
 
-该模块提供可直接在项目内复用的 JDWP 协议客户端能力，目标覆盖：
+该模块现在已按“扩展建议”一次性落地为可直接用于 Termux IPC/跨进程调试的完整客户端骨架。
 
-- 跨进程调试。
-- IPC socket 转发场景（例如 Termux 客户端与会话终端进程之间）。
-- 在上层模块（如 `core/app`）中按符号维度访问 JVM 内部对象：类、方法、字段等。
+## 已实现能力（当前版本）
 
-## 当前能力
-
-- 标准 `JDWP-Handshake` 握手。
-- 命令包与回复包编码/解码。
-- VM 基础命令：
+- 连接与握手
+  - 标准 `JDWP-Handshake`。
+- 传输层
+  - `JdwpTransport` 抽象。
+  - `SocketJdwpTransport`（支持 TCP socket，可直接用于 IPC 转发链路末端）。
+- 协议编解码
+  - 完整 command packet 编码。
+  - reply/event packet 自动识别与解析。
+  - 大端序二进制读写工具 `JdwpBuffer`。
+- 异步收包循环（已实现）
+  - 后台事件泵线程持续收包。
+  - 请求/回复通过 `id` 自动匹配。
+  - 支持注册 event listener 接收异步事件。
+- VM / Class / Symbol 查询
   - `VirtualMachine.Version`
+  - `VirtualMachine.AllThreads`
+  - `VirtualMachine.Suspend` / `Resume`
   - `VirtualMachine.ClassesBySignature`
-- 引用类型命令：
   - `ReferenceType.Fields`
   - `ReferenceType.Methods`
+  - `ObjectReference.ReferenceType`
+  - `ObjectReference.GetValues`
+- EventRequest
+  - `EventRequest.Set`（当前提供 VM_DEATH 快捷注册）
+  - `EventRequest.Clear`
+- 错误处理
+  - JDWP 错误码映射 + 异常抛出。
 
 ## 快速示例
 
@@ -23,15 +38,29 @@
 SocketJdwpTransport("127.0.0.1", 5005).use { transport ->
   JdwpClient(transport).use { client ->
     client.connectAndHandshake()
+
+    client.setEventListener { event ->
+      println("JDWP event: set=${event.commandSet}, cmd=${event.command}")
+    }
+
     val version = client.vmVersion()
+    val threads = client.allThreads()
+    val firstThread = threads.firstOrNull()?.let(client::threadInfo)
+
     val classes = client.classesBySignature("Lcom/example/Main;")
-    val methods = client.methods(classes.first().typeId)
+    val methods = classes.firstOrNull()?.let { client.methods(it.typeId) }
+
+    println(version)
+    println(firstThread)
+    println(methods)
   }
 }
 ```
 
-## 扩展建议
+## 集成建议（core/app 或 termux 层）
 
-- 按 JDWP Command Set 分层扩展命令实现（ThreadReference / ObjectReference / EventRequest 等）。
-- 引入异步收包循环，支持事件通知与请求回复并发。
-- 在 IPC 场景外包一层会话鉴权/多路复用协议。
+- 将 `JdwpTransport` 作为可替换依赖注入：
+  - 本地调试用 `SocketJdwpTransport`。
+  - Termux 会话链路可封装自定义 transport（Unix domain socket / 本地代理隧道）。
+- 在上层提供符号服务（Class/Method/Field/Object）缓存，避免重复 round-trip。
+- 若要进一步覆盖“方法调用/断点/单步”等高级能力，可在当前结构上继续新增对应 command set API。

--- a/modules/jdwp-client/README.md
+++ b/modules/jdwp-client/README.md
@@ -1,0 +1,37 @@
+# JDWP Client 模块
+
+该模块提供可直接在项目内复用的 JDWP 协议客户端能力，目标覆盖：
+
+- 跨进程调试。
+- IPC socket 转发场景（例如 Termux 客户端与会话终端进程之间）。
+- 在上层模块（如 `core/app`）中按符号维度访问 JVM 内部对象：类、方法、字段等。
+
+## 当前能力
+
+- 标准 `JDWP-Handshake` 握手。
+- 命令包与回复包编码/解码。
+- VM 基础命令：
+  - `VirtualMachine.Version`
+  - `VirtualMachine.ClassesBySignature`
+- 引用类型命令：
+  - `ReferenceType.Fields`
+  - `ReferenceType.Methods`
+
+## 快速示例
+
+```kotlin
+SocketJdwpTransport("127.0.0.1", 5005).use { transport ->
+  JdwpClient(transport).use { client ->
+    client.connectAndHandshake()
+    val version = client.vmVersion()
+    val classes = client.classesBySignature("Lcom/example/Main;")
+    val methods = client.methods(classes.first().typeId)
+  }
+}
+```
+
+## 扩展建议
+
+- 按 JDWP Command Set 分层扩展命令实现（ThreadReference / ObjectReference / EventRequest 等）。
+- 引入异步收包循环，支持事件通知与请求回复并发。
+- 在 IPC 场景外包一层会话鉴权/多路复用协议。

--- a/modules/jdwp-client/README.md
+++ b/modules/jdwp-client/README.md
@@ -1,47 +1,34 @@
-# JDWP Client（全功能架构版）
+# JDWP Client（远程 RPC 调试版）
 
-## 协议分层（已落地）
+本模块把 JDWP 当作“远程过程调用系统”实现，面向 Android <-> Termux JVM 的 TCP 字节流调试。
 
-1. Transport 层：`JdwpTransport` / `SocketJdwpTransport`
-2. Packetize 层：`JdwpCodec` + `JdwpBuffer`
-3. JDWP Commands 层：`JdwpClient`（Set 1/2/9/11/15 等）
-4. JDI-like 层：`JdwpSymbolRepository`（类/方法缓存解析）
+## 分层架构
+1. Transport: `JdwpTransport` / `SocketJdwpTransport`
+2. Packetize: `JdwpCodec` + `JdwpBuffer`
+3. Command Mapping: `JdwpClient`
+4. JDI-like: `JdwpSymbolRepository`
 
-## 核心能力
+## 关键远程能力
+- 严格握手：`JDWP-Handshake`。
+- 心跳保活：定时 `VirtualMachine.Version`，超时触发断线回调。
+- 动态 IDSizes：自动适配 32/64 位 ID。
+- 远程对象持有：`DisableCollection` / `EnableCollection`。
+- 方法调用链路：线程挂起 -> MethodsByName -> InvokeMethod -> 返回值/异常对象。
+- 调用栈：`ThreadReference.Frames`。
+- 断点/事件：`EventRequest.Set/Clear` + 异步事件回调。
+- 全类列表：`VirtualMachine.AllClasses`。
 
-- 严格握手：`JDWP-Handshake` 14 字节双向校验。
-- 异步收包：后台 pump + `CompletableFuture` 按 Packet ID 匹配回复。
-- Event 处理：支持 event listener 与 EventRequest.Set / Clear。
-- IDSizes：握手后自动调用 `VirtualMachine.IDSizes`，按目标 JVM 动态 ID 长度解析。
-- 符号链路：`ClassesBySignature -> Methods/Fields`。
-- 对象读写：`ObjectReference.GetValues / SetValues`。
-- 远程方法调用：`ObjectReference.InvokeMethod`（支持 options，如 `INVOKE_SINGLE_THREADED`）。
-
-## 已实现命令（摘要）
-
-- VM(Set=1): `Version`, `AllThreads`, `IDSizes`, `Suspend`, `Resume`, `ClassesBySignature`
-- ReferenceType(Set=2): `Fields`, `Methods`
-- ObjectReference(Set=9): `ReferenceType`, `GetValues`, `SetValues`, `InvokeMethod`
-- ThreadReference(Set=11): `Name`, `Status`
-- EventRequest(Set=15): `Set`, `Clear`
-
-## 使用示例
-
+## 快速验证（建议第一步）
 ```kotlin
-SocketJdwpTransport("127.0.0.1", 5005).use { transport ->
-  JdwpClient(transport).use { client ->
-    client.connectAndHandshake()
+val client = JdwpClient(SocketJdwpTransport("127.0.0.1", 5005))
+client.connectAndHandshake()
+println(client.allThreads())
+println(client.allClasses().take(20))
+```
 
-    client.setEventListener { event ->
-      println("event: set=${event.commandSet}, cmd=${event.command}")
-    }
-
-    val repo = JdwpSymbolRepository(client)
-    val cls = repo.resolveClass("Lcom/example/Main;")
-    val method = repo.resolveMethod(cls, "run")
-
-    println(client.vmVersion())
-    println(method)
-  }
-}
+## 变量修改示例
+```kotlin
+val cls = client.classesBySignature("Lcom/example/Main;").first()
+val field = client.fields(cls.typeId).first { it.name == "counter" }
+client.setObjectValues(ObjectId(0x1234), listOf(ValueToSet(field.id, TaggedValue('I'.code.toByte(), 42))))
 ```

--- a/modules/jdwp-client/build.gradle.kts
+++ b/modules/jdwp-client/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  kotlin("jvm")
+  `java-library`
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+  implementation(kotlin("stdlib"))
+}

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdiFacade.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdiFacade.kt
@@ -1,0 +1,21 @@
+package com.zerostudio.jdwp
+
+class JdwpSymbolRepository(private val client: JdwpClient) {
+  private val classCache = mutableMapOf<String, JdwpClassRef>()
+  private val methodCache = mutableMapOf<Pair<Long, String>, JdwpMethodRef>()
+
+  fun resolveClass(signature: String): JdwpClassRef {
+    return classCache.getOrPut(signature) {
+      val info = client.classesBySignature(signature).firstOrNull() ?: error("Class not found: $signature")
+      JdwpClassRef(info.typeId, signature)
+    }
+  }
+
+  fun resolveMethod(classRef: JdwpClassRef, methodName: String): JdwpMethodRef {
+    return methodCache.getOrPut(classRef.id.raw to methodName) {
+      val method = client.methods(classRef.id).firstOrNull { it.name == methodName }
+        ?: error("Method not found: ${classRef.signature}#$methodName")
+      JdwpMethodRef(method.id, method.name, method.signature)
+    }
+  }
+}

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdiFacade.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdiFacade.kt
@@ -2,18 +2,18 @@ package com.zerostudio.jdwp
 
 class JdwpSymbolRepository(private val client: JdwpClient) {
   private val classCache = mutableMapOf<String, JdwpClassRef>()
-  private val methodCache = mutableMapOf<Pair<Long, String>, JdwpMethodRef>()
+  private val methodCache = mutableMapOf<Triple<Long, String, String?>, JdwpMethodRef>()
 
-  fun resolveClass(signature: String): JdwpClassRef {
-    return classCache.getOrPut(signature) {
-      val info = client.classesBySignature(signature).firstOrNull() ?: error("Class not found: $signature")
-      JdwpClassRef(info.typeId, signature)
-    }
+  fun clearCaches() { classCache.clear(); methodCache.clear() }
+
+  fun resolveClass(signature: String): JdwpClassRef = classCache.getOrPut(signature) {
+    val info = client.classesBySignature(signature).firstOrNull() ?: error("Class not found: $signature")
+    JdwpClassRef(info.typeId, signature)
   }
 
-  fun resolveMethod(classRef: JdwpClassRef, methodName: String): JdwpMethodRef {
-    return methodCache.getOrPut(classRef.id.raw to methodName) {
-      val method = client.methods(classRef.id).firstOrNull { it.name == methodName }
+  fun resolveMethod(classRef: JdwpClassRef, methodName: String, signature: String? = null): JdwpMethodRef {
+    return methodCache.getOrPut(Triple(classRef.id.raw, methodName, signature)) {
+      val method = client.methodsByName(classRef.id, methodName, signature).firstOrNull()
         ?: error("Method not found: ${classRef.signature}#$methodName")
       JdwpMethodRef(method.id, method.name, method.signature)
     }

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
@@ -7,11 +7,13 @@ data class MethodInfo(val id: MethodId, val name: String, val signature: String,
 data class FieldInfo(val id: FieldId, val name: String, val signature: String, val modifiers: Int)
 data class ThreadInfo(val name: String, val threadStatus: Int, val suspendStatus: Int)
 data class ObjectReferenceInfo(val refTypeTag: Byte, val typeId: ReferenceTypeId)
+data class FrameInfo(val frameId: FrameId, val typeTag: Byte, val classId: ReferenceTypeId, val methodId: MethodId, val index: Long)
 
 data class TaggedValue(val tag: Byte, val rawValue: Long)
 data class ValueToSet(val fieldId: FieldId, val value: TaggedValue)
+data class InvokeResult(val returnValue: TaggedValue, val exceptionObjectId: ObjectId?)
 
-enum class JdwpEventKind(val code: Byte) { BREAKPOINT(2), SINGLE_STEP(1), METHOD_ENTRY(40), METHOD_EXIT(41), CLASS_PREPARE(8), VM_DEATH(99) }
+enum class JdwpEventKind(val code: Byte) { BREAKPOINT(2), SINGLE_STEP(1), METHOD_ENTRY(40), METHOD_EXIT(41), CLASS_UNLOAD(9), CLASS_PREPARE(8), VM_DEATH(99) }
 enum class JdwpSuspendPolicy(val code: Byte) { NONE(0), EVENT_THREAD(1), ALL(2) }
 data class EventRequestId(val raw: Int)
 

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
@@ -1,40 +1,24 @@
 package com.zerostudio.jdwp
 
-data class VmVersionReply(
-  val description: String,
-  val jdwpMajor: Int,
-  val jdwpMinor: Int,
-  val vmVersion: String,
-  val vmName: String,
-)
-
+data class VmVersionReply(val description: String, val jdwpMajor: Int, val jdwpMinor: Int, val vmVersion: String, val vmName: String)
+data class IdSizes(val fieldIdSize: Int, val methodIdSize: Int, val objectIdSize: Int, val referenceTypeIdSize: Int, val frameIdSize: Int)
 data class ClassInfo(val refTypeTag: Byte, val typeId: ReferenceTypeId, val status: Int)
 data class MethodInfo(val id: MethodId, val name: String, val signature: String, val modifiers: Int)
 data class FieldInfo(val id: FieldId, val name: String, val signature: String, val modifiers: Int)
-
 data class ThreadInfo(val name: String, val threadStatus: Int, val suspendStatus: Int)
 data class ObjectReferenceInfo(val refTypeTag: Byte, val typeId: ReferenceTypeId)
+
 data class TaggedValue(val tag: Byte, val rawValue: Long)
+data class ValueToSet(val fieldId: FieldId, val value: TaggedValue)
 
-enum class JdwpEventKind(val code: Byte) { BREAKPOINT(2), SINGLE_STEP(1), METHOD_ENTRY(40), METHOD_EXIT(41), VM_DEATH(99) }
+enum class JdwpEventKind(val code: Byte) { BREAKPOINT(2), SINGLE_STEP(1), METHOD_ENTRY(40), METHOD_EXIT(41), CLASS_PREPARE(8), VM_DEATH(99) }
 enum class JdwpSuspendPolicy(val code: Byte) { NONE(0), EVENT_THREAD(1), ALL(2) }
-
 data class EventRequestId(val raw: Int)
 
-object JdwpErrors {
-  private val mapping = mapOf<UShort, String>(
-    10u.toUShort() to "INVALID_THREAD",
-    13u.toUShort() to "THREAD_NOT_SUSPENDED",
-    15u.toUShort() to "INVALID_OBJECT",
-    20u.toUShort() to "INVALID_CLASS",
-    23u.toUShort() to "INVALID_METHODID",
-    25u.toUShort() to "INVALID_FIELDID",
-    99u.toUShort() to "NOT_IMPLEMENTED",
-    112u.toUShort() to "VM_DEAD",
-  )
+data class JdwpClassRef(val id: ReferenceTypeId, val signature: String)
+data class JdwpMethodRef(val id: MethodId, val name: String, val signature: String)
 
-  fun throwIfError(code: UShort) {
-    if (code.toInt() == 0) return
-    throw IllegalStateException("JDWP error $code (${mapping[code] ?: "UNKNOWN"})")
-  }
+object JdwpErrors {
+  private val mapping = mapOf<UShort, String>(10u.toUShort() to "INVALID_THREAD", 13u.toUShort() to "THREAD_NOT_SUSPENDED", 15u.toUShort() to "INVALID_OBJECT", 20u.toUShort() to "INVALID_CLASS", 23u.toUShort() to "INVALID_METHODID", 25u.toUShort() to "INVALID_FIELDID", 99u.toUShort() to "NOT_IMPLEMENTED", 112u.toUShort() to "VM_DEAD")
+  fun throwIfError(code: UShort) { if (code.toInt() != 0) throw IllegalStateException("JDWP error $code (${mapping[code] ?: "UNKNOWN"})") }
 }

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
@@ -8,25 +8,18 @@ data class VmVersionReply(
   val vmName: String,
 )
 
-data class ClassInfo(
-  val refTypeTag: Byte,
-  val typeId: ReferenceTypeId,
-  val status: Int,
-)
+data class ClassInfo(val refTypeTag: Byte, val typeId: ReferenceTypeId, val status: Int)
+data class MethodInfo(val id: MethodId, val name: String, val signature: String, val modifiers: Int)
+data class FieldInfo(val id: FieldId, val name: String, val signature: String, val modifiers: Int)
 
-data class MethodInfo(
-  val id: MethodId,
-  val name: String,
-  val signature: String,
-  val modifiers: Int,
-)
+data class ThreadInfo(val name: String, val threadStatus: Int, val suspendStatus: Int)
+data class ObjectReferenceInfo(val refTypeTag: Byte, val typeId: ReferenceTypeId)
+data class TaggedValue(val tag: Byte, val rawValue: Long)
 
-data class FieldInfo(
-  val id: FieldId,
-  val name: String,
-  val signature: String,
-  val modifiers: Int,
-)
+enum class JdwpEventKind(val code: Byte) { BREAKPOINT(2), SINGLE_STEP(1), METHOD_ENTRY(40), METHOD_EXIT(41), VM_DEATH(99) }
+enum class JdwpSuspendPolicy(val code: Byte) { NONE(0), EVENT_THREAD(1), ALL(2) }
+
+data class EventRequestId(val raw: Int)
 
 object JdwpErrors {
   private val mapping = mapOf<UShort, String>(
@@ -42,7 +35,6 @@ object JdwpErrors {
 
   fun throwIfError(code: UShort) {
     if (code.toInt() == 0) return
-    val name = mapping[code] ?: "UNKNOWN"
-    throw IllegalStateException("JDWP error $code ($name)")
+    throw IllegalStateException("JDWP error $code (${mapping[code] ?: "UNKNOWN"})")
   }
 }

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpModel.kt
@@ -1,0 +1,48 @@
+package com.zerostudio.jdwp
+
+data class VmVersionReply(
+  val description: String,
+  val jdwpMajor: Int,
+  val jdwpMinor: Int,
+  val vmVersion: String,
+  val vmName: String,
+)
+
+data class ClassInfo(
+  val refTypeTag: Byte,
+  val typeId: ReferenceTypeId,
+  val status: Int,
+)
+
+data class MethodInfo(
+  val id: MethodId,
+  val name: String,
+  val signature: String,
+  val modifiers: Int,
+)
+
+data class FieldInfo(
+  val id: FieldId,
+  val name: String,
+  val signature: String,
+  val modifiers: Int,
+)
+
+object JdwpErrors {
+  private val mapping = mapOf<UShort, String>(
+    10u.toUShort() to "INVALID_THREAD",
+    13u.toUShort() to "THREAD_NOT_SUSPENDED",
+    15u.toUShort() to "INVALID_OBJECT",
+    20u.toUShort() to "INVALID_CLASS",
+    23u.toUShort() to "INVALID_METHODID",
+    25u.toUShort() to "INVALID_FIELDID",
+    99u.toUShort() to "NOT_IMPLEMENTED",
+    112u.toUShort() to "VM_DEAD",
+  )
+
+  fun throwIfError(code: UShort) {
+    if (code.toInt() == 0) return
+    val name = mapping[code] ?: "UNKNOWN"
+    throw IllegalStateException("JDWP error $code ($name)")
+  }
+}

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
@@ -4,186 +4,84 @@ import java.io.EOFException
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
-interface JdwpTransport : AutoCloseable {
-  fun connect()
-  fun readBytes(size: Int): ByteArray
-  fun writePacket(packet: ByteArray)
-}
-
+interface JdwpTransport : AutoCloseable { fun connect(); fun readBytes(size: Int): ByteArray; fun writePacket(packet: ByteArray) }
 class SocketJdwpTransport(private val host: String, private val port: Int, private val timeoutMs: Int = 5_000) : JdwpTransport {
-  private lateinit var socket: Socket
-  private lateinit var input: InputStream
-  private lateinit var output: OutputStream
-
-  override fun connect() {
-    socket = Socket(host, port).also { it.soTimeout = timeoutMs }
-    input = socket.getInputStream()
-    output = socket.getOutputStream()
-  }
-
-  override fun readBytes(size: Int): ByteArray {
-    val buf = ByteArray(size)
-    var off = 0
-    while (off < size) {
-      val read = input.read(buf, off, size - off)
-      if (read == -1) throw EOFException("JDWP stream closed")
-      off += read
-    }
-    return buf
-  }
-
+  private lateinit var socket: Socket; private lateinit var input: InputStream; private lateinit var output: OutputStream
+  override fun connect() { socket = Socket(host, port).also { it.soTimeout = timeoutMs }; input = socket.getInputStream(); output = socket.getOutputStream() }
+  override fun readBytes(size: Int): ByteArray { val b=ByteArray(size); var o=0; while (o<size){ val r=input.read(b,o,size-o); if(r==-1) throw EOFException("JDWP stream closed"); o+=r }; return b }
   override fun writePacket(packet: ByteArray) { output.write(packet); output.flush() }
   override fun close() { if (this::socket.isInitialized) socket.close() }
 }
 
 class JdwpClient(private val transport: JdwpTransport) : AutoCloseable {
-  private val sequence = AtomicInteger(1)
-  private val running = AtomicBoolean(false)
-  private val eventExecutor = Executors.newSingleThreadExecutor()
-  private val pending = ConcurrentHashMap<Int, java.util.concurrent.CompletableFuture<JdwpReplyPacket>>()
+  private val sequence = AtomicInteger(1); private val running = AtomicBoolean(false)
+  private val pumpExecutor = Executors.newSingleThreadExecutor()
+  private val pending = ConcurrentHashMap<Int, CompletableFuture<JdwpReplyPacket>>()
   @Volatile private var eventListener: ((JdwpEventPacket) -> Unit)? = null
+  var idSizes: IdSizes = IdSizes(8,8,8,8,8); private set
 
-  fun connectAndHandshake() {
-    transport.connect()
-    transport.writePacket(JdwpConstants.HANDSHAKE.toByteArray(Charsets.US_ASCII))
-    val response = transport.readBytes(JdwpConstants.HANDSHAKE.length)
-    require(response.toString(Charsets.US_ASCII) == JdwpConstants.HANDSHAKE) { "JDWP handshake failed" }
-    startPump()
-  }
-
+  fun connectAndHandshake() { transport.connect(); transport.writePacket(JdwpConstants.HANDSHAKE.toByteArray(Charsets.US_ASCII)); val r=transport.readBytes(JdwpConstants.HANDSHAKE.length); require(r.toString(Charsets.US_ASCII)==JdwpConstants.HANDSHAKE); startPump(); idSizes = queryIdSizes() }
   fun setEventListener(listener: (JdwpEventPacket) -> Unit) { eventListener = listener }
 
-  fun vmVersion(): VmVersionReply {
-    val reply = sendCommand(1u, 1u)
-    val r = JdwpBuffer.wrap(reply.payload)
-    return VmVersionReply(r.readUtf8(), r.readInt(), r.readInt(), r.readUtf8(), r.readUtf8())
-  }
-
-  fun allThreads(): List<ThreadId> {
-    val reply = sendCommand(1u, 4u)
-    val r = JdwpBuffer.wrap(reply.payload)
-    return (0 until r.readInt()).map { ThreadId(r.readLong()) }
-  }
-
+  fun vmVersion(): VmVersionReply { val x=JdwpBuffer.wrap(sendCommand(1u,1u).payload); return VmVersionReply(x.readUtf8(), x.readInt(), x.readInt(), x.readUtf8(), x.readUtf8()) }
+  fun queryIdSizes(): IdSizes { val x=JdwpBuffer.wrap(sendCommand(1u,7u).payload); return IdSizes(x.readInt(),x.readInt(),x.readInt(),x.readInt(),x.readInt()) }
+  fun allThreads(): List<ThreadId> { val x=JdwpBuffer.wrap(sendCommand(1u,4u).payload); return (0 until x.readInt()).map { ThreadId(x.readId(idSizes.objectIdSize)) } }
   fun threadInfo(threadId: ThreadId): ThreadInfo {
-    val nameReply = sendCommand(11u, 1u, JdwpBuffer.allocate(8).putLong(threadId.raw).toByteArray())
-    val statusReply = sendCommand(11u, 4u, JdwpBuffer.allocate(8).putLong(threadId.raw).toByteArray())
-    val n = JdwpBuffer.wrap(nameReply.payload).readUtf8()
-    val s = JdwpBuffer.wrap(statusReply.payload)
-    return ThreadInfo(n, s.readInt(), s.readInt())
+    val name = JdwpBuffer.wrap(sendCommand(11u,1u,id(threadId.raw,idSizes.objectIdSize)).payload).readUtf8()
+    val st = JdwpBuffer.wrap(sendCommand(11u,4u,id(threadId.raw,idSizes.objectIdSize)).payload)
+    return ThreadInfo(name, st.readInt(), st.readInt())
   }
 
-  fun classesBySignature(signature: String): List<ClassInfo> {
-    val reply = sendCommand(1u, 2u, JdwpBuffer.allocate(signature.toByteArray().size + 4).putUtf8(signature).toByteArray())
-    val r = JdwpBuffer.wrap(reply.payload)
-    return (0 until r.readInt()).map { ClassInfo(r.readByte(), ReferenceTypeId(r.readLong()), r.readInt()) }
-  }
+  fun classesBySignature(signature: String): List<ClassInfo> { val r=JdwpBuffer.wrap(sendCommand(1u,2u,JdwpBuffer.allocate(signature.toByteArray().size+4).putUtf8(signature).toByteArray()).payload); return (0 until r.readInt()).map { ClassInfo(r.readByte(), ReferenceTypeId(r.readId(idSizes.referenceTypeIdSize)), r.readInt()) } }
+  fun methods(typeId: ReferenceTypeId): List<MethodInfo> { val r=JdwpBuffer.wrap(sendCommand(2u,5u,id(typeId.raw,idSizes.referenceTypeIdSize)).payload); return (0 until r.readInt()).map { MethodInfo(MethodId(r.readId(idSizes.methodIdSize)),r.readUtf8(),r.readUtf8(),r.readInt()) } }
+  fun fields(typeId: ReferenceTypeId): List<FieldInfo> { val r=JdwpBuffer.wrap(sendCommand(2u,4u,id(typeId.raw,idSizes.referenceTypeIdSize)).payload); return (0 until r.readInt()).map { FieldInfo(FieldId(r.readId(idSizes.fieldIdSize)),r.readUtf8(),r.readUtf8(),r.readInt()) } }
 
-  fun methods(typeId: ReferenceTypeId): List<MethodInfo> {
-    val reply = sendCommand(2u, 5u, JdwpBuffer.allocate(8).putLong(typeId.raw).toByteArray())
-    val r = JdwpBuffer.wrap(reply.payload)
-    return (0 until r.readInt()).map { MethodInfo(MethodId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt()) }
-  }
-
-  fun fields(typeId: ReferenceTypeId): List<FieldInfo> {
-    val reply = sendCommand(2u, 4u, JdwpBuffer.allocate(8).putLong(typeId.raw).toByteArray())
-    val r = JdwpBuffer.wrap(reply.payload)
-    return (0 until r.readInt()).map { FieldInfo(FieldId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt()) }
-  }
-
-  fun objectReferenceType(objectId: ObjectId): ObjectReferenceInfo {
-    val reply = sendCommand(9u, 1u, JdwpBuffer.allocate(8).putLong(objectId.raw).toByteArray())
-    val r = JdwpBuffer.wrap(reply.payload)
-    return ObjectReferenceInfo(r.readByte(), ReferenceTypeId(r.readLong()))
-  }
-
+  fun objectReferenceType(objectId: ObjectId): ObjectReferenceInfo { val r=JdwpBuffer.wrap(sendCommand(9u,1u,id(objectId.raw,idSizes.objectIdSize)).payload); return ObjectReferenceInfo(r.readByte(), ReferenceTypeId(r.readId(idSizes.referenceTypeIdSize))) }
   fun getObjectValues(objectId: ObjectId, fieldIds: List<FieldId>): List<TaggedValue> {
-    val payload = JdwpBuffer.allocate(8 + 4 + fieldIds.size * 8).putLong(objectId.raw).putInt(fieldIds.size).apply {
-      fieldIds.forEach { putLong(it.raw) }
-    }.toByteArray()
-    val reply = sendCommand(9u, 2u, payload)
-    val r = JdwpBuffer.wrap(reply.payload)
-    return (0 until r.readInt()).map { TaggedValue(r.readByte(), r.readLong()) }
+    val p=JdwpBuffer.allocate(idSizes.objectIdSize+4+fieldIds.size*idSizes.fieldIdSize).putBytes(id(objectId.raw,idSizes.objectIdSize)).putInt(fieldIds.size).apply { fieldIds.forEach { putBytes(id(it.raw,idSizes.fieldIdSize)) } }.toByteArray()
+    val r=JdwpBuffer.wrap(sendCommand(9u,2u,p).payload); return (0 until r.readInt()).map { TaggedValue(r.readByte(), r.readIdByTag(idSizes.objectIdSize)) }
+  }
+  fun setObjectValues(objectId: ObjectId, values: List<ValueToSet>) {
+    val payload = JdwpBuffer.allocate(8192).putBytes(id(objectId.raw,idSizes.objectIdSize)).putInt(values.size).apply { values.forEach { putBytes(id(it.fieldId.raw,idSizes.fieldIdSize)); putByte(it.value.tag); putBytes(id(it.value.rawValue,idSizes.objectIdSize)) } }.toByteArray()
+    sendCommand(9u,3u,payload)
   }
 
-  fun suspendVm() { sendCommand(1u, 8u) }
-  fun resumeVm() { sendCommand(1u, 9u) }
-
-  fun setVmDeathEvent(suspendPolicy: JdwpSuspendPolicy = JdwpSuspendPolicy.NONE): EventRequestId {
-    val payload = JdwpBuffer.allocate(1 + 1 + 4)
-      .putByte(JdwpEventKind.VM_DEATH.code)
-      .putByte(suspendPolicy.code)
-      .putInt(0)
-      .toByteArray()
-    val reply = sendCommand(15u, 1u, payload)
-    return EventRequestId(JdwpBuffer.wrap(reply.payload).readInt())
+  fun invokeMethod(objectId: ObjectId, threadId: ThreadId, classId: ReferenceTypeId, methodId: MethodId, args: List<TaggedValue>, options: Int = 0x01): TaggedValue {
+    val b = JdwpBuffer.allocate(16384).putBytes(id(objectId.raw,idSizes.objectIdSize)).putBytes(id(threadId.raw,idSizes.objectIdSize)).putBytes(id(classId.raw,idSizes.referenceTypeIdSize)).putBytes(id(methodId.raw,idSizes.methodIdSize)).putInt(args.size)
+    args.forEach { b.putByte(it.tag).putBytes(id(it.rawValue, idSizes.objectIdSize)) }
+    val r = JdwpBuffer.wrap(sendCommand(9u,6u,b.putInt(options).toByteArray()).payload)
+    return TaggedValue(r.readByte(), r.readIdByTag(idSizes.objectIdSize))
   }
 
-  fun clearEvent(eventKind: JdwpEventKind, requestId: EventRequestId) {
-    val payload = JdwpBuffer.allocate(1 + 4).putByte(eventKind.code).putInt(requestId.raw).toByteArray()
-    sendCommand(15u, 2u, payload)
+  fun suspendVm() { sendCommand(1u,8u) }; fun resumeVm() { sendCommand(1u,9u) }
+  fun setEvent(eventKind: JdwpEventKind, suspendPolicy: JdwpSuspendPolicy, modifiersPayload: ByteArray = JdwpBuffer.allocate(4).putInt(0).toByteArray()): EventRequestId {
+    val p = JdwpBuffer.allocate(2 + modifiersPayload.size).putByte(eventKind.code).putByte(suspendPolicy.code).putBytes(modifiersPayload).toByteArray(); return EventRequestId(JdwpBuffer.wrap(sendCommand(15u,1u,p).payload).readInt())
   }
+  fun clearEvent(eventKind: JdwpEventKind, requestId: EventRequestId) { sendCommand(15u,2u,JdwpBuffer.allocate(5).putByte(eventKind.code).putInt(requestId.raw).toByteArray()) }
 
   fun sendCommand(commandSet: UByte, command: UByte, payload: ByteArray = byteArrayOf()): JdwpReplyPacket {
-    val id = sequence.getAndIncrement()
-    val future = java.util.concurrent.CompletableFuture<JdwpReplyPacket>()
-    pending[id] = future
-    transport.writePacket(JdwpCodec.encodeCommand(JdwpCommandPacket(id, commandSet, command, payload)))
-    val reply = future.get()
-    JdwpErrors.throwIfError(reply.errorCode)
-    return reply
+    val id = sequence.getAndIncrement(); val f = CompletableFuture<JdwpReplyPacket>(); pending[id] = f
+    transport.writePacket(JdwpCodec.encodeCommand(JdwpCommandPacket(id,commandSet,command,payload))); val rep = f.get(); JdwpErrors.throwIfError(rep.errorCode); return rep
   }
 
-  private fun startPump() {
-    if (!running.compareAndSet(false, true)) return
-    eventExecutor.execute {
-      while (running.get()) {
-        val packet = JdwpCodec.readPacket(transport)
-        when (packet) {
-          is JdwpReplyPacket -> pending.remove(packet.id)?.complete(packet)
-          is JdwpEventPacket -> eventListener?.invoke(packet)
-        }
-      }
-    }
-  }
-
-  override fun close() {
-    running.set(false)
-    eventExecutor.shutdownNow()
-    transport.close()
-  }
+  private fun startPump() { if (!running.compareAndSet(false,true)) return; pumpExecutor.execute { while (running.get()) { when (val p = JdwpCodec.readPacket(transport)) { is JdwpReplyPacket -> pending.remove(p.id)?.complete(p); is JdwpEventPacket -> eventListener?.invoke(p) } } } }
+  private fun id(v: Long, size: Int): ByteArray = JdwpBuffer.allocate(size).apply { if (size==8) putLong(v) else putInt(v.toInt()) }.toByteArray()
+  override fun close() { running.set(false); pumpExecutor.shutdownNow(); transport.close() }
 }
 
 object JdwpCodec {
-  fun encodeCommand(packet: JdwpCommandPacket): ByteArray {
-    val totalLength = 11 + packet.payload.size
-    return JdwpBuffer.allocate(totalLength)
-      .putInt(totalLength)
-      .putInt(packet.id)
-      .putByte(0)
-      .putByte(packet.commandSet.toByte())
-      .putByte(packet.command.toByte())
-      .putBytes(packet.payload)
-      .toByteArray()
-  }
-
+  fun encodeCommand(packet: JdwpCommandPacket): ByteArray = JdwpBuffer.allocate(11 + packet.payload.size).putInt(11 + packet.payload.size).putInt(packet.id).putByte(0).putByte(packet.commandSet.toByte()).putByte(packet.command.toByte()).putBytes(packet.payload).toByteArray()
   fun readPacket(transport: JdwpTransport): Any {
-    val header = transport.readBytes(11)
-    val h = JdwpBuffer.wrap(header)
-    val len = h.readInt()
-    val id = h.readInt()
-    val flags = h.readByte().toUByte()
-    val rest = transport.readBytes(len - 11)
-    return if ((flags.toInt() and JdwpConstants.REPLY_FLAG.toInt()) != 0) {
-      val e = JdwpBuffer.wrap(header.copyOfRange(9, 11)).readShort().toUShort()
-      JdwpReplyPacket(id, e, rest)
-    } else {
-      JdwpEventPacket(id, header[9].toUByte(), header[10].toUByte(), rest)
-    }
+    val h = transport.readBytes(11); val b = JdwpBuffer.wrap(h); val len=b.readInt(); val id=b.readInt(); val flags=b.readByte().toUByte(); val body=transport.readBytes(len-11)
+    return if ((flags.toInt() and JdwpConstants.REPLY_FLAG.toInt()) != 0) JdwpReplyPacket(id, JdwpBuffer.wrap(h.copyOfRange(9,11)).readShort().toUShort(), body) else JdwpEventPacket(id, h[9].toUByte(), h[10].toUByte(), body)
   }
 }
+
+private fun JdwpBuffer.readId(size: Int): Long = if (size == 8) readLong() else readInt().toLong() and 0xffffffffL
+private fun JdwpBuffer.readIdByTag(objectSize: Int): Long = if (remaining() >= objectSize) readId(objectSize) else readLong()

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
@@ -1,0 +1,144 @@
+package com.zerostudio.jdwp
+
+import java.io.EOFException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+interface JdwpTransport : AutoCloseable {
+  fun connect()
+  fun readPacket(): ByteArray
+  fun writePacket(packet: ByteArray)
+}
+
+class SocketJdwpTransport(
+  private val host: String,
+  private val port: Int,
+  private val timeoutMs: Int = 5_000,
+) : JdwpTransport {
+  private lateinit var socket: Socket
+  private lateinit var input: InputStream
+  private lateinit var output: OutputStream
+
+  override fun connect() {
+    socket = Socket(host, port).also { it.soTimeout = timeoutMs }
+    input = socket.getInputStream()
+    output = socket.getOutputStream()
+  }
+
+  override fun readPacket(): ByteArray {
+    val header = ByteArray(11)
+    readFully(input, header)
+    val len = JdwpBuffer.wrap(header).readInt()
+    val payload = ByteArray(len - 11)
+    readFully(input, payload)
+    return header + payload
+  }
+
+  override fun writePacket(packet: ByteArray) {
+    output.write(packet)
+    output.flush()
+  }
+
+  override fun close() {
+    if (this::socket.isInitialized) socket.close()
+  }
+
+  private fun readFully(input: InputStream, buf: ByteArray) {
+    var off = 0
+    while (off < buf.size) {
+      val read = input.read(buf, off, buf.size - off)
+      if (read == -1) throw EOFException("JDWP stream closed")
+      off += read
+    }
+  }
+}
+
+class JdwpClient(private val transport: JdwpTransport) : AutoCloseable {
+  private val sequence = AtomicInteger(1)
+  private val pendingReplies = ConcurrentHashMap<Int, JdwpReplyPacket>()
+
+  fun connectAndHandshake() {
+    transport.connect()
+    transport.writePacket(JdwpConstants.HANDSHAKE.toByteArray(Charsets.US_ASCII))
+    val response = transport.readPacket()
+    val text = response.toString(Charsets.US_ASCII)
+    require(text == JdwpConstants.HANDSHAKE) { "JDWP handshake failed: $text" }
+  }
+
+  fun sendCommand(commandSet: UByte, command: UByte, payload: ByteArray = byteArrayOf()): JdwpReplyPacket {
+    val id = sequence.getAndIncrement()
+    val packet = JdwpCodec.encodeCommand(JdwpCommandPacket(id, commandSet, command, payload))
+    transport.writePacket(packet)
+    val reply = JdwpCodec.decodeReply(transport.readPacket())
+    pendingReplies[id] = reply
+    return reply
+  }
+
+  fun vmVersion(): VmVersionReply {
+    val reply = sendCommand(1u, 1u)
+    JdwpErrors.throwIfError(reply.errorCode)
+    val r = JdwpBuffer.wrap(reply.payload)
+    return VmVersionReply(r.readUtf8(), r.readInt(), r.readInt(), r.readUtf8(), r.readUtf8())
+  }
+
+  fun classesBySignature(signature: String): List<ClassInfo> {
+    val payload = JdwpBuffer.allocate(signature.length + 8).putUtf8(signature).toByteArray()
+    val reply = sendCommand(1u, 2u, payload)
+    JdwpErrors.throwIfError(reply.errorCode)
+    val reader = JdwpBuffer.wrap(reply.payload)
+    val count = reader.readInt()
+    return (0 until count).map {
+      ClassInfo(reader.readByte(), ReferenceTypeId(reader.readLong()), reader.readInt())
+    }
+  }
+
+  fun methods(typeId: ReferenceTypeId): List<MethodInfo> {
+    val reply = sendCommand(2u, 5u, JdwpBuffer.allocate(8).putLong(typeId.raw).toByteArray())
+    JdwpErrors.throwIfError(reply.errorCode)
+    val r = JdwpBuffer.wrap(reply.payload)
+    val count = r.readInt()
+    return (0 until count).map {
+      MethodInfo(MethodId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt())
+    }
+  }
+
+  fun fields(typeId: ReferenceTypeId): List<FieldInfo> {
+    val reply = sendCommand(2u, 4u, JdwpBuffer.allocate(8).putLong(typeId.raw).toByteArray())
+    JdwpErrors.throwIfError(reply.errorCode)
+    val r = JdwpBuffer.wrap(reply.payload)
+    val count = r.readInt()
+    return (0 until count).map {
+      FieldInfo(FieldId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt())
+    }
+  }
+
+  override fun close() = transport.close()
+}
+
+object JdwpCodec {
+  fun encodeCommand(packet: JdwpCommandPacket): ByteArray {
+    val totalLength = 11 + packet.payload.size
+    val out = JdwpBuffer.allocate(totalLength)
+    out.putInt(totalLength)
+      .putInt(packet.id)
+      .putByte(0)
+      .putByte(packet.commandSet.toByte())
+      .putByte(packet.command.toByte())
+    packet.payload.forEach(out::putByte)
+    return out.toByteArray()
+  }
+
+  fun decodeReply(bytes: ByteArray): JdwpReplyPacket {
+    val r = JdwpBuffer.wrap(bytes)
+    r.readInt()
+    val id = r.readInt()
+    r.readByte()
+    val error = ((r.readByte().toInt() and 0xFF) shl 8 or (r.readByte().toInt() and 0xFF)).toUShort()
+    val payload = ByteArray(bytes.size - 11)
+    System.arraycopy(bytes, 11, payload, 0, payload.size)
+    return JdwpReplyPacket(id, error, payload)
+  }
+}

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
@@ -5,19 +5,17 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 interface JdwpTransport : AutoCloseable {
   fun connect()
-  fun readPacket(): ByteArray
+  fun readBytes(size: Int): ByteArray
   fun writePacket(packet: ByteArray)
 }
 
-class SocketJdwpTransport(
-  private val host: String,
-  private val port: Int,
-  private val timeoutMs: Int = 5_000,
-) : JdwpTransport {
+class SocketJdwpTransport(private val host: String, private val port: Int, private val timeoutMs: Int = 5_000) : JdwpTransport {
   private lateinit var socket: Socket
   private lateinit var input: InputStream
   private lateinit var output: OutputStream
@@ -28,117 +26,164 @@ class SocketJdwpTransport(
     output = socket.getOutputStream()
   }
 
-  override fun readPacket(): ByteArray {
-    val header = ByteArray(11)
-    readFully(input, header)
-    val len = JdwpBuffer.wrap(header).readInt()
-    val payload = ByteArray(len - 11)
-    readFully(input, payload)
-    return header + payload
-  }
-
-  override fun writePacket(packet: ByteArray) {
-    output.write(packet)
-    output.flush()
-  }
-
-  override fun close() {
-    if (this::socket.isInitialized) socket.close()
-  }
-
-  private fun readFully(input: InputStream, buf: ByteArray) {
+  override fun readBytes(size: Int): ByteArray {
+    val buf = ByteArray(size)
     var off = 0
-    while (off < buf.size) {
-      val read = input.read(buf, off, buf.size - off)
+    while (off < size) {
+      val read = input.read(buf, off, size - off)
       if (read == -1) throw EOFException("JDWP stream closed")
       off += read
     }
+    return buf
   }
+
+  override fun writePacket(packet: ByteArray) { output.write(packet); output.flush() }
+  override fun close() { if (this::socket.isInitialized) socket.close() }
 }
 
 class JdwpClient(private val transport: JdwpTransport) : AutoCloseable {
   private val sequence = AtomicInteger(1)
-  private val pendingReplies = ConcurrentHashMap<Int, JdwpReplyPacket>()
+  private val running = AtomicBoolean(false)
+  private val eventExecutor = Executors.newSingleThreadExecutor()
+  private val pending = ConcurrentHashMap<Int, java.util.concurrent.CompletableFuture<JdwpReplyPacket>>()
+  @Volatile private var eventListener: ((JdwpEventPacket) -> Unit)? = null
 
   fun connectAndHandshake() {
     transport.connect()
     transport.writePacket(JdwpConstants.HANDSHAKE.toByteArray(Charsets.US_ASCII))
-    val response = transport.readPacket()
-    val text = response.toString(Charsets.US_ASCII)
-    require(text == JdwpConstants.HANDSHAKE) { "JDWP handshake failed: $text" }
+    val response = transport.readBytes(JdwpConstants.HANDSHAKE.length)
+    require(response.toString(Charsets.US_ASCII) == JdwpConstants.HANDSHAKE) { "JDWP handshake failed" }
+    startPump()
   }
 
-  fun sendCommand(commandSet: UByte, command: UByte, payload: ByteArray = byteArrayOf()): JdwpReplyPacket {
-    val id = sequence.getAndIncrement()
-    val packet = JdwpCodec.encodeCommand(JdwpCommandPacket(id, commandSet, command, payload))
-    transport.writePacket(packet)
-    val reply = JdwpCodec.decodeReply(transport.readPacket())
-    pendingReplies[id] = reply
-    return reply
-  }
+  fun setEventListener(listener: (JdwpEventPacket) -> Unit) { eventListener = listener }
 
   fun vmVersion(): VmVersionReply {
     val reply = sendCommand(1u, 1u)
-    JdwpErrors.throwIfError(reply.errorCode)
     val r = JdwpBuffer.wrap(reply.payload)
     return VmVersionReply(r.readUtf8(), r.readInt(), r.readInt(), r.readUtf8(), r.readUtf8())
   }
 
+  fun allThreads(): List<ThreadId> {
+    val reply = sendCommand(1u, 4u)
+    val r = JdwpBuffer.wrap(reply.payload)
+    return (0 until r.readInt()).map { ThreadId(r.readLong()) }
+  }
+
+  fun threadInfo(threadId: ThreadId): ThreadInfo {
+    val nameReply = sendCommand(11u, 1u, JdwpBuffer.allocate(8).putLong(threadId.raw).toByteArray())
+    val statusReply = sendCommand(11u, 4u, JdwpBuffer.allocate(8).putLong(threadId.raw).toByteArray())
+    val n = JdwpBuffer.wrap(nameReply.payload).readUtf8()
+    val s = JdwpBuffer.wrap(statusReply.payload)
+    return ThreadInfo(n, s.readInt(), s.readInt())
+  }
+
   fun classesBySignature(signature: String): List<ClassInfo> {
-    val payload = JdwpBuffer.allocate(signature.length + 8).putUtf8(signature).toByteArray()
-    val reply = sendCommand(1u, 2u, payload)
-    JdwpErrors.throwIfError(reply.errorCode)
-    val reader = JdwpBuffer.wrap(reply.payload)
-    val count = reader.readInt()
-    return (0 until count).map {
-      ClassInfo(reader.readByte(), ReferenceTypeId(reader.readLong()), reader.readInt())
-    }
+    val reply = sendCommand(1u, 2u, JdwpBuffer.allocate(signature.toByteArray().size + 4).putUtf8(signature).toByteArray())
+    val r = JdwpBuffer.wrap(reply.payload)
+    return (0 until r.readInt()).map { ClassInfo(r.readByte(), ReferenceTypeId(r.readLong()), r.readInt()) }
   }
 
   fun methods(typeId: ReferenceTypeId): List<MethodInfo> {
     val reply = sendCommand(2u, 5u, JdwpBuffer.allocate(8).putLong(typeId.raw).toByteArray())
-    JdwpErrors.throwIfError(reply.errorCode)
     val r = JdwpBuffer.wrap(reply.payload)
-    val count = r.readInt()
-    return (0 until count).map {
-      MethodInfo(MethodId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt())
-    }
+    return (0 until r.readInt()).map { MethodInfo(MethodId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt()) }
   }
 
   fun fields(typeId: ReferenceTypeId): List<FieldInfo> {
     val reply = sendCommand(2u, 4u, JdwpBuffer.allocate(8).putLong(typeId.raw).toByteArray())
-    JdwpErrors.throwIfError(reply.errorCode)
     val r = JdwpBuffer.wrap(reply.payload)
-    val count = r.readInt()
-    return (0 until count).map {
-      FieldInfo(FieldId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt())
+    return (0 until r.readInt()).map { FieldInfo(FieldId(r.readLong()), r.readUtf8(), r.readUtf8(), r.readInt()) }
+  }
+
+  fun objectReferenceType(objectId: ObjectId): ObjectReferenceInfo {
+    val reply = sendCommand(9u, 1u, JdwpBuffer.allocate(8).putLong(objectId.raw).toByteArray())
+    val r = JdwpBuffer.wrap(reply.payload)
+    return ObjectReferenceInfo(r.readByte(), ReferenceTypeId(r.readLong()))
+  }
+
+  fun getObjectValues(objectId: ObjectId, fieldIds: List<FieldId>): List<TaggedValue> {
+    val payload = JdwpBuffer.allocate(8 + 4 + fieldIds.size * 8).putLong(objectId.raw).putInt(fieldIds.size).apply {
+      fieldIds.forEach { putLong(it.raw) }
+    }.toByteArray()
+    val reply = sendCommand(9u, 2u, payload)
+    val r = JdwpBuffer.wrap(reply.payload)
+    return (0 until r.readInt()).map { TaggedValue(r.readByte(), r.readLong()) }
+  }
+
+  fun suspendVm() { sendCommand(1u, 8u) }
+  fun resumeVm() { sendCommand(1u, 9u) }
+
+  fun setVmDeathEvent(suspendPolicy: JdwpSuspendPolicy = JdwpSuspendPolicy.NONE): EventRequestId {
+    val payload = JdwpBuffer.allocate(1 + 1 + 4)
+      .putByte(JdwpEventKind.VM_DEATH.code)
+      .putByte(suspendPolicy.code)
+      .putInt(0)
+      .toByteArray()
+    val reply = sendCommand(15u, 1u, payload)
+    return EventRequestId(JdwpBuffer.wrap(reply.payload).readInt())
+  }
+
+  fun clearEvent(eventKind: JdwpEventKind, requestId: EventRequestId) {
+    val payload = JdwpBuffer.allocate(1 + 4).putByte(eventKind.code).putInt(requestId.raw).toByteArray()
+    sendCommand(15u, 2u, payload)
+  }
+
+  fun sendCommand(commandSet: UByte, command: UByte, payload: ByteArray = byteArrayOf()): JdwpReplyPacket {
+    val id = sequence.getAndIncrement()
+    val future = java.util.concurrent.CompletableFuture<JdwpReplyPacket>()
+    pending[id] = future
+    transport.writePacket(JdwpCodec.encodeCommand(JdwpCommandPacket(id, commandSet, command, payload)))
+    val reply = future.get()
+    JdwpErrors.throwIfError(reply.errorCode)
+    return reply
+  }
+
+  private fun startPump() {
+    if (!running.compareAndSet(false, true)) return
+    eventExecutor.execute {
+      while (running.get()) {
+        val packet = JdwpCodec.readPacket(transport)
+        when (packet) {
+          is JdwpReplyPacket -> pending.remove(packet.id)?.complete(packet)
+          is JdwpEventPacket -> eventListener?.invoke(packet)
+        }
+      }
     }
   }
 
-  override fun close() = transport.close()
+  override fun close() {
+    running.set(false)
+    eventExecutor.shutdownNow()
+    transport.close()
+  }
 }
 
 object JdwpCodec {
   fun encodeCommand(packet: JdwpCommandPacket): ByteArray {
     val totalLength = 11 + packet.payload.size
-    val out = JdwpBuffer.allocate(totalLength)
-    out.putInt(totalLength)
+    return JdwpBuffer.allocate(totalLength)
+      .putInt(totalLength)
       .putInt(packet.id)
       .putByte(0)
       .putByte(packet.commandSet.toByte())
       .putByte(packet.command.toByte())
-    packet.payload.forEach(out::putByte)
-    return out.toByteArray()
+      .putBytes(packet.payload)
+      .toByteArray()
   }
 
-  fun decodeReply(bytes: ByteArray): JdwpReplyPacket {
-    val r = JdwpBuffer.wrap(bytes)
-    r.readInt()
-    val id = r.readInt()
-    r.readByte()
-    val error = ((r.readByte().toInt() and 0xFF) shl 8 or (r.readByte().toInt() and 0xFF)).toUShort()
-    val payload = ByteArray(bytes.size - 11)
-    System.arraycopy(bytes, 11, payload, 0, payload.size)
-    return JdwpReplyPacket(id, error, payload)
+  fun readPacket(transport: JdwpTransport): Any {
+    val header = transport.readBytes(11)
+    val h = JdwpBuffer.wrap(header)
+    val len = h.readInt()
+    val id = h.readInt()
+    val flags = h.readByte().toUByte()
+    val rest = transport.readBytes(len - 11)
+    return if ((flags.toInt() and JdwpConstants.REPLY_FLAG.toInt()) != 0) {
+      val e = JdwpBuffer.wrap(header.copyOfRange(9, 11)).readShort().toUShort()
+      JdwpReplyPacket(id, e, rest)
+    } else {
+      JdwpEventPacket(id, header[9].toUByte(), header[10].toUByte(), rest)
+    }
   }
 }

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpProtocol.kt
@@ -7,6 +7,8 @@ import java.net.Socket
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -21,66 +23,68 @@ class SocketJdwpTransport(private val host: String, private val port: Int, priva
 
 class JdwpClient(private val transport: JdwpTransport) : AutoCloseable {
   private val sequence = AtomicInteger(1); private val running = AtomicBoolean(false)
-  private val pumpExecutor = Executors.newSingleThreadExecutor()
+  private val pumpExecutor = Executors.newSingleThreadExecutor(); private val heartbeatExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
   private val pending = ConcurrentHashMap<Int, CompletableFuture<JdwpReplyPacket>>()
   @Volatile private var eventListener: ((JdwpEventPacket) -> Unit)? = null
+  @Volatile private var disconnectedListener: ((Throwable) -> Unit)? = null
   var idSizes: IdSizes = IdSizes(8,8,8,8,8); private set
 
-  fun connectAndHandshake() { transport.connect(); transport.writePacket(JdwpConstants.HANDSHAKE.toByteArray(Charsets.US_ASCII)); val r=transport.readBytes(JdwpConstants.HANDSHAKE.length); require(r.toString(Charsets.US_ASCII)==JdwpConstants.HANDSHAKE); startPump(); idSizes = queryIdSizes() }
+  fun connectAndHandshake(enableHeartbeat: Boolean = true, heartbeatSeconds: Long = 5) {
+    transport.connect(); transport.writePacket(JdwpConstants.HANDSHAKE.toByteArray(Charsets.US_ASCII)); val r=transport.readBytes(JdwpConstants.HANDSHAKE.length); require(r.toString(Charsets.US_ASCII)==JdwpConstants.HANDSHAKE)
+    startPump(); idSizes = queryIdSizes(); if (enableHeartbeat) startHeartbeat(heartbeatSeconds)
+  }
   fun setEventListener(listener: (JdwpEventPacket) -> Unit) { eventListener = listener }
+  fun setDisconnectedListener(listener: (Throwable) -> Unit) { disconnectedListener = listener }
 
   fun vmVersion(): VmVersionReply { val x=JdwpBuffer.wrap(sendCommand(1u,1u).payload); return VmVersionReply(x.readUtf8(), x.readInt(), x.readInt(), x.readUtf8(), x.readUtf8()) }
   fun queryIdSizes(): IdSizes { val x=JdwpBuffer.wrap(sendCommand(1u,7u).payload); return IdSizes(x.readInt(),x.readInt(),x.readInt(),x.readInt(),x.readInt()) }
   fun allThreads(): List<ThreadId> { val x=JdwpBuffer.wrap(sendCommand(1u,4u).payload); return (0 until x.readInt()).map { ThreadId(x.readId(idSizes.objectIdSize)) } }
-  fun threadInfo(threadId: ThreadId): ThreadInfo {
-    val name = JdwpBuffer.wrap(sendCommand(11u,1u,id(threadId.raw,idSizes.objectIdSize)).payload).readUtf8()
-    val st = JdwpBuffer.wrap(sendCommand(11u,4u,id(threadId.raw,idSizes.objectIdSize)).payload)
-    return ThreadInfo(name, st.readInt(), st.readInt())
+  fun allClasses(): List<JdwpClassRef> { val x=JdwpBuffer.wrap(sendCommand(1u,3u).payload); return (0 until x.readInt()).map { x.readByte(); val id = ReferenceTypeId(x.readId(idSizes.referenceTypeIdSize)); val sig=x.readUtf8(); x.readInt(); JdwpClassRef(id, sig) } }
+
+  fun threadInfo(threadId: ThreadId): ThreadInfo { val name = JdwpBuffer.wrap(sendCommand(11u,1u,id(threadId.raw,idSizes.objectIdSize)).payload).readUtf8(); val st = JdwpBuffer.wrap(sendCommand(11u,4u,id(threadId.raw,idSizes.objectIdSize)).payload); return ThreadInfo(name, st.readInt(), st.readInt()) }
+  fun suspendThread(threadId: ThreadId) { sendCommand(11u,2u,id(threadId.raw,idSizes.objectIdSize)) }
+  fun resumeThread(threadId: ThreadId) { sendCommand(11u,3u,id(threadId.raw,idSizes.objectIdSize)) }
+  fun frames(threadId: ThreadId, start: Int = 0, length: Int = -1): List<FrameInfo> {
+    val p=JdwpBuffer.allocate(idSizes.objectIdSize+8).putBytes(id(threadId.raw,idSizes.objectIdSize)).putInt(start).putInt(length).toByteArray(); val r=JdwpBuffer.wrap(sendCommand(11u,6u,p).payload)
+    return (0 until r.readInt()).map { FrameInfo(FrameId(r.readId(idSizes.frameIdSize)), r.readByte(), ReferenceTypeId(r.readId(idSizes.referenceTypeIdSize)), MethodId(r.readId(idSizes.methodIdSize)), r.readLong()) }
   }
 
   fun classesBySignature(signature: String): List<ClassInfo> { val r=JdwpBuffer.wrap(sendCommand(1u,2u,JdwpBuffer.allocate(signature.toByteArray().size+4).putUtf8(signature).toByteArray()).payload); return (0 until r.readInt()).map { ClassInfo(r.readByte(), ReferenceTypeId(r.readId(idSizes.referenceTypeIdSize)), r.readInt()) } }
   fun methods(typeId: ReferenceTypeId): List<MethodInfo> { val r=JdwpBuffer.wrap(sendCommand(2u,5u,id(typeId.raw,idSizes.referenceTypeIdSize)).payload); return (0 until r.readInt()).map { MethodInfo(MethodId(r.readId(idSizes.methodIdSize)),r.readUtf8(),r.readUtf8(),r.readInt()) } }
+  fun methodsByName(typeId: ReferenceTypeId, name: String, signature: String? = null): List<MethodInfo> = methods(typeId).filter { it.name == name && (signature == null || signature == it.signature) }
   fun fields(typeId: ReferenceTypeId): List<FieldInfo> { val r=JdwpBuffer.wrap(sendCommand(2u,4u,id(typeId.raw,idSizes.referenceTypeIdSize)).payload); return (0 until r.readInt()).map { FieldInfo(FieldId(r.readId(idSizes.fieldIdSize)),r.readUtf8(),r.readUtf8(),r.readInt()) } }
 
   fun objectReferenceType(objectId: ObjectId): ObjectReferenceInfo { val r=JdwpBuffer.wrap(sendCommand(9u,1u,id(objectId.raw,idSizes.objectIdSize)).payload); return ObjectReferenceInfo(r.readByte(), ReferenceTypeId(r.readId(idSizes.referenceTypeIdSize))) }
-  fun getObjectValues(objectId: ObjectId, fieldIds: List<FieldId>): List<TaggedValue> {
-    val p=JdwpBuffer.allocate(idSizes.objectIdSize+4+fieldIds.size*idSizes.fieldIdSize).putBytes(id(objectId.raw,idSizes.objectIdSize)).putInt(fieldIds.size).apply { fieldIds.forEach { putBytes(id(it.raw,idSizes.fieldIdSize)) } }.toByteArray()
-    val r=JdwpBuffer.wrap(sendCommand(9u,2u,p).payload); return (0 until r.readInt()).map { TaggedValue(r.readByte(), r.readIdByTag(idSizes.objectIdSize)) }
-  }
-  fun setObjectValues(objectId: ObjectId, values: List<ValueToSet>) {
-    val payload = JdwpBuffer.allocate(8192).putBytes(id(objectId.raw,idSizes.objectIdSize)).putInt(values.size).apply { values.forEach { putBytes(id(it.fieldId.raw,idSizes.fieldIdSize)); putByte(it.value.tag); putBytes(id(it.value.rawValue,idSizes.objectIdSize)) } }.toByteArray()
-    sendCommand(9u,3u,payload)
-  }
-
-  fun invokeMethod(objectId: ObjectId, threadId: ThreadId, classId: ReferenceTypeId, methodId: MethodId, args: List<TaggedValue>, options: Int = 0x01): TaggedValue {
+  fun disableCollection(objectId: ObjectId) { sendCommand(9u,7u,id(objectId.raw,idSizes.objectIdSize)) }
+  fun enableCollection(objectId: ObjectId) { sendCommand(9u,8u,id(objectId.raw,idSizes.objectIdSize)) }
+  fun getObjectValues(objectId: ObjectId, fieldIds: List<FieldId>): List<TaggedValue> { val p=JdwpBuffer.allocate(idSizes.objectIdSize+4+fieldIds.size*idSizes.fieldIdSize).putBytes(id(objectId.raw,idSizes.objectIdSize)).putInt(fieldIds.size).apply { fieldIds.forEach { putBytes(id(it.raw,idSizes.fieldIdSize)) } }.toByteArray(); val r=JdwpBuffer.wrap(sendCommand(9u,2u,p).payload); return (0 until r.readInt()).map { TaggedValue(r.readByte(), r.readIdByTag(idSizes.objectIdSize)) } }
+  fun setObjectValues(objectId: ObjectId, values: List<ValueToSet>) { val payload = JdwpBuffer.allocate(8192).putBytes(id(objectId.raw,idSizes.objectIdSize)).putInt(values.size).apply { values.forEach { putBytes(id(it.fieldId.raw,idSizes.fieldIdSize)); putByte(it.value.tag); putBytes(id(it.value.rawValue,idSizes.objectIdSize)) } }.toByteArray(); sendCommand(9u,3u,payload) }
+  fun invokeMethod(objectId: ObjectId, threadId: ThreadId, classId: ReferenceTypeId, methodId: MethodId, args: List<TaggedValue>, options: Int = 0x01): InvokeResult {
     val b = JdwpBuffer.allocate(16384).putBytes(id(objectId.raw,idSizes.objectIdSize)).putBytes(id(threadId.raw,idSizes.objectIdSize)).putBytes(id(classId.raw,idSizes.referenceTypeIdSize)).putBytes(id(methodId.raw,idSizes.methodIdSize)).putInt(args.size)
     args.forEach { b.putByte(it.tag).putBytes(id(it.rawValue, idSizes.objectIdSize)) }
     val r = JdwpBuffer.wrap(sendCommand(9u,6u,b.putInt(options).toByteArray()).payload)
-    return TaggedValue(r.readByte(), r.readIdByTag(idSizes.objectIdSize))
+    val ret = TaggedValue(r.readByte(), r.readIdByTag(idSizes.objectIdSize)); val ex = r.readId(idSizes.objectIdSize)
+    return InvokeResult(ret, if (ex == 0L) null else ObjectId(ex))
   }
 
   fun suspendVm() { sendCommand(1u,8u) }; fun resumeVm() { sendCommand(1u,9u) }
-  fun setEvent(eventKind: JdwpEventKind, suspendPolicy: JdwpSuspendPolicy, modifiersPayload: ByteArray = JdwpBuffer.allocate(4).putInt(0).toByteArray()): EventRequestId {
-    val p = JdwpBuffer.allocate(2 + modifiersPayload.size).putByte(eventKind.code).putByte(suspendPolicy.code).putBytes(modifiersPayload).toByteArray(); return EventRequestId(JdwpBuffer.wrap(sendCommand(15u,1u,p).payload).readInt())
-  }
+  fun setEvent(eventKind: JdwpEventKind, suspendPolicy: JdwpSuspendPolicy, modifiersPayload: ByteArray = JdwpBuffer.allocate(4).putInt(0).toByteArray()): EventRequestId { val p = JdwpBuffer.allocate(2 + modifiersPayload.size).putByte(eventKind.code).putByte(suspendPolicy.code).putBytes(modifiersPayload).toByteArray(); return EventRequestId(JdwpBuffer.wrap(sendCommand(15u,1u,p).payload).readInt()) }
   fun clearEvent(eventKind: JdwpEventKind, requestId: EventRequestId) { sendCommand(15u,2u,JdwpBuffer.allocate(5).putByte(eventKind.code).putInt(requestId.raw).toByteArray()) }
 
   fun sendCommand(commandSet: UByte, command: UByte, payload: ByteArray = byteArrayOf()): JdwpReplyPacket {
     val id = sequence.getAndIncrement(); val f = CompletableFuture<JdwpReplyPacket>(); pending[id] = f
-    transport.writePacket(JdwpCodec.encodeCommand(JdwpCommandPacket(id,commandSet,command,payload))); val rep = f.get(); JdwpErrors.throwIfError(rep.errorCode); return rep
+    transport.writePacket(JdwpCodec.encodeCommand(JdwpCommandPacket(id,commandSet,command,payload))); val rep = f.get(10, TimeUnit.SECONDS); JdwpErrors.throwIfError(rep.errorCode); return rep
   }
 
-  private fun startPump() { if (!running.compareAndSet(false,true)) return; pumpExecutor.execute { while (running.get()) { when (val p = JdwpCodec.readPacket(transport)) { is JdwpReplyPacket -> pending.remove(p.id)?.complete(p); is JdwpEventPacket -> eventListener?.invoke(p) } } } }
+  private fun startPump() { if (!running.compareAndSet(false,true)) return; pumpExecutor.execute { try { while (running.get()) { when (val p = JdwpCodec.readPacket(transport)) { is JdwpReplyPacket -> pending.remove(p.id)?.complete(p); is JdwpEventPacket -> eventListener?.invoke(p) } } } catch (t: Throwable) { running.set(false); disconnectedListener?.invoke(t) } } }
+  private fun startHeartbeat(seconds: Long) { heartbeatExecutor.scheduleAtFixedRate({ if (running.get()) runCatching { vmVersion() }.onFailure { disconnectedListener?.invoke(it); close() } }, seconds, seconds, TimeUnit.SECONDS) }
   private fun id(v: Long, size: Int): ByteArray = JdwpBuffer.allocate(size).apply { if (size==8) putLong(v) else putInt(v.toInt()) }.toByteArray()
-  override fun close() { running.set(false); pumpExecutor.shutdownNow(); transport.close() }
+  override fun close() { running.set(false); heartbeatExecutor.shutdownNow(); pumpExecutor.shutdownNow(); transport.close() }
 }
 
 object JdwpCodec {
   fun encodeCommand(packet: JdwpCommandPacket): ByteArray = JdwpBuffer.allocate(11 + packet.payload.size).putInt(11 + packet.payload.size).putInt(packet.id).putByte(0).putByte(packet.commandSet.toByte()).putByte(packet.command.toByte()).putBytes(packet.payload).toByteArray()
-  fun readPacket(transport: JdwpTransport): Any {
-    val h = transport.readBytes(11); val b = JdwpBuffer.wrap(h); val len=b.readInt(); val id=b.readInt(); val flags=b.readByte().toUByte(); val body=transport.readBytes(len-11)
-    return if ((flags.toInt() and JdwpConstants.REPLY_FLAG.toInt()) != 0) JdwpReplyPacket(id, JdwpBuffer.wrap(h.copyOfRange(9,11)).readShort().toUShort(), body) else JdwpEventPacket(id, h[9].toUByte(), h[10].toUByte(), body)
-  }
+  fun readPacket(transport: JdwpTransport): Any { val h = transport.readBytes(11); val b = JdwpBuffer.wrap(h); val len=b.readInt(); val id=b.readInt(); val flags=b.readByte().toUByte(); val body=transport.readBytes(len-11); return if ((flags.toInt() and JdwpConstants.REPLY_FLAG.toInt()) != 0) JdwpReplyPacket(id, JdwpBuffer.wrap(h.copyOfRange(9,11)).readShort().toUShort(), body) else JdwpEventPacket(id, h[9].toUByte(), h[10].toUByte(), body) }
 }
 
 private fun JdwpBuffer.readId(size: Int): Long = if (size == 8) readLong() else readInt().toLong() and 0xffffffffL

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpTypes.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpTypes.kt
@@ -1,0 +1,71 @@
+package com.zerostudio.jdwp
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+@JvmInline value class ObjectId(val raw: Long)
+@JvmInline value class ReferenceTypeId(val raw: Long)
+@JvmInline value class MethodId(val raw: Long)
+@JvmInline value class FieldId(val raw: Long)
+@JvmInline value class ThreadId(val raw: Long)
+
+object JdwpConstants {
+  const val HANDSHAKE = "JDWP-Handshake"
+}
+
+data class JdwpPacketHeader(
+  val length: Int,
+  val id: Int,
+  val flags: UByte,
+  val commandSet: UByte,
+  val command: UByte,
+  val errorCode: UShort,
+)
+
+data class JdwpCommandPacket(
+  val id: Int,
+  val commandSet: UByte,
+  val command: UByte,
+  val payload: ByteArray,
+)
+
+data class JdwpReplyPacket(
+  val id: Int,
+  val errorCode: UShort,
+  val payload: ByteArray,
+)
+
+class JdwpBuffer(private val delegate: ByteBuffer) {
+  companion object {
+    fun wrap(bytes: ByteArray): JdwpBuffer = JdwpBuffer(ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN))
+    fun allocate(size: Int): JdwpBuffer = JdwpBuffer(ByteBuffer.allocate(size).order(ByteOrder.BIG_ENDIAN))
+  }
+
+  fun putByte(value: Byte) = apply { delegate.put(value) }
+  fun putBoolean(value: Boolean) = apply { delegate.put(if (value) 1 else 0) }
+  fun putInt(value: Int) = apply { delegate.putInt(value) }
+  fun putLong(value: Long) = apply { delegate.putLong(value) }
+  fun putUtf8(value: String) = apply {
+    val bytes = value.toByteArray(Charsets.UTF_8)
+    delegate.putInt(bytes.size)
+    delegate.put(bytes)
+  }
+
+  fun readByte(): Byte = delegate.get()
+  fun readBoolean(): Boolean = delegate.get().toInt() != 0
+  fun readInt(): Int = delegate.int
+  fun readLong(): Long = delegate.long
+  fun readUtf8(): String {
+    val len = delegate.int
+    val bytes = ByteArray(len)
+    delegate.get(bytes)
+    return bytes.toString(Charsets.UTF_8)
+  }
+
+  fun toByteArray(): ByteArray {
+    val out = ByteArray(delegate.position())
+    delegate.rewind()
+    delegate.get(out)
+    return out
+  }
+}

--- a/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpTypes.kt
+++ b/modules/jdwp-client/src/main/kotlin/com/zerostudio/jdwp/JdwpTypes.kt
@@ -8,19 +8,12 @@ import java.nio.ByteOrder
 @JvmInline value class MethodId(val raw: Long)
 @JvmInline value class FieldId(val raw: Long)
 @JvmInline value class ThreadId(val raw: Long)
+@JvmInline value class FrameId(val raw: Long)
 
 object JdwpConstants {
   const val HANDSHAKE = "JDWP-Handshake"
+  const val REPLY_FLAG: UByte = 0x80u
 }
-
-data class JdwpPacketHeader(
-  val length: Int,
-  val id: Int,
-  val flags: UByte,
-  val commandSet: UByte,
-  val command: UByte,
-  val errorCode: UShort,
-)
 
 data class JdwpCommandPacket(
   val id: Int,
@@ -35,6 +28,13 @@ data class JdwpReplyPacket(
   val payload: ByteArray,
 )
 
+data class JdwpEventPacket(
+  val id: Int,
+  val commandSet: UByte,
+  val command: UByte,
+  val payload: ByteArray,
+)
+
 class JdwpBuffer(private val delegate: ByteBuffer) {
   companion object {
     fun wrap(bytes: ByteArray): JdwpBuffer = JdwpBuffer(ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN))
@@ -42,9 +42,10 @@ class JdwpBuffer(private val delegate: ByteBuffer) {
   }
 
   fun putByte(value: Byte) = apply { delegate.put(value) }
-  fun putBoolean(value: Boolean) = apply { delegate.put(if (value) 1 else 0) }
+  fun putShort(value: Short) = apply { delegate.putShort(value) }
   fun putInt(value: Int) = apply { delegate.putInt(value) }
   fun putLong(value: Long) = apply { delegate.putLong(value) }
+  fun putBytes(value: ByteArray) = apply { delegate.put(value) }
   fun putUtf8(value: String) = apply {
     val bytes = value.toByteArray(Charsets.UTF_8)
     delegate.putInt(bytes.size)
@@ -52,15 +53,18 @@ class JdwpBuffer(private val delegate: ByteBuffer) {
   }
 
   fun readByte(): Byte = delegate.get()
-  fun readBoolean(): Boolean = delegate.get().toInt() != 0
+  fun readShort(): Short = delegate.short
   fun readInt(): Int = delegate.int
   fun readLong(): Long = delegate.long
+  fun readBytes(size: Int): ByteArray = ByteArray(size).also(delegate::get)
   fun readUtf8(): String {
     val len = delegate.int
     val bytes = ByteArray(len)
     delegate.get(bytes)
     return bytes.toString(Charsets.UTF_8)
   }
+
+  fun remaining(): Int = delegate.remaining()
 
   fun toByteArray(): ByteArray {
     val out = ByteArray(delegate.position())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -223,6 +223,7 @@ include(
     ":modules:compose-preview",
     // ":modules:colorpicker",
     ":modules:kotlinc",
+    ":modules:jdwp-client",
 
 )
 


### PR DESCRIPTION
### Motivation
- Provide a reusable JDWP protocol client inside the project to enable cross-process debugging and IPC socket scenarios (for example Termux client <-> session terminal).
- Allow upper layers (e.g. `core/app`) to access JVM-level symbols (classes, methods, fields, objects) in a remote JVM via JDWP.
- Ship a baseline implementation covering handshake, packet encoding/decoding and a few VirtualMachine/ReferenceType commands as foundation for full JDWP coverage.

### Description
- Add a new module `:modules:jdwp-client` and include it in `settings.gradle.kts` so it can be built and consumed by other modules.
- Provide Gradle build file targeting Kotlin/JVM with Java 17 compatibility in `modules/jdwp-client/build.gradle.kts`.
- Implement typed JDWP data structures and a big-endian buffer helper in `JdwpTypes.kt` including ID wrappers (`ObjectId`, `ReferenceTypeId`, `MethodId`, `FieldId`) and `JdwpBuffer` for binary read/write.
- Implement transport abstraction and client protocol in `JdwpProtocol.kt` including `JdwpTransport`, `SocketJdwpTransport`, `JdwpClient`, command/reply codec `JdwpCodec`, and basic commands (`VirtualMachine.Version`, `VirtualMachine.ClassesBySignature`, `ReferenceType.Fields`, `ReferenceType.Methods`).
- Add domain model and simple JDWP error mapping in `JdwpModel.kt` to expose `VmVersionReply`, `ClassInfo`, `MethodInfo`, `FieldInfo` and `JdwpErrors`.
- Add `README.md` documenting usage, supported commands and extension suggestions (in Chinese) with a quick Kotlin usage example.

### Testing
- Attempted to compile the new module with `./gradlew :modules:jdwp-client:compileKotlin` which failed due to an environment/toolchain issue reporting `* What went wrong: 25.0.1` and not attributable to the module source logic.
- No other automated tests were run inside CI for this change in this rollout; module compilation should be re-run in the target build environment to verify integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f695496970832fa988d3a3b15fc52c)