### PR TITLE
Fix symbol panel anchor hierarchy and EdgeSnap upward gesture handling

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -108,7 +108,6 @@ import com.itsaky.androidide.xml.widgets.WidgetTableRegistry
 import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.event.SubscriptionReceipt
 import java.io.File
-import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlinx.coroutines.CoroutineScope
@@ -896,15 +895,9 @@ abstract class BaseEditorActivity :
   private fun updateSymbolInputPageAnchor(active: Boolean) {
     if (_binding == null) return
     val params = content.symbolInputPage.layoutParams as CoordinatorLayout.LayoutParams
-    if (active) {
-      params.anchorId = View.NO_ID
-      params.anchorGravity = Gravity.NO_GRAVITY
-      params.gravity = Gravity.BOTTOM
-    } else {
-      params.anchorId = R.id.bottom_sheet
-      params.anchorGravity = Gravity.TOP
-      params.gravity = Gravity.NO_GRAVITY
-    }
+    params.anchorId = R.id.bottom_sheet
+    params.anchorGravity = Gravity.TOP
+    params.gravity = Gravity.NO_GRAVITY
     content.symbolInputPage.layoutParams = params
   }
 
@@ -1067,19 +1060,23 @@ abstract class BaseEditorActivity :
         object : EdgeSnapBubbleView.OnBubbleGestureListener {
           override fun onDrag(fraction: Float) {
              if (_binding != null) {
-                 val absFrac = abs(fraction)
-                 val alpha = (1f - absFrac * 0.8f).coerceIn(0.2f, 1f)
+                 val progress = fraction.coerceIn(0f, 1f)
+                 val alpha = (1f - progress * 0.8f).coerceIn(0.2f, 1f)
                  content.headerContainer.alpha = alpha
+                 content.cardView.alpha = alpha
+                 content.pageSwitchGestureBubble.alpha = (0.6f + 0.4f * (1f - progress)).coerceIn(0.4f, 1f)
              }
           }
 
           override fun onRelease(fraction: Float) {
-             if (fraction > 0.15f) { 
+             if (fraction > 0.15f) {
                 requestBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
-             } else if (fraction < -0.15f) { 
+             } else {
                 requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
              }
              content.headerContainer.alpha = 1f
+             content.cardView.alpha = 1f
+             content.pageSwitchGestureBubble.alpha = 1f
           }
         }
     )

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -129,6 +129,17 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
       }
 
       MotionEvent.ACTION_MOVE -> {
+        if (orientation == Orientation.HORIZONTAL) {
+          val rawDrag = downX - currentTouchX
+          deltaX = rawDrag.coerceAtLeast(0f).coerceAtMost(backMaxWidth)
+          forwardX = currentTouchX
+          if (isEdge) {
+            onBubbleGestureListener?.onDrag(getDragFraction())
+            invalidate()
+          }
+          return true
+        }
+
         deltaX = downX - currentTouchX
         val diff = forwardX - currentTouchX
         if (diff > 0) {


### PR DESCRIPTION
### Motivation
- 修复 `AdvancedSymbolInputView`/`symbol_input_page` 在切换外部符号输入模式时脱离 `bottom_sheet` 锚点导致位置漂移的问题。 
- 纠正 `EdgeSnapBubbleView` 水平模式下的手势方向逻辑，使驼峰拉伸/回弹只在向上滑动时响应，而向下滑动不再触发动画。 
- 使页面顶部的 header/card/bubble 在拖动期间按手势进度同步透明度，并在释放后恢复或触发展开/折叠。 

### Description
- 在 `BaseEditorActivity` 中调整 `updateSymbolInputPageAnchor`，将 `symbolInputPage` 固定为始终锚定到 `R.id.bottom_sheet` 且 `anchorGravity = Gravity.TOP`，消除外部模式切换时的脱离行为（文件：`core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt`）。
- 在 `BaseEditorActivity.setupPageSwitchGestureBubble` 中更新手势回调逻辑，使用上滑进度 `fraction.coerceIn(0f,1f)` 来驱动 `headerContainer`/`cardView`/`pageSwitchGestureBubble` 的 alpha，同步释放阈值为展开/折叠的判定并确保释放后恢复 alpha（文件：`core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt`）。
- 在 `EdgeSnapBubbleView.onTouchEvent` 中为水平（`Orientation.HORIZONTAL`）模式加入专用分支，计算向上拖拽量并限制为 `[0, backMaxWidth]`，仅在该方向上调用 `onDrag` 并 `invalidate()`，从而避免向下滑动时触发驼峰拉伸动画（文件：`core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt`）。
- 清理了冗余的绝对值依赖并同步了拖动与释放时的视觉反馈，保持 IME 同步路径与原有逻辑兼容性。 

### Testing
- 尝试运行 `./gradlew :core:app:compileDebugKotlin -x lint` 以编译受影响模块，构建在本环境因本地 SDK/toolchain 问题报错并中止，错误指向工具链版本 `25.0.1`，故编译未能在此 CI 环境完成（失败）。
- 未运行额外的单元/集成测试；手动静态检查和小范围交互逻辑验证通过（非自动化）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f992b14a50832f9ae25326c37df156)