### PR TITLE
Fix AdvancedSymbolInputView anchoring and EdgeSnapBubble upward-gesture behavior

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -815,7 +815,8 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              syncSymbolInputHierarchyForSlide(slideOffset)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -896,16 +897,19 @@ abstract class BaseEditorActivity :
   private fun updateSymbolInputPageAnchor(active: Boolean) {
     if (_binding == null) return
     val params = content.symbolInputPage.layoutParams as CoordinatorLayout.LayoutParams
-    if (active) {
-      params.anchorId = View.NO_ID
-      params.anchorGravity = Gravity.NO_GRAVITY
-      params.gravity = Gravity.BOTTOM
-    } else {
-      params.anchorId = R.id.bottom_sheet
-      params.anchorGravity = Gravity.TOP
-      params.gravity = Gravity.NO_GRAVITY
-    }
+    params.anchorId = R.id.bottom_sheet
+    params.anchorGravity = Gravity.TOP
+    params.gravity = Gravity.NO_GRAVITY
     content.symbolInputPage.layoutParams = params
+  }
+
+  private fun syncSymbolInputHierarchyForSlide(slideOffset: Float) {
+    if (_binding == null || isExternalSymbolPageActive) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val fade = (1f - progress).coerceIn(0f, 1f)
+    content.headerOverlayContainer.alpha = fade
+    content.pageSwitchGestureBubble.alpha = fade
+    content.headerContainer.alpha = fade
   }
 
   private fun setExternalSymbolPageActive(active: Boolean) {
@@ -1029,15 +1033,11 @@ abstract class BaseEditorActivity :
         val navBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
         latestImeBottomInset = imeBottom
         
-        content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
+        content.externalSymbolInputView.setImeBottomInset(imeBottom)
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
-        } else {
-            view.translationY = 0f
-        }
+        val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+        view.translationY = targetTranslationY
 
         insets
     }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -129,7 +129,8 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
       }
 
       MotionEvent.ACTION_MOVE -> {
-        deltaX = downX - currentTouchX
+        val rawDelta = downX - currentTouchX
+        deltaX = if (orientation == Orientation.HORIZONTAL) rawDelta.coerceAtLeast(0f) else rawDelta
         val diff = forwardX - currentTouchX
         if (diff > 0) {
           if (currentTouchX < thresholdLeft && left) {
@@ -160,7 +161,10 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
         }
         forwardX = currentTouchX
         if (isEdge) {
-          onBubbleGestureListener?.onDrag(getDragFraction())
+          val dragFraction = getDragFraction()
+          if (orientation != Orientation.HORIZONTAL || dragFraction > 0f) {
+            onBubbleGestureListener?.onDrag(dragFraction)
+          }
           invalidate()
         }
       }
@@ -171,7 +175,10 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
           if (abs(deltaX) < backMaxWidth * 0.2f) {
             performClick()
           }
-          onBubbleGestureListener?.onRelease(getDragFraction())
+          val dragFraction = getDragFraction()
+          if (orientation != Orientation.HORIZONTAL || dragFraction > 0f) {
+            onBubbleGestureListener?.onRelease(dragFraction)
+          }
           deltaX = 0f
           invalidate()
         }


### PR DESCRIPTION
### Motivation
- Fix incorrect placement of `AdvancedSymbolInputView` which could detach from the expected top-anchor stack `bottom_sheet > AdvancedSymbolInputView > header_container > EdgeSnapBubbleView` and appear at the bottom.
- Ensure `AdvancedSymbolInputView` follows the IME top edge whenever the keyboard is shown and restore prior layout when IME hides.
- Prevent downward horizontal gestures from driving the EdgeSnap hump stretch/rebound animation and only play that animation when the user drags upward as intended.

### Description
- In `BaseEditorActivity.kt` keep `symbolInputPage` anchored to `R.id.bottom_sheet` by default by simplifying `updateSymbolInputPageAnchor` so the symbol page remains bound to the bottom-sheet top baseline (`AdvancedSymbolInputView` anchor). 
- Add `syncSymbolInputHierarchyForSlide(slideOffset: Float)` and call it from `BottomSheetBehavior.onSlide` to proportionally fade/sync `headerOverlayContainer`, `pageSwitchGestureBubble` and `headerContainer` during bottom-sheet drags so header/bubble hide/show follows gesture percentage.
- In the IME insets handler (`ViewCompat.setOnApplyWindowInsetsListener`) always apply the IME bottom inset to the external symbol input view and update the container translation so `AdvancedSymbolInputView` follows IME top edge whenever the keyboard is visible.
- In `EdgeSnapBubbleView.kt` change `onTouchEvent` to compute a `rawDelta` and coerce it positive for horizontal orientation, and only invoke `onDrag`/`onRelease` callbacks when the drag fraction indicates an upward (expanding) gesture (i.e. `dragFraction > 0f`), preventing downward drags from triggering the hump animation.

### Testing
- Attempted a local Kotlin compile with `./gradlew :core:app:compileDebugKotlin -x lint`, but the build aborted early in this environment with a toolchain/version error (`25.0.1`) and did not complete module compilation.
- Verified diffs and ran code search checks to ensure modified symbols and call-sites (`rg`/`sed`) were updated as expected and committed the changes; no unit/instrumented tests were executed in this environment due to the toolchain failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9879de710832fbdc9afd5176ecab5)