### PR TITLE
Fix symbol input anchoring and EdgeSnapBubble upward-drag behavior

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -216,6 +216,7 @@ abstract class BaseEditorActivity :
   private var bottomSheetSlideOffset = 0f
   private var blockBottomSheetExpandForTabSwitch = false
   private var latestImeBottomInset = 0
+  private var isImeVisible = false
   private var pendingBottomSheetState: Int? = null
   private var cursorPositionReceipt: SubscriptionReceipt<SelectionChangeEvent>? = null
 
@@ -942,7 +943,7 @@ abstract class BaseEditorActivity :
       content.externalSymbolInputView.visibility = View.VISIBLE
       
       updateSymbolInputPageAnchor(true)
-      applyExternalSymbolImeInset()
+      syncSymbolInputPageWithAnchor()
       
     } else {
       content.bottomSheet.setBottomSheetDragEnabled(true)
@@ -959,10 +960,9 @@ abstract class BaseEditorActivity :
       content.tvCursorPosition.visibility = View.VISIBLE
       content.externalSymbolInputView.visibility = View.GONE
       
-      content.symbolInputPage.translationY = 0f
-      
       updateSymbolInputPageAnchor(false)
       content.bottomSheet.resetSymbolInputPageHeight()
+      syncSymbolInputPageWithAnchor()
     }
     
     content.pageSwitchGestureBubble.bringToFront()
@@ -976,9 +976,21 @@ abstract class BaseEditorActivity :
 
   private fun applyExternalSymbolImeInset() {
     if (_binding == null) return
-    content.symbolInputPage.translationY = 0f
-    val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
-    content.externalSymbolInputView.setImeBottomInset(targetImeInset)
+    syncSymbolInputPageWithAnchor()
+  }
+
+  private fun syncSymbolInputPageWithAnchor() {
+    if (_binding == null) return
+    val navBottom = ViewCompat.getRootWindowInsets(content.symbolInputPage)
+      ?.getInsets(WindowInsetsCompat.Type.navigationBars())
+      ?.bottom ?: 0
+    val keyboardOffset = if (isImeVisible && latestImeBottomInset > 0) {
+      (latestImeBottomInset - navBottom).coerceAtLeast(0)
+    } else {
+      0
+    }
+    content.symbolInputPage.translationY = -keyboardOffset.toFloat()
+    content.externalSymbolInputView.setImeBottomInset(if (isImeVisible) latestImeBottomInset else 0)
   }
 
   private fun setupExternalSymbolImeSync() {
@@ -1004,7 +1016,7 @@ abstract class BaseEditorActivity :
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
-                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).coerceAtLeast(0).toFloat() else 0f
                 return bounds
             }
 
@@ -1012,12 +1024,11 @@ abstract class BaseEditorActivity :
                 insets: WindowInsetsCompat,
                 runningAnimations: MutableList<WindowInsetsAnimationCompat>
             ): WindowInsetsCompat {
-                if (!isExternalSymbolPageActive) return insets
-
                 val imeAnimation = runningAnimations.find { it.typeMask and WindowInsetsCompat.Type.ime() != 0 }
                 if (imeAnimation != null) {
                     val fraction = imeAnimation.interpolatedFraction
                     symbolInputPage.translationY = startTranslationY + (endTranslationY - startTranslationY) * fraction
+                    content.externalSymbolInputView.setImeBottomInset((latestImeBottomInset * fraction).toInt())
                 }
                 return insets
             }
@@ -1031,13 +1042,8 @@ abstract class BaseEditorActivity :
         
         content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
 
-        val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
-        } else {
-            view.translationY = 0f
-        }
+        isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+        syncSymbolInputPageWithAnchor()
 
         insets
     }
