### PR TITLE
Fix AdvancedSymbolInput anchoring/IME sync and EdgeSnapBubbleView upward-swipe behavior

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -815,7 +815,11 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              val hiddenFraction = slideOffset.coerceIn(0f, 1f)
+              this.headerOverlayContainer.alpha = 1f - hiddenFraction
+              this.pageSwitchGestureBubble.alpha = 1f - hiddenFraction
+              this.externalSymbolInputView.alpha = 1f - (hiddenFraction * 0.35f)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -896,7 +900,7 @@ abstract class BaseEditorActivity :
   private fun updateSymbolInputPageAnchor(active: Boolean) {
     if (_binding == null) return
     val params = content.symbolInputPage.layoutParams as CoordinatorLayout.LayoutParams
-    if (active) {
+    if (active || latestImeBottomInset > 0) {
       params.anchorId = View.NO_ID
       params.anchorGravity = Gravity.NO_GRAVITY
       params.gravity = Gravity.BOTTOM
@@ -1012,8 +1016,6 @@ abstract class BaseEditorActivity :
                 insets: WindowInsetsCompat,
                 runningAnimations: MutableList<WindowInsetsAnimationCompat>
             ): WindowInsetsCompat {
-                if (!isExternalSymbolPageActive) return insets
-
                 val imeAnimation = runningAnimations.find { it.typeMask and WindowInsetsCompat.Type.ime() != 0 }
                 if (imeAnimation != null) {
                     val fraction = imeAnimation.interpolatedFraction
@@ -1028,16 +1030,16 @@ abstract class BaseEditorActivity :
         val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
         val navBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
         latestImeBottomInset = imeBottom
-        
-        content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
-
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
+        content.externalSymbolInputView.setImeBottomInset(if (isImeVisible) imeBottom else 0)
+
+        val targetTranslationY = if (isImeVisible && imeBottom > 0) {
+            -(imeBottom - navBottom).toFloat().coerceAtMost(0f)
         } else {
-            view.translationY = 0f
+            0f
         }
+        view.translationY = targetTranslationY
+        updateSymbolInputPageAnchor(isExternalSymbolPageActive)
 
         insets
     }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -113,7 +113,7 @@ class EdgeSnapBubbleView : View {
   }
 
 override fun onTouchEvent(ev: MotionEvent): Boolean {
-    // 兼容水平模式下的垂直拖拽手势
+    // 水平模式用垂直坐标：只响应“向上拖拽”
     val currentTouchX = if (orientation == Orientation.HORIZONTAL) ev.y else ev.x
     // 固定绘制锚点，保障拖拽手势时视觉驼峰完美居中
     currentY = if (orientation == Orientation.HORIZONTAL) backViewHeight / 2f else ev.y
@@ -129,6 +129,17 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
       }
 
       MotionEvent.ACTION_MOVE -> {
+        if (orientation == Orientation.HORIZONTAL) {
+          val upwardDelta = (downX - currentTouchX).coerceAtLeast(0f)
+          deltaX = upwardDelta.coerceAtMost(backMaxWidth)
+          if (isEdge) {
+            onBubbleGestureListener?.onDrag(getDragFraction())
+            invalidate()
+          }
+          forwardX = currentTouchX
+          return isEdge
+        }
+
         deltaX = downX - currentTouchX
         val diff = forwardX - currentTouchX
         if (diff > 0) {


### PR DESCRIPTION
### Motivation
- Fix advanced symbol input not staying anchored at the bottom/top according to the specified hierarchy and IME behavior. 
- Correct `EdgeSnapBubbleView` gesture handling so only upward swipe drives the hump stretch animation and downward swipes do not trigger it. 
- Ensure dynamic switching between `bottom_sheet` anchoring and IME-top anchoring for `AdvancedSymbolInputView` and keep layered controls visually synchronized during bottom-sheet drag. 

### Description
- Changed `EdgeSnapBubbleView.onTouchEvent()` to map horizontal (top/bubble) gestures to a clamped upward-only delta and to call `onDrag` only for upward movement, preventing downward swipes from driving the hump animation (file: `core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt`).
- Synchronized overlay visibility with bottom-sheet sliding by fading `headerOverlayContainer`, `pageSwitchGestureBubble` and partially fading `externalSymbolInputView` based on `slideOffset` to preserve the visual stacking `AdvancedSymbolInputView > header_container > EdgeSnapBubbleView` during drag (file: `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt`).
- Made anchor logic in `updateSymbolInputPageAnchor()` responsive to IME presence by treating a non-zero `latestImeBottomInset` like external activation so `symbol_input_page` switches to bottom gravity while IME is visible and restores when IME closes (file: `BaseEditorActivity.kt`).
- Improved IME synchronization in `setupExternalSymbolImeSync()` so `symbol_input_page` translation follows IME animation regardless of external-page state, `external_symbol_input_view` receives the IME inset whenever the keyboard is visible, and `updateSymbolInputPageAnchor()` is re-evaluated during IME open/close transitions (file: `BaseEditorActivity.kt`).

### Testing
- Attempted automated compilation with `./gradlew :core:app:compileDebugKotlin -x lint`, but the build failed due to the container toolchain/SDK environment error (`What went wrong: 25.0.1`), so runtime verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f992b14a50832f9ae25326c37df156)