### PR TITLE
修复 JumpSymbol 中 Java/Kotlin 符号名称与签名解析

### DIFF
--- a/editor/impl/src/main/java/com/itsaky/androidide/actions/code/jumpsymbol/TreeSitterSymbolResolver.kt
+++ b/editor/impl/src/main/java/com/itsaky/androidide/actions/code/jumpsymbol/TreeSitterSymbolResolver.kt
@@ -76,7 +76,10 @@ object TreeSitterSymbolResolver {
         SymbolInfo(name, "Package Declaration", startLine, SymbolType.PACKAGE)
       }
       "import_declaration" -> {
-        val name = getNodeText(node.getChildByFieldName("name"), source) ?: return null
+        val name =
+            getNodeText(node.getChildByFieldName("name"), source)
+                ?: getNodeText(node, source)?.removePrefix("import")?.removeSuffix(";")?.trim()
+                ?: return null
         SymbolInfo(name, "Import", startLine, SymbolType.IMPORT)
       }
       "class_declaration" -> {
@@ -94,9 +97,8 @@ object TreeSitterSymbolResolver {
       "method_declaration" -> {
         val name = getNodeText(node.getChildByFieldName("name"), source) ?: return null
         val params = getNodeText(node.getChildByFieldName("parameters"), source) ?: "()"
-        val returnType = getNodeText(node.getChildByFieldName("type"), source) ?: "void"
 
-        SymbolInfo(name, "$params : $returnType", startLine, SymbolType.METHOD)
+        SymbolInfo(name, params, startLine, SymbolType.METHOD)
       }
       "constructor_declaration" -> {
         val name = getNodeText(node.getChildByFieldName("name"), source) ?: return null
@@ -141,7 +143,10 @@ object TreeSitterSymbolResolver {
         SymbolInfo(name, "Package", startLine, SymbolType.PACKAGE)
       }
       "import_header" -> {
-        val name = getNodeText(findChildByType(node, "identifier"), source) ?: "import"
+        val name =
+            getNodeText(findChildByType(node, "identifier"), source)
+                ?: getNodeText(node, source)?.removePrefix("import")?.trim()
+                ?: "import"
         SymbolInfo(name, "Import", startLine, SymbolType.IMPORT)
       }
       "class_declaration" -> {
@@ -156,12 +161,13 @@ object TreeSitterSymbolResolver {
         val name = getNodeText(findChildByType(node, "simple_identifier"), source) ?: "<anon>"
         val params = getNodeText(findChildByType(node, "function_value_parameters"), source) ?: "()"
 
-        SymbolInfo(name, params, startLine, SymbolType.FUNCTION)
+        SymbolInfo(name, params, startLine, SymbolType.METHOD)
       }
       "property_declaration" -> {
         val decl = findChildByType(node, "variable_declaration")
         val name = getNodeText(findChildByType(decl, "simple_identifier"), source) ?: "prop"
-        SymbolInfo(name, "Property", startLine, SymbolType.VARIABLE)
+        val type = getNodeText(findChildByType(decl, "type_annotation"), source) ?: "Property"
+        SymbolInfo(name, type, startLine, SymbolType.FIELD)
       }
       else -> null
     }
@@ -173,9 +179,15 @@ object TreeSitterSymbolResolver {
     return try {
       val start = node.startByte
       val end = node.endByte
-      if (start < 0 || end > source.length || start >= end) null else source.substring(start, end)
+      val bytes = source.toByteArray(Charsets.UTF_8)
+      if (start < 0 || end > bytes.size || start >= end) {
+        null
+      } else {
+        String(bytes, start, end - start, Charsets.UTF_8)
+      }
     } catch (e: IllegalStateException) {
-      // 如果仍然发生 "Cannot access native object"，则捕获并返回 null
+      null
+    } catch (e: Exception) {
       null
     }
   }


### PR DESCRIPTION
### Motivation
- 修正 Java/Kotlin 在 Jump Symbol 列表中主值（name）或副信息（签名/类型）解析错误导致显示不准确的问题。 
- 确保 `method` 只展示方法名与参数签名，避免将返回类型当作副信息混入（符合既定预期）。
- 解决 Tree-sitter 返回的 byte 范围与 Kotlin/Java `String` 字符索引不一致导致的多字节字符切片错位问题。

### Description
- Java: 在 `import_declaration` 增加兜底解析，当基于字段的节点提取失败时回退到节点文本并清理前后缀以获取正确的 import 名称。 
- Java: 将 `method_declaration` 的副信息由 `parameters : returnType` 改为只保留 `parameters`（保留主值为方法名）。
- Kotlin: 将 `function_declaration` 统一归类为 `SymbolType.METHOD` 并保留参数签名作为副信息；将 `property_declaration` 改为使用类型注解作为副信息并归类为 `SymbolType.FIELD`。 
- 核心文本提取 `getNodeText` 改为按 Tree-sitter 的 byte 偏移在 `UTF-8` 字节数组上解码并增加越界与异常保护，以避免多字节源码下的截取错位。 
- 修改文件：`editor/impl/src/main/java/com/itsaky/androidide/actions/code/jumpsymbol/TreeSitterSymbolResolver.kt`。 

### Testing
- 运行了 `./gradlew :editor:impl:compileDebugKotlin -q` 进行编译验证，构建在当前环境因工具链/Gradle 问题失败（错误输出：`What went wrong: 25.0.1`）。
- 未新增自动化单元测试；本次变更仅调整符号解析逻辑并修复多字节截取问题。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f2077388832fae516a0e46d5b131)