### PR TITLE
Improve bottom-sheet focus/overlay behavior and fix IME translation handling

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -30,6 +30,7 @@ import android.text.style.ClickableSpan
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
+import android.widget.RelativeLayout
 import android.view.Gravity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
@@ -214,6 +215,7 @@ abstract class BaseEditorActivity :
 
   private var optionsMenuInvalidator: Runnable? = null
   private var bottomSheetSlideOffset = 0f
+  private var isBottomSheetFocusMode = false
   private var blockBottomSheetExpandForTabSwitch = false
   private var latestImeBottomInset = 0
   private var pendingBottomSheetState: Int? = null
@@ -309,6 +311,7 @@ abstract class BaseEditorActivity :
       if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
       content.cardView.visibility = bottomSheetCardVisibilitySnapshot
       content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      updateEdgeBubbleAnchorToHeader(content.headerContainer.visibility == View.VISIBLE)
     }
   }
 
@@ -806,6 +809,8 @@ abstract class BaseEditorActivity :
             } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
               resetEditorSurfaceTransform()
             }
+            updateBottomSheetFocusMode(newState)
+            updateBindingHierarchyForMode(newState)
           }
 
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -815,7 +820,9 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              syncBottomSheetOverlayWithSlide(slideOffset)
+              updateBindingHierarchyForSlide(slideOffset)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -874,6 +881,81 @@ abstract class BaseEditorActivity :
         }
       }
       setExternalSymbolPageActive(false)
+    }
+  }
+
+
+  private fun updateBottomSheetFocusMode(state: Int) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val focused = state == BottomSheetBehavior.STATE_EXPANDED
+    if (isBottomSheetFocusMode == focused) return
+    isBottomSheetFocusMode = focused
+
+    if (focused) {
+      content.externalSymbolInputView.setImeBottomInset(0)
+      content.symbolInputPage.translationY = 0f
+      syncBottomSheetOverlayWithSlide(1f)
+    } else {
+      syncBottomSheetOverlayWithSlide(bottomSheetSlideOffset)
+    }
+  }
+
+  private fun syncBottomSheetOverlayWithSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val alpha = (1f - progress).coerceIn(0f, 1f)
+    content.headerOverlayContainer.alpha = alpha
+    content.pageSwitchGestureBubble.alpha = alpha
+    content.externalSymbolInputView.alpha = alpha
+    val visible = alpha > 0.02f
+    val targetVisibility = if (visible) View.VISIBLE else View.GONE
+    if (content.headerOverlayContainer.visibility != targetVisibility) {
+      content.headerOverlayContainer.visibility = targetVisibility
+    }
+    if (content.pageSwitchGestureBubble.visibility != targetVisibility) {
+      content.pageSwitchGestureBubble.visibility = targetVisibility
+    }
+    if (content.externalSymbolInputView.visibility != targetVisibility) {
+      content.externalSymbolInputView.visibility = targetVisibility
+    }
+  }
+
+
+  private fun updateBindingHierarchyForMode(bottomSheetState: Int) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val expanded = bottomSheetState == BottomSheetBehavior.STATE_EXPANDED
+    updateEdgeBubbleAnchorToHeader(!expanded && content.headerContainer.visibility == View.VISIBLE)
+    val overlayTargetVisibility = if (expanded) View.GONE else View.VISIBLE
+    if (content.headerOverlayContainer.visibility != overlayTargetVisibility) {
+      content.headerOverlayContainer.visibility = overlayTargetVisibility
+    }
+    if (content.externalSymbolInputView.visibility != overlayTargetVisibility) {
+      content.externalSymbolInputView.visibility = overlayTargetVisibility
+    }
+  }
+
+  private fun updateBindingHierarchyForSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val showHeaderBound = progress < 0.6f && content.headerContainer.visibility == View.VISIBLE
+    updateEdgeBubbleAnchorToHeader(showHeaderBound)
+  }
+
+  private fun updateEdgeBubbleAnchorToHeader(anchorToHeader: Boolean) {
+    if (_binding == null) return
+    content.pageSwitchGestureBubble.updateLayoutParams<RelativeLayout.LayoutParams> {
+      removeRule(RelativeLayout.ALIGN_PARENT_TOP)
+      removeRule(RelativeLayout.ABOVE)
+      removeRule(RelativeLayout.ALIGN_TOP)
+      removeRule(RelativeLayout.ALIGN_BOTTOM)
+      removeRule(RelativeLayout.BELOW)
+      if (anchorToHeader) {
+        // Keep bubble directly above header; never align to header top/bottom to avoid
+        // RelativeLayout dependency cycles (bubble -> border -> header -> bubble).
+        addRule(RelativeLayout.ABOVE, R.id.header_container)
+      } else {
+        addRule(RelativeLayout.ALIGN_PARENT_TOP)
+      }
     }
   }
 
