### PR TITLE
Fix external symbol header layout and bottom sheet gesture ownership

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -32,6 +32,7 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.RelativeLayout
 import android.view.Gravity
+import android.view.MotionEvent
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
@@ -120,6 +121,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import android.view.ViewConfiguration
 
 /**
  * Base class for EditorActivity which handles most of the view related things.
@@ -141,6 +143,9 @@ abstract class BaseEditorActivity :
   private var bottomSheetCardVisibilitySnapshot: Int = View.VISIBLE
   private var bottomSheetHeaderVisibilitySnapshot: Int = View.VISIBLE
   private var isExternalSymbolPageActive = false
+  private var headerGestureStartY = 0f
+  private var headerGestureDragging = false
+  private val headerGestureTouchSlop by lazy { ViewConfiguration.get(this).scaledTouchSlop }
 
   var isDestroying = false
     protected set
@@ -650,6 +655,7 @@ abstract class BaseEditorActivity :
   fun refreshSymbolInput(editor: CodeEditorView) {
     if (isDestroying || _binding == null) return
     content.bottomSheet.refreshSymbolInput(editor)
+    editor.editor?.let { content.externalSymbolInputView.bindEditor(it) }
   }
 
   private fun checkIsDestroying() {
@@ -1137,13 +1143,7 @@ abstract class BaseEditorActivity :
     bubble.setOrientation(EdgeSnapBubbleView.Orientation.HORIZONTAL)
     bubble.setPosition(EdgeSnapBubbleView.Position.TOP)
     
-    bubble.setOnBubbleClickListener {
-      if (editorBottomSheet?.state == BottomSheetBehavior.STATE_EXPANDED) {
-         requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
-      } else {
-         requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
-      }
-    }
+    bubble.setOnBubbleClickListener { toggleHeaderContainerVisibility() }
     
     bubble.setOnBubbleGestureListener(
         object : EdgeSnapBubbleView.OnBubbleGestureListener {
@@ -1165,6 +1165,62 @@ abstract class BaseEditorActivity :
           }
         }
     )
+
+    val headerGestureListener =
+        View.OnTouchListener { _, event ->
+          when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+              headerGestureStartY = event.rawY
+              headerGestureDragging = false
+              true
+            }
+            MotionEvent.ACTION_MOVE -> {
+              val deltaY = event.rawY - headerGestureStartY
+              if (!headerGestureDragging && abs(deltaY) > headerGestureTouchSlop) {
+                headerGestureDragging = true
+              }
+              true
+            }
+            MotionEvent.ACTION_UP -> {
+              val deltaY = event.rawY - headerGestureStartY
+              if (headerGestureDragging) {
+                if (deltaY < -headerGestureTouchSlop) requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
+                if (deltaY > headerGestureTouchSlop) requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
+              }
+              headerGestureDragging = false
+              true
+            }
+            MotionEvent.ACTION_CANCEL -> {
+              headerGestureDragging = false
+              true
+            }
+            else -> false
+          }
+        }
+    content.headerContainer.setOnTouchListener(headerGestureListener)
+    content.pageSwitchGestureBubble.setOnTouchListener(headerGestureListener)
+  }
+
+  private fun toggleHeaderContainerVisibility() {
+    if (_binding == null) return
+    val header = content.headerContainer
+    val targetVisible = header.visibility != View.VISIBLE
+    if (targetVisible) {
+      header.visibility = View.VISIBLE
+      header.alpha = 0f
+      header.translationY = -header.height.toFloat().coerceAtLeast(24f)
+      header.animate().alpha(1f).translationY(0f).setDuration(180L).start()
+    } else {
+      header.animate().alpha(0f).translationY(-header.height.toFloat().coerceAtLeast(24f)).setDuration(180L)
+          .withEndAction {
+            header.visibility = View.GONE
+            header.alpha = 1f
+            header.translationY = 0f
+            updateEdgeBubbleAnchorToHeader(false)
+          }
+          .start()
+    }
+    if (targetVisible) updateEdgeBubbleAnchorToHeader(true)
   }
 
   private fun requestBottomSheetState(targetState: Int) {

--- a/core/app/src/main/res/layout/layout_editor_bottom_action.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_action.xml
@@ -22,7 +22,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
+  android:layout_height="wrap_content"
   tools:layout_height="56dp">
 
   <com.google.android.material.progressindicator.LinearProgressIndicator


### PR DESCRIPTION
### Motivation
- 修复 editor 首次打开时 `header_container` 被挤高/挤下导致 `AdvancedSymbolInputView` 未在预期位置锚定的问题。 
- 解决 `AdvancedSymbolInputView` 在未展开时无法通过已配置的符号/动作操作编辑器的问题（未绑定当前 editor）。
- 将打开抽屉的上滑手势从 `AdvancedSymbolInputView` 内部迁移到 `header_container` + `EdgeSnapBubbleView`，避免手势冲突并统一手势归属。 

### Description
- 将底部动作布局根节点高度从 `match_parent` 改为 `wrap_content`，防止子布局撑高整体 header（`core/app/src/main/res/layout/layout_editor_bottom_action.xml`）。
- 在 `refreshSymbolInput(editor)` 中为外部符号面板绑定当前 `CodeEditor`：调用 `externalSymbolInputView.bindEditor(...)`，使符号点击/长按能在未展开时也作用于编辑器（`BaseEditorActivity.kt`）。
- 将抽屉控制手势从气泡单一方法改为：把垂直拖拽监听器绑定到 `header_container` 与 `pageSwitchGestureBubble`，根据垂直位移决定调用 `requestBottomSheetState(...)` 展开/收起抽屉（`BaseEditorActivity.kt`）。
- 将 `EdgeSnapBubbleView` 的点击行为由直接切换抽屉改为切换 `header_container` 的可见性，并实现与抽屉开/关风格一致的上下平移动画与 alpha 过渡（`BaseEditorActivity.kt`）。
- 新增与手势相关的字段（`headerGestureStartY`、`headerGestureDragging`、`headerGestureTouchSlop`）并使用 `MotionEvent`/`ViewConfiguration` 做阈值判断与防抖处理（`BaseEditorActivity.kt`）。

### Testing
- 尝试执行编译：`./gradlew :core:app:compileDebugKotlin -x lint`，构建在本地环境因工具链/环境问题失败（报错指向 `25.0.1`），因此无法完成本地 APK 编译验证 (失败)。
- 已通过 IDE/CI 以外的静态检查（代码变更自检）并提交修改，变更已编译级别审阅但未通过完整编译链验证（见上）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6d531b9d8832fa64c4400b6541794)