### PR TITLE
Fix AdvancedSymbolInputView anchoring and IME/bottom-sheet layering

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -216,6 +216,7 @@ abstract class BaseEditorActivity :
   private var bottomSheetSlideOffset = 0f
   private var blockBottomSheetExpandForTabSwitch = false
   private var latestImeBottomInset = 0
+  private var imeAnchorActive = false
   private var pendingBottomSheetState: Int? = null
   private var cursorPositionReceipt: SubscriptionReceipt<SelectionChangeEvent>? = null
 
@@ -815,6 +816,7 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
+              updateSymbolOverlayBySheetOffset(slideOffset)
               
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
@@ -976,9 +978,42 @@ abstract class BaseEditorActivity :
 
   private fun applyExternalSymbolImeInset() {
     if (_binding == null) return
-    content.symbolInputPage.translationY = 0f
     val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
+    updateSymbolInputPageAnchorForIme(imeAnchorActive)
+  }
+
+  private fun updateSymbolOverlayBySheetOffset(slideOffset: Float) {
+    if (_binding == null) return
+    val progress = slideOffset.coerceIn(0f, 1f)
+    val alpha = (1f - progress).coerceIn(0f, 1f)
+    val translateY = progress * content.headerOverlayContainer.height * 0.5f
+    content.headerOverlayContainer.alpha = alpha
+    content.headerOverlayContainer.translationY = translateY
+    content.externalSymbolInputView.alpha = alpha
+    content.externalSymbolInputView.translationY = translateY
+  }
+
+  private fun updateSymbolInputPageAnchorForIme(imeVisible: Boolean) {
+    if (_binding == null) return
+    imeAnchorActive = imeVisible
+    val symbolInputPage = content.symbolInputPage
+    if (!isExternalSymbolPageActive) {
+      updateSymbolInputPageAnchor(false)
+      symbolInputPage.translationY = if (imeVisible && latestImeBottomInset > 0) {
+        -latestImeBottomInset.toFloat()
+      } else {
+        0f
+      }
+      return
+    }
+
+    updateSymbolInputPageAnchor(true)
+    symbolInputPage.translationY = if (imeVisible && latestImeBottomInset > 0) {
+      -latestImeBottomInset.toFloat()
+    } else {
+      0f
+    }
   }
 
   private fun setupExternalSymbolImeSync() {
@@ -1026,18 +1061,11 @@ abstract class BaseEditorActivity :
 
     ViewCompat.setOnApplyWindowInsetsListener(symbolInputPage) { view, insets ->
         val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-        val navBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
         latestImeBottomInset = imeBottom
+        val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime()) && imeBottom > 0
         
         content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
-
-        val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
-        } else {
-            view.translationY = 0f
-        }
+        updateSymbolInputPageAnchorForIme(isImeVisible)
 
         insets
     }


### PR DESCRIPTION
### Motivation
- Fix incorrect positioning and layering of `AdvancedSymbolInputView` so it remains anchored to the correct top-edge depending on bottom-sheet vs IME state.
- Ensure the three controls (`AdvancedSymbolInputView` / `header_container` / `EdgeSnapBubbleView`) move and hide/show synchronously during bottom-sheet gestures.
- Unify IME handling so that when the system keyboard opens the symbol input is forced to the IME top edge and restored on close.

### Description
- Added `imeAnchorActive` state and centralized IME/anchor handling in `BaseEditorActivity` to keep anchor state consistent across mode switches.
- Introduced `updateSymbolOverlayBySheetOffset(slideOffset: Float)` to synchronize alpha and translation of `headerOverlayContainer` and `externalSymbolInputView` during bottom-sheet sliding and wired it into the bottom-sheet `onSlide` path.
- Added `updateSymbolInputPageAnchorForIme(imeVisible: Boolean)` and routed window insets changes to it so the `symbol_input_page` is dynamically re-anchored to the bottom-sheet top or IME top as required.
- Reworked `applyExternalSymbolImeInset()` and the insets listener to use the centralized anchor/translation update paths instead of ad-hoc translation resets.
- Changes live in `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` and keep existing behaviors (external symbol page vs normal header) but ensure consistent top-edge binding and smooth transitions.

### Testing
- Attempted a Kotlin compile check with `./gradlew :core:app:compileDebugKotlin -x lint`, but the run failed due to environment Gradle wrapper download being blocked by a proxy (`HTTP/1.1 403 Forbidden`) so no build-time verification could be completed in this environment.
- No unit/instrumentation tests were added; runtime behavior to validate: bottom-sheet slide follow, IME open forces symbol input to IME top, and restore on IME close (manual QA recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9aa8a5984832f8a97fe94ac01fe36)