@@ -936,6 +1018,7 @@ abstract class BaseEditorActivity :
       content.pageSwitchGestureBubble.setArrowExpanded(false)
       
       content.headerContainer.visibility = View.GONE
+      updateEdgeBubbleAnchorToHeader(false)
       content.cardView.visibility = View.GONE
       content.border.root.visibility = View.GONE
       content.tvCursorPosition.visibility = View.GONE
@@ -954,6 +1037,7 @@ abstract class BaseEditorActivity :
       content.pageSwitchGestureBubble.setArrowExpanded(true)
       
       content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      updateEdgeBubbleAnchorToHeader(content.headerContainer.visibility == View.VISIBLE)
       content.cardView.visibility = bottomSheetCardVisibilitySnapshot
       content.border.root.visibility = View.VISIBLE
       content.tvCursorPosition.visibility = View.VISIBLE
@@ -963,6 +1047,7 @@ abstract class BaseEditorActivity :
       
       updateSymbolInputPageAnchor(false)
       content.bottomSheet.resetSymbolInputPageHeight()
+      updateBindingHierarchyForSlide(bottomSheetSlideOffset)
     }
     
     content.pageSwitchGestureBubble.bringToFront()
@@ -1004,7 +1089,7 @@ abstract class BaseEditorActivity :
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
-                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtLeast(0f) else 0f
                 return bounds
             }
 
@@ -1033,7 +1118,7 @@ abstract class BaseEditorActivity :
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
         if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtLeast(0f) else 0f
             view.translationY = targetTranslationY
         } else {
             view.translationY = 0f


### PR DESCRIPTION
### Motivation

- Ensure the editor UI correctly handles a focused bottom sheet state by keeping overlays, header bubble anchoring and symbol input layout consistent when the sheet expands. 
- Make the page-switch gesture bubble reliably anchor to either the header or the top depending on bottom-sheet / external-symbol state to avoid layout cycles. 
- Correct erroneous IME translation behavior that produced negative translations for the external symbol input during inset animations.

### Description

- Added a new `isBottomSheetFocusMode` flag and introduced `updateBottomSheetFocusMode`, `syncBottomSheetOverlayWithSlide`, `updateBindingHierarchyForMode`, `updateBindingHierarchyForSlide`, and `updateEdgeBubbleAnchorToHeader` to manage overlay alpha, visibility and the bubble anchor as the sheet state/slide changes. 
- Hooked the new sync/update helpers into bottom-sheet callbacks and slide handlers and into external symbol mode entry/exit and header hide/release paths. 
- Adjusted external-symbol IME inset animation logic to use `coerceAtLeast(0f)` (was `coerceAtMost(0f)`) to prevent applying unintended negative translations. 
- Updated layout rules for `pageSwitchGestureBubble` using `RelativeLayout.LayoutParams` and added the required import, and toggled visibility/alpha of `headerOverlayContainer`, `pageSwitchGestureBubble`, and `externalSymbolInputView` based on sheet state/slide.

### Testing

- Built the app with `./gradlew assembleDebug` and the build completed successfully. 
- Ran JVM unit tests with `./gradlew test` and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62bd8955c832f9bbf51c9ec6299e7)