### PR TITLE
Fix EdgeSnapBubbleView conflicting Kotlin declarations

### DIFF
--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -287,7 +287,6 @@ class EdgeSnapBubbleView : View {
     }
 
     canvas.save()
-    val drawDelta = if (deltaX == 0f) backMaxWidth * 0.35f else abs(deltaX)
     if ((deltaX > 0 && left) || (deltaX == 0f && !right)) {
       backPath!!.moveTo(0f, deltaY)
       backPath!!.quadTo(0f, backViewHeight / 4 + deltaY, drawDelta / 3, backViewHeight * 3 / 8 + deltaY)
@@ -386,14 +385,6 @@ class EdgeSnapBubbleView : View {
     // }
     // canvas.drawPath(arrowPath!!, arrowPaint!!)
   // }
-
-  fun setBackViewHeight(backViewHeight: Float) {
-    this.backViewHeight = backViewHeight
-  }
-
-  fun setBackEdgeWidth(backEdgeWidth: Float) {
-    this.backEdgeWidth = backEdgeWidth
-  }
 
   fun setBackViewHeight(backViewHeight: Float) { this.backViewHeight = backViewHeight }
   fun setBackEdgeWidth(backEdgeWidth: Float) { this.backEdgeWidth = backEdgeWidth }


### PR DESCRIPTION
### Motivation
- Resolve Kotlin compilation errors caused by duplicate local variable and duplicate method declarations in `EdgeSnapBubbleView.kt`.

### Description
- Removed the duplicate `val drawDelta` declaration in `onDraw` to eliminate the conflicting local declaration.
- Removed duplicate `setBackViewHeight` and `setBackEdgeWidth` method definitions to remove conflicting overloads and kept the concise setter implementations in `core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt`.

### Testing
- Ran `./gradlew :core:common:compileDebugKotlin -q`, which no longer reports the original conflicting declaration/overload errors from `EdgeSnapBubbleView.kt`.
- The Gradle run still fails due to an unrelated environment/toolchain issue (`25.0.1`), so full build completion requires CI/toolchain fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f936715450832fbae439d02603a614)