@@ -1067,19 +1073,22 @@ abstract class BaseEditorActivity :
         object : EdgeSnapBubbleView.OnBubbleGestureListener {
           override fun onDrag(fraction: Float) {
              if (_binding != null) {
-                 val absFrac = abs(fraction)
-                 val alpha = (1f - absFrac * 0.8f).coerceIn(0.2f, 1f)
+                 // 仅上滑手势驱动抽屉展开动画，下滑不播放驼峰拉伸
+                 val upwardFraction = fraction.coerceAtLeast(0f)
+                 content.pageSwitchGestureBubble.alpha = (0.35f + upwardFraction * 0.65f).coerceIn(0.35f, 1f)
+                 val alpha = (1f - upwardFraction * 0.8f).coerceIn(0.2f, 1f)
                  content.headerContainer.alpha = alpha
              }
           }
 
           override fun onRelease(fraction: Float) {
-             if (fraction > 0.15f) { 
+             if (fraction > 0.15f) {
                 requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
-             } else if (fraction < -0.15f) { 
+             } else if (fraction < -0.15f) {
                 requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
              }
              content.headerContainer.alpha = 1f
+             content.pageSwitchGestureBubble.alpha = 1f
           }
         }
     )

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -113,11 +113,38 @@ class EdgeSnapBubbleView : View {
   }
 
 override fun onTouchEvent(ev: MotionEvent): Boolean {
-    // 兼容水平模式下的垂直拖拽手势
-    val currentTouchX = if (orientation == Orientation.HORIZONTAL) ev.y else ev.x
-    // 固定绘制锚点，保障拖拽手势时视觉驼峰完美居中
-    currentY = if (orientation == Orientation.HORIZONTAL) backViewHeight / 2f else ev.y
-    
+    if (orientation == Orientation.HORIZONTAL) {
+      currentY = backViewHeight / 2f
+      when (ev.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+          downX = ev.y
+          isEdge = true
+          deltaX = 0f
+          parent?.requestDisallowInterceptTouchEvent(true)
+        }
+        MotionEvent.ACTION_MOVE -> {
+          if (!isEdge) return false
+          // 上滑手势为正进度；下滑保持 0，不触发拉伸动画。
+          deltaX = (downX - ev.y).coerceIn(0f, backMaxWidth)
+          onBubbleGestureListener?.onDrag(getDragFraction())
+          invalidate()
+        }
+        MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+          if (!isEdge) return false
+          val fraction = getDragFraction()
+          if (fraction < 0.2f) performClick()
+          onBubbleGestureListener?.onRelease(fraction)
+          isEdge = false
+          deltaX = 0f
+          invalidate()
+        }
+      }
+      return true
+    }
+
+    val currentTouchX = ev.x
+    currentY = ev.y
+
     when (ev.action) {
       MotionEvent.ACTION_DOWN -> {
         downX = currentTouchX


### PR DESCRIPTION
### Motivation
- The `AdvancedSymbolInputView` was not consistently anchored to the correct top anchor (bottom sheet top vs IME top) and could be positioned incorrectly after IME open/close or bottom-sheet state changes.  
- `EdgeSnapBubbleView` horizontal gesture handling played the hump stretch animation during downward drags; the intended behavior is that only upward drags drive the stretch/progress animation.  
- Centralize IME/anchor synchronization so `AdvancedSymbolInputView`, `header_container` and `EdgeSnapBubbleView` move as a single stacked unit according to the required binding hierarchy (bottom_sheet vs IME top).  

### Description
- Added a centralized `syncSymbolInputPageWithAnchor()` helper in `BaseEditorActivity` and wired it into external-symbol page activation, IME animation callbacks and `WindowInsets` listener to keep the symbol input page translation and `AdvancedSymbolInputView` inset consistent. (`core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt`).  
- Reworked IME animation handling to update translation progressively and to track IME visibility with an `isImeVisible` flag so the symbol input page is forced to follow IME top when the keyboard is visible and restored when closed. (`setupExternalSymbolImeSync` and `syncSymbolInputPageWithAnchor`).  
- Adjusted `setupPageSwitchGestureBubble()` to only use upward drag fraction for visual feedback and to avoid playing stretch visuals on downward drags, and to restore alphas on release. (`BaseEditorActivity`).  
- Fixed `EdgeSnapBubbleView.onTouchEvent` horizontal-orientation handling so upward (swipe-up) motion produces a positive progress (`deltaX`) and downward motion does not trigger the hump/stretch animation; releases still report `onRelease` with a fraction. (`core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt`).  
- Kept the bottom-sheet vs IME binding semantics intact: `bottom_sheet > AdvancedSymbolInputView > header_container > EdgeSnapBubbleView` and when IME is visible: `IME top > AdvancedSymbolInputView > header_container > EdgeSnapBubbleView` (implemented via anchor switching + `syncSymbolInputPageWithAnchor`).  

### Testing
- Attempted a Kotlin compile check with `./gradlew :core:app:compileDebugKotlin :core:common:compileDebugKotlin`, which ran but failed due to a local toolchain/SDK environment issue (`25.0.1`) unrelated to the source logic; the compile did not complete successfully.  
- No unit tests were added or run for these UI/gesture changes in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9879de710832fbdc9afd5176ecab5)