### PR TITLE
Bottom sheet: focus mode, overlay sync, IME translation fixes and edge bubble anchoring

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -30,6 +30,7 @@ import android.text.style.ClickableSpan
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
+import android.widget.RelativeLayout
 import android.view.Gravity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
@@ -214,6 +215,7 @@ abstract class BaseEditorActivity :
 
   private var optionsMenuInvalidator: Runnable? = null
   private var bottomSheetSlideOffset = 0f
+  private var isBottomSheetFocusMode = false
   private var blockBottomSheetExpandForTabSwitch = false
   private var latestImeBottomInset = 0
   private var pendingBottomSheetState: Int? = null
@@ -309,6 +311,7 @@ abstract class BaseEditorActivity :
       if (!wasRemoved || bottomSheetHeaderHideReasons.isNotEmpty()) return@runOnUiThread
       content.cardView.visibility = bottomSheetCardVisibilitySnapshot
       content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      updateEdgeBubbleAnchorToHeader(content.headerContainer.visibility == View.VISIBLE)
     }
   }
 
@@ -806,6 +809,8 @@ abstract class BaseEditorActivity :
             } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
               resetEditorSurfaceTransform()
             }
+            updateBottomSheetFocusMode(newState)
+            updateBindingHierarchyForMode(newState)
           }
 
           override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -815,7 +820,9 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              syncBottomSheetOverlayWithSlide(slideOffset)
+              updateBindingHierarchyForSlide(slideOffset)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -854,6 +861,8 @@ abstract class BaseEditorActivity :
       viewContainer.viewTreeObserver.addOnGlobalLayoutListener(observer)
       
       bottomSheet.setOffsetAnchor(editorAppBarLayout, symbolInputPage)
+      updateSymbolInputPageAnchor(false)
+      symbolInputPage.visibility = View.VISIBLE
       
       bottomSheet.onHeaderPageChanged = { page ->
         if (_binding != null) {
@@ -874,6 +883,65 @@ abstract class BaseEditorActivity :
         }
       }
       setExternalSymbolPageActive(false)
+    }
+  }
+
+
+  private fun updateBottomSheetFocusMode(state: Int) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val focused = state == BottomSheetBehavior.STATE_EXPANDED
+    if (isBottomSheetFocusMode == focused) return
+    isBottomSheetFocusMode = focused
+
+    if (focused) {
+      content.externalSymbolInputView.setImeBottomInset(0)
+      content.symbolInputPage.translationY = 0f
+      syncBottomSheetOverlayWithSlide(1f)
+    } else {
+      syncBottomSheetOverlayWithSlide(bottomSheetSlideOffset)
+    }
+  }
+
+  private fun syncBottomSheetOverlayWithSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val alpha = (1f - progress).coerceIn(0f, 1f)
+    content.headerOverlayContainer.alpha = alpha
+    content.pageSwitchGestureBubble.alpha = alpha
+    content.externalSymbolInputView.alpha = alpha
+    content.headerOverlayContainer.isEnabled = alpha > 0.02f
+    content.pageSwitchGestureBubble.isEnabled = alpha > 0.02f
+    content.externalSymbolInputView.isEnabled = alpha > 0.02f
+  }
+
+  private fun updateBindingHierarchyForMode(bottomSheetState: Int) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val expanded = bottomSheetState == BottomSheetBehavior.STATE_EXPANDED
+    updateEdgeBubbleAnchorToHeader(!expanded && content.headerContainer.visibility == View.VISIBLE)
+    content.headerOverlayContainer.importantForAccessibility =
+        if (expanded) View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+        else View.IMPORTANT_FOR_ACCESSIBILITY_AUTO
+  }
+
+  private fun updateBindingHierarchyForSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val showHeaderBound = progress < 0.6f && content.headerContainer.visibility == View.VISIBLE
+    updateEdgeBubbleAnchorToHeader(showHeaderBound)
+  }
+
+  private fun updateEdgeBubbleAnchorToHeader(anchorToHeader: Boolean) {
+    if (_binding == null) return
+    content.pageSwitchGestureBubble.updateLayoutParams<RelativeLayout.LayoutParams> {
+      // IMPORTANT: Do not create any dependency against header_container/border because
+      // header_container is positioned below border and border is positioned below bubble.
+      // Any bubble <-> header relation can create a RelativeLayout dependency cycle.
+      removeRule(RelativeLayout.ALIGN_PARENT_TOP)
+      removeRule(RelativeLayout.ABOVE)
+      removeRule(RelativeLayout.ALIGN_TOP)
+      removeRule(RelativeLayout.ALIGN_BOTTOM)
+      removeRule(RelativeLayout.BELOW)
+      addRule(RelativeLayout.ALIGN_PARENT_TOP)
     }
   }
 
@@ -936,6 +1004,7 @@ abstract class BaseEditorActivity :
       content.pageSwitchGestureBubble.setArrowExpanded(false)
       
       content.headerContainer.visibility = View.GONE
+      updateEdgeBubbleAnchorToHeader(false)
       content.cardView.visibility = View.GONE
       content.border.root.visibility = View.GONE
       content.tvCursorPosition.visibility = View.GONE
@@ -954,15 +1023,17 @@ abstract class BaseEditorActivity :
       content.pageSwitchGestureBubble.setArrowExpanded(true)
       
       content.headerContainer.visibility = bottomSheetHeaderVisibilitySnapshot
+      updateEdgeBubbleAnchorToHeader(content.headerContainer.visibility == View.VISIBLE)
       content.cardView.visibility = bottomSheetCardVisibilitySnapshot
       content.border.root.visibility = View.VISIBLE
       content.tvCursorPosition.visibility = View.VISIBLE
-      content.externalSymbolInputView.visibility = View.GONE
+      content.externalSymbolInputView.visibility = View.VISIBLE
       
       content.symbolInputPage.translationY = 0f
       
       updateSymbolInputPageAnchor(false)
       content.bottomSheet.resetSymbolInputPageHeight()
+      updateBindingHierarchyForSlide(bottomSheetSlideOffset)
     }
     
     content.pageSwitchGestureBubble.bringToFront()
@@ -1004,7 +1075,7 @@ abstract class BaseEditorActivity :
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
-                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtLeast(0f) else 0f
                 return bounds
             }
 
@@ -1033,7 +1104,7 @@ abstract class BaseEditorActivity :
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
         if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtLeast(0f) else 0f
             view.translationY = targetTranslationY
         } else {
             view.translationY = 0f


### PR DESCRIPTION
### Motivation
- Improve bottom-sheet focus behavior so the header overlay, gesture bubble and external-symbol input behave and are accessible correctly when the sheet is expanded. 
- Avoid RelativeLayout dependency cycles between the edge bubble and header while keeping proper anchoring during slide/expand transitions. 
- Fix incorrect IME translation sign logic for the external symbol input so it moves correctly with the keyboard.

### Description
- Added `isBottomSheetFocusMode` state and implemented `updateBottomSheetFocusMode`, `syncBottomSheetOverlayWithSlide`, `updateBindingHierarchyForMode`, and `updateBindingHierarchyForSlide` to centralize focus/overlay behavior and call them from `onStateChanged` and `onSlide` handlers. 
- Added `updateEdgeBubbleAnchorToHeader` which updates `pageSwitchGestureBubble` `RelativeLayout.LayoutParams` by removing conflicting rules and applying `ALIGN_PARENT_TOP` while avoiding RelativeLayout cycles. 
- Call `updateEdgeBubbleAnchorToHeader` from several places (`releaseBottomSheetHeaderHide`, `setExternalSymbolPageActive`, and slide/state update flows) and update accessibility (`importantForAccessibility`) when the sheet is expanded. 
- Keep `externalSymbolInputView` visible and manage its IME inset & translation consistently; changed `symbolInputPage` visibility/anchor handling and ensure the view hierarchy is re-ordered (`bringToFront`) where needed. 
- Fixed IME translation math in `setupExternalSymbolImeSync` by replacing `coerceAtMost(0f)` with `coerceAtLeast(0f)` for `endTranslationY` and target translation computation so the external symbol page translates in the correct direction.

### Testing
- Built the app with Gradle (`assembleDebug`) and the build completed successfully. 
- Ran the project's unit test suite and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62bd8955c832f9bbf51c9ec6299e7)