### PR TITLE
Compact header heights, bind AdvancedSymbolInputView to editor, and toggle header via bubble click

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -847,6 +847,7 @@ abstract class BaseEditorActivity :
 
     content.apply {
       setupExternalSymbolImeSync()
+      provideCurrentEditor()?.editor?.let { externalSymbolInputView.bindEditor(it) }
       bottomSheet.onActionTextChanged = { content.bottomAction.actionText.text = it }
       bottomSheet.onActionProgressChanged = { content.bottomAction.progress.setProgressCompat(it, true) }
       bottomSheet.onStatusChanged = { text, gravity ->
@@ -1138,11 +1139,7 @@ abstract class BaseEditorActivity :
     bubble.setPosition(EdgeSnapBubbleView.Position.TOP)
     
     bubble.setOnBubbleClickListener {
-      if (editorBottomSheet?.state == BottomSheetBehavior.STATE_EXPANDED) {
-         requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
-      } else {
-         requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
-      }
+      toggleHeaderContainerVisibility()
     }
     
     bubble.setOnBubbleGestureListener(
@@ -1165,6 +1162,30 @@ abstract class BaseEditorActivity :
           }
         }
     )
+  }
+
+
+  private fun toggleHeaderContainerVisibility() {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val show = content.headerContainer.visibility != View.VISIBLE
+    val containerHeight = content.headerOverlayContainer.height.toFloat().takeIf { it > 0f } ?: 1f
+    val translationFrom = if (show) -containerHeight else 0f
+    val translationTo = if (show) 0f else -containerHeight
+    if (show) {
+      content.headerContainer.visibility = View.VISIBLE
+    }
+    content.headerOverlayContainer.animate().cancel()
+    content.headerOverlayContainer.translationY = translationFrom
+    content.headerOverlayContainer.animate()
+      .translationY(translationTo)
+      .setDuration(200L)
+      .withEndAction {
+        if (_binding == null) return@withEndAction
+        content.headerOverlayContainer.translationY = 0f
+        content.headerContainer.visibility = if (show) View.VISIBLE else View.GONE
+      }
+      .start()
+    updateEdgeBubbleAnchorToHeader(show)
   }
 
   private fun requestBottomSheetState(targetState: Int) {

--- a/core/app/src/main/res/layout/layout_editor_bottom_action.xml
+++ b/core/app/src/main/res/layout/layout_editor_bottom_action.xml
@@ -22,8 +22,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  tools:layout_height="56dp">
+  android:layout_height="14dp">
 
   <com.google.android.material.progressindicator.LinearProgressIndicator
     android:id="@+id/progress"
@@ -42,8 +41,8 @@
     android:layout_height="wrap_content"
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
-    android:layout_marginTop="8dp"
-    android:layout_marginBottom="8dp"
+    android:layout_marginTop="0dp"
+    android:layout_marginBottom="0dp"
     android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintEnd_toEndOf="parent"

--- a/core/app/src/main/res/layout/layout_editor_build_status.xml
+++ b/core/app/src/main/res/layout/layout_editor_build_status.xml
@@ -25,7 +25,7 @@
     android:id="@+id/statusText"
     android:layout_width="0dp"
     android:layout_height="match_parent"
-    android:minHeight="56dp"
+    android:minHeight="14dp"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
     android:gravity="center"


### PR DESCRIPTION
### Motivation
- Reduce the vertical footprint of the bottom-sheet header rows so the header area and its nested layouts (APK install / build service status and action row) are ~70-75% smaller at layout-definition level. 
- Fix interaction loss when `AdvancedSymbolInputView` is collapsed by ensuring it targets the active editor instance. 
- Move the simple click behavior for the edge bubble away from opening/closing the drawer and into a header visibility toggle to avoid competing drawer gesture logic.

### Description
- Reduced header row sizes by changing `layout_editor_build_status.xml` to use `android:minHeight="14dp"` and `layout_editor_bottom_action.xml` root to `android:layout_height="14dp"` and removing vertical margins. 
- Bind the live editor to the external symbol panel by calling `provideCurrentEditor()?.editor?.let { externalSymbolInputView.bindEditor(it) }` during bottom-sheet setup in `BaseEditorActivity` (`content.apply { ... }`). 
- Replaced the `EdgeSnapBubbleView` click handler to call `toggleHeaderContainerVisibility()` instead of toggling bottom-sheet state and added the `toggleHeaderContainerVisibility()` helper which animates `header_overlay_container` vertical translation and updates the bubble anchor via `updateEdgeBubbleAnchorToHeader(show)`. 
- Kept existing bubble swipe (drag/release) handling for expand/collapse, and preserved current external-symbol anchoring/mode flow unchanged.

### Testing
- Attempted to compile `:core:app:compileDebugKotlin` to validate changes, but the build failed in this environment due to SDK/toolchain issue (`25.0.1`) so a full compile verification could not be completed. 
- Changes were lint- and diff-inspected locally and committed (no other automated test suites were run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f728893e7c832f97da8aa52943a22b)