### PR TITLE
Fix AdvancedSymbolInputView anchoring and IME / bottom-sheet layering

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -815,7 +815,13 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              applyLayeredVisibilityByBottomSheet(slideOffset)
+              val imeVisible = ViewCompat.getRootWindowInsets(symbolInputPage)?.isVisible(WindowInsetsCompat.Type.ime()) == true
+              if (!imeVisible) {
+                val anchorBottom = bottomSheet.top
+                updateSymbolStackByBottomAnchor(anchorBottom)
+              }
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -906,6 +912,32 @@ abstract class BaseEditorActivity :
       params.gravity = Gravity.NO_GRAVITY
     }
     content.symbolInputPage.layoutParams = params
+  }
+
+
+  private fun updateSymbolStackByBottomAnchor(anchorBottom: Int) {
+    if (_binding == null) return
+    val safeAnchorBottom = anchorBottom.coerceAtLeast(0)
+    val pageHeight = content.symbolInputPage.height
+    val pageTop = safeAnchorBottom - pageHeight
+    content.symbolInputPage.y = pageTop.toFloat()
+
+    val headerContainer = content.headerOverlayContainer
+    val bubble = content.pageSwitchGestureBubble
+    val stackTop = pageTop
+
+    headerContainer.y = (stackTop - headerContainer.height).toFloat()
+    bubble.y = (headerContainer.y - bubble.height)
+  }
+
+  private fun applyLayeredVisibilityByBottomSheet(slideOffset: Float) {
+    if (_binding == null) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val visibilityAlpha = (1f - progress).coerceIn(0f, 1f)
+    content.headerOverlayContainer.alpha = visibilityAlpha
+    content.headerContainer.alpha = visibilityAlpha
+    content.cardView.alpha = visibilityAlpha
+    content.pageSwitchGestureBubble.alpha = (0.55f + 0.45f * visibilityAlpha).coerceIn(0.55f, 1f)
   }
 
   private fun setExternalSymbolPageActive(active: Boolean) {
@@ -1004,7 +1036,7 @@ abstract class BaseEditorActivity :
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
-                endTranslationY = if (imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+                endTranslationY = if (imeBottom > navBottom) -(imeBottom - navBottom).toFloat() else 0f
                 return bounds
             }
 
@@ -1033,10 +1065,15 @@ abstract class BaseEditorActivity :
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
         if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+            val targetTranslationY = if (isImeVisible && imeBottom > navBottom) -(imeBottom - navBottom).toFloat() else 0f
             view.translationY = targetTranslationY
+            val imeTop = view.bottom + targetTranslationY.toInt()
+            updateSymbolStackByBottomAnchor(imeTop)
         } else {
             view.translationY = 0f
+            if (!isImeVisible) {
+              updateSymbolStackByBottomAnchor(content.bottomSheet.top)
+            }
         }
 
         insets


### PR DESCRIPTION
### Motivation
- Fix incorrect positioning of `AdvancedSymbolInputView` so it stays anchored to the correct bottom anchor (bottom sheet top or IME top) and maintain the intended top/bottom layer ordering among bottom_sheet > AdvancedSymbolInputView > header_container > EdgeSnapBubbleView. 
- Ensure dynamic dual-modal switching between bottom-sheet and IME modes where the symbol view always follows the active top-edge anchor. 
- Make header/card/bubble visibility and positioning follow bottom-sheet gestures proportionally and avoid brittle clamp/math that previously broke IME lift behavior.

### Description
- Added `updateSymbolStackByBottomAnchor(anchorBottom: Int)` in `BaseEditorActivity` to compute and set a single coordinated stack layout for `symbolInputPage`, `headerOverlayContainer` and `pageSwitchGestureBubble` from a single bottom anchor. 
- Added `applyLayeredVisibilityByBottomSheet(slideOffset: Float)` to drive proportional alpha transitions for the header/card/bubble during bottom-sheet slides. 
- In bottom-sheet `onSlide(...)` now call `applyLayeredVisibilityByBottomSheet(...)` and update the symbol stack using `updateSymbolStackByBottomAnchor(bottomSheet.top)` when IME is not visible so the symbol UI follows the bottom-sheet top correctly. 
- Fixed IME inset/animation math: compute IME lift as `-(imeBottom - navBottom)` only when `imeBottom > navBottom` (instead of clamping to zero incorrectly), and when IME is visible switch the symbol stack anchor to the IME top; when IME closes restore anchor back to the bottom-sheet top. 
- Minimal, focused edits contained in `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` to implement the anchor/visibility logic while preserving existing drawing/animation approaches.

### Testing
- Attempted to run `./gradlew :core:app:compileDebugKotlin -x lint`, but the build aborted early with a local SDK/toolchain error (`25.0.1`) before the module compiled, so full module compilation tests did not complete. 
- No automated unit/integration tests were executed in this environment; change is limited to UI layout/animation logic and requires running the app on device/emulator for functional verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9aa8a5984832f8a97fe94ac01fe36)