### PR TITLE
Fix AdvancedSymbolInputView anchoring and EdgeSnapBubbleView horizontal gesture handling

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -216,6 +216,7 @@ abstract class BaseEditorActivity :
   private var bottomSheetSlideOffset = 0f
   private var blockBottomSheetExpandForTabSwitch = false
   private var latestImeBottomInset = 0
+  private var isImeVisibleForSymbolInput = false
   private var pendingBottomSheetState: Int? = null
   private var cursorPositionReceipt: SubscriptionReceipt<SelectionChangeEvent>? = null
 
@@ -896,15 +897,10 @@ abstract class BaseEditorActivity :
   private fun updateSymbolInputPageAnchor(active: Boolean) {
     if (_binding == null) return
     val params = content.symbolInputPage.layoutParams as CoordinatorLayout.LayoutParams
-    if (active) {
-      params.anchorId = View.NO_ID
-      params.anchorGravity = Gravity.NO_GRAVITY
-      params.gravity = Gravity.BOTTOM
-    } else {
-      params.anchorId = R.id.bottom_sheet
-      params.anchorGravity = Gravity.TOP
-      params.gravity = Gravity.NO_GRAVITY
-    }
+    // 始终锚定到底部抽屉顶部；IME 弹出时通过 translation 同步到 IME 顶部。
+    params.anchorId = R.id.bottom_sheet
+    params.anchorGravity = Gravity.TOP
+    params.gravity = Gravity.NO_GRAVITY
     content.symbolInputPage.layoutParams = params
   }
 
@@ -960,7 +956,8 @@ abstract class BaseEditorActivity :
       content.externalSymbolInputView.visibility = View.GONE
       
       content.symbolInputPage.translationY = 0f
-      
+      isImeVisibleForSymbolInput = false
+
       updateSymbolInputPageAnchor(false)
       content.bottomSheet.resetSymbolInputPageHeight()
     }
@@ -1032,6 +1029,7 @@ abstract class BaseEditorActivity :
         content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+        isImeVisibleForSymbolInput = isImeVisible
         if (isExternalSymbolPageActive) {
             val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
             view.translationY = targetTranslationY

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -205,7 +205,7 @@ abstract class BaseEditorActivity :
     }
   }
 
-  private var isImeVisible = false
+  private var activityImeVisible = false
   private var contentCardRealHeight: Int? = null
   private val editorSurfaceContainerBackground by lazy { resolveAttr(R.attr.colorSurfaceDim) }
   private val editorLayoutCorners by lazy {
@@ -281,8 +281,8 @@ abstract class BaseEditorActivity :
     }
 
     val isImeVisibleNow = imeInsets.bottom > 0
-    if (this.isImeVisible != isImeVisibleNow) {
-      this.isImeVisible = isImeVisibleNow
+    if (this.activityImeVisible != isImeVisibleNow) {
+      this.activityImeVisible = isImeVisibleNow
       onSoftInputChanged()
     }
   }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -113,8 +113,12 @@ class EdgeSnapBubbleView : View {
   }
 
 override fun onTouchEvent(ev: MotionEvent): Boolean {
+    if (orientation == Orientation.HORIZONTAL) {
+      return handleHorizontalTouchEvent(ev)
+    }
+
     // 兼容水平模式下的垂直拖拽手势
-    val currentTouchX = if (orientation == Orientation.HORIZONTAL) ev.y else ev.x
+    val currentTouchX = ev.x
     // 固定绘制锚点，保障拖拽手势时视觉驼峰完美居中
     currentY = if (orientation == Orientation.HORIZONTAL) backViewHeight / 2f else ev.y
     
@@ -182,6 +186,40 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
       }
     }
     return isEdge
+  }
+
+  private fun handleHorizontalTouchEvent(ev: MotionEvent): Boolean {
+    currentY = backViewHeight / 2f
+    when (ev.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        downX = ev.y
+        deltaX = 0f
+        isEdge = true
+        parent?.requestDisallowInterceptTouchEvent(true)
+        invalidate()
+        return true
+      }
+      MotionEvent.ACTION_MOVE -> {
+        if (!isEdge) return false
+        val dy = downX - ev.y
+        deltaX = dy.coerceIn(-backMaxWidth, backMaxWidth)
+        onBubbleGestureListener?.onDrag(getDragFraction())
+        invalidate()
+        return true
+      }
+      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+        if (!isEdge) return false
+        if (abs(deltaX) < backMaxWidth * 0.2f) {
+          performClick()
+        }
+        onBubbleGestureListener?.onRelease(getDragFraction())
+        deltaX = 0f
+        isEdge = false
+        invalidate()
+        return true
+      }
+    }
+    return false
   }
 
   private fun drawHorizontalBubble(canvas: Canvas, dragDelta: Float) {


### PR DESCRIPTION
### Motivation
- 修复符号输入面板没有按照底部抽屉 / IME 的层级关系固定显示在目标顶部的问题，并保证在 IME 弹出时强制同步到软键盘顶部边缘。 
- 解决 EdgeSnapBubbleView 在“水平模式（顶部气泡）”时触摸手势方向映射错误，导致驼峰贝塞尔动画只在错误的手势方向上播放的问题。 

### Description
- 始终将 `symbol_input_page` 的 `CoordinatorLayout.LayoutParams` 锚定到 `R.id.bottom_sheet` 的顶部，并在 IME 模式下通过 `translationY` / insets 动画同步到软键盘顶部以实现双模态（bottom_sheet / IME）切换（修改文件：`BaseEditorActivity.kt`）。
- 增加并维护符号输入专用的 IME 可见状态标记 `isImeVisibleForSymbolInput`，并在外部符号模式退出时正确重置 translation 与状态以恢复原始层级关系（修改文件：`BaseEditorActivity.kt`）。
- 将 `EdgeSnapBubbleView` 的水平（顶部）触摸处理提取为 `handleHorizontalTouchEvent` 专用路径，改为将垂直滑动量映射到内部 `deltaX` 并在上滑时实时驱动 `onDrag`，保证驼峰拉伸/回弹动画随上滑手势播放，同时保留轻触判定（修改文件：`EdgeSnapBubbleView.kt`）。
- 保留原有竖直模式逻辑与绘制实现，改动尽量局部以保持原有层级约束与性能考虑（文件：`BaseEditorActivity.kt`, `EdgeSnapBubbleView.kt`）。

### Testing
- 运行编译命令 `./gradlew :core:app:compileDebugKotlin -x lint` 以验证改动编译性；此次环境中构建在工具链/SDK 阶段失败并未完成编译，失败信息为 `25.0.1`（工具链版本问题），因此无法在该环境完成模块级编译验证（失败）。
- 已在代码层面进行 smoke-level 手动审查与行为逻辑调整，确保触摸到回调映射与 IME translation 路径被正确更新（自动化编译未通过，故无通过的自动测试记录）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9879de710832fbdc9afd5176ecab5)