### PR TITLE
Fix symbol input anchoring with BottomSheet and IME

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -893,16 +893,20 @@ abstract class BaseEditorActivity :
     )
   }
 
-  private fun updateSymbolInputPageAnchor(active: Boolean) {
+  private fun updateSymbolInputPageAnchor(active: Boolean, imeVisible: Boolean = false) {
     if (_binding == null) return
     val params = content.symbolInputPage.layoutParams as CoordinatorLayout.LayoutParams
-    if (active) {
+    if (imeVisible) {
+      params.anchorId = View.NO_ID
+      params.anchorGravity = Gravity.NO_GRAVITY
+      params.gravity = Gravity.BOTTOM
+    } else if (active) {
       params.anchorId = View.NO_ID
       params.anchorGravity = Gravity.NO_GRAVITY
       params.gravity = Gravity.BOTTOM
     } else {
       params.anchorId = R.id.bottom_sheet
-      params.anchorGravity = Gravity.TOP
+      params.anchorGravity = Gravity.BOTTOM
       params.gravity = Gravity.NO_GRAVITY
     }
     content.symbolInputPage.layoutParams = params
@@ -941,7 +945,7 @@ abstract class BaseEditorActivity :
       content.tvCursorPosition.visibility = View.GONE
       content.externalSymbolInputView.visibility = View.VISIBLE
       
-      updateSymbolInputPageAnchor(true)
+      updateSymbolInputPageAnchor(true, latestImeBottomInset > 0)
       applyExternalSymbolImeInset()
       
     } else {
@@ -961,7 +965,7 @@ abstract class BaseEditorActivity :
       
       content.symbolInputPage.translationY = 0f
       
-      updateSymbolInputPageAnchor(false)
+      updateSymbolInputPageAnchor(false, latestImeBottomInset > 0)
       content.bottomSheet.resetSymbolInputPageHeight()
     }
     
@@ -1012,7 +1016,6 @@ abstract class BaseEditorActivity :
                 insets: WindowInsetsCompat,
                 runningAnimations: MutableList<WindowInsetsAnimationCompat>
             ): WindowInsetsCompat {
-                if (!isExternalSymbolPageActive) return insets
 
                 val imeAnimation = runningAnimations.find { it.typeMask and WindowInsetsCompat.Type.ime() != 0 }
                 if (imeAnimation != null) {
@@ -1032,12 +1035,10 @@ abstract class BaseEditorActivity :
         content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
 
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
-        } else {
-            view.translationY = 0f
-        }
+        val shouldFollowIme = isImeVisible && imeBottom > 0
+        updateSymbolInputPageAnchor(isExternalSymbolPageActive, shouldFollowIme)
+        val targetTranslationY = if (shouldFollowIme) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+        view.translationY = targetTranslationY
 
         insets
     }

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -120,7 +120,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="bottom"
-          app:layout_anchorGravity="top"
+          app:layout_anchorGravity="bottom"
           android:orientation="vertical"
           android:elevation="0dp"
           android:background="@null"


### PR DESCRIPTION
### Motivation
- Ensure `AdvancedSymbolInputView` (`symbol_input_page`) is anchored and layered according to the required stack (`bottom_sheet > AdvancedSymbolInputView > header_container > EdgeSnapBubbleView`) and that it force-follows the IME top edge when the keyboard is visible.
- Avoid position/stutter bugs when switching between bottom-sheet mode and IME mode by centralizing anchor/translation logic and keeping IME animation interpolation active for all modes.

### Description
- Changed `app:layout_anchorGravity` for `symbol_input_page` in `core/app/src/main/res/layout/content_editor.xml` from `top` to `bottom` to bind the view to the bottom edge of the `bottom_sheet`.
- Updated `updateSymbolInputPageAnchor` in `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` to `updateSymbolInputPageAnchor(active: Boolean, imeVisible: Boolean = false)` and prioritized IME anchoring when `imeVisible` is true.
- Reapplied anchor logic during `setExternalSymbolPageActive(...)` by passing current IME inset state so state transitions do not leave the symbol input in a stale position.
- Adjusted `setupExternalSymbolImeSync()` to keep IME animation interpolation and to call `updateSymbolInputPageAnchor(...)` on each inset update, computing a unified `targetTranslationY` so the `symbol_input_page` follows IME top edge regardless of external-symbol mode.
- Removed the early return that prevented IME animation interpolation when external-symbol mode was not active, allowing smooth animated translation in all relevant cases.

### Testing
- Attempted to compile the app Kotlin module with `./gradlew :core:app:compileDebugKotlin -x lint`; the build failed early with an environment/toolchain error (`What went wrong: 25.0.1`) unrelated to the code changes, so no successful compile/test could be completed in this environment.
- Static inspection and project run tools (search/patch) were used to verify changed call sites and layout attribute updates succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9aa8a5984832f8a97fe94ac01fe36)