### PR TITLE
Fix RelativeLayout ID reference in data file tree layout

### DIFF
--- a/core/app/src/main/res/layout/layout_data_file_tree.xml
+++ b/core/app/src/main/res/layout/layout_data_file_tree.xml
@@ -23,7 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/mount_status"
-        android:layout_above="@+id/bottom_bar"
+        android:layout_above="@id/bottom_bar"
         android:fillViewport="true" />
 
     <ProgressBar


### PR DESCRIPTION
### Motivation
- Prevent a RelativeLayout dependency ID from being declared in a positional rule which can cause circular/dependency graph issues at measure time by ensuring constraints reference an existing view ID.

### Description
- Replace `android:layout_above="@+id/bottom_bar"` with `android:layout_above="@id/bottom_bar"` in `core/app/src/main/res/layout/layout_data_file_tree.xml` so the rule references the existing `bottom_bar` ID instead of creating it.

### Testing
- Verified the change via `git diff -- core/app/src/main/res/layout/layout_data_file_tree.xml` and inspected the file with `nl -ba core/app/src/main/res/layout/layout_data_file_tree.xml | sed -n '20,32p'`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a1c9a240832f96c8d26cb4bf4981)