### PR TITLE
修复符号输入面板在 BottomSheet / IME 下的锚定与 EdgeSnap 气泡初始化定位

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -896,7 +896,11 @@ abstract class BaseEditorActivity :
   private fun updateSymbolInputPageAnchor(active: Boolean) {
     if (_binding == null) return
     val params = content.symbolInputPage.layoutParams as CoordinatorLayout.LayoutParams
-    if (active) {
+    if (latestImeBottomInset > 0) {
+      params.anchorId = View.NO_ID
+      params.anchorGravity = Gravity.NO_GRAVITY
+      params.gravity = Gravity.BOTTOM
+    } else if (active) {
       params.anchorId = View.NO_ID
       params.anchorGravity = Gravity.NO_GRAVITY
       params.gravity = Gravity.BOTTOM
@@ -976,9 +980,9 @@ abstract class BaseEditorActivity :
 
   private fun applyExternalSymbolImeInset() {
     if (_binding == null) return
-    content.symbolInputPage.translationY = 0f
-    val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
+    val targetImeInset = latestImeBottomInset
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
+    content.symbolInputPage.translationY = if (latestImeBottomInset > 0) -latestImeBottomInset.toFloat() else 0f
   }
 
   private fun setupExternalSymbolImeSync() {
@@ -1012,8 +1016,6 @@ abstract class BaseEditorActivity :
                 insets: WindowInsetsCompat,
                 runningAnimations: MutableList<WindowInsetsAnimationCompat>
             ): WindowInsetsCompat {
-                if (!isExternalSymbolPageActive) return insets
-
                 val imeAnimation = runningAnimations.find { it.typeMask and WindowInsetsCompat.Type.ime() != 0 }
                 if (imeAnimation != null) {
                     val fraction = imeAnimation.interpolatedFraction
@@ -1027,17 +1029,12 @@ abstract class BaseEditorActivity :
     ViewCompat.setOnApplyWindowInsetsListener(symbolInputPage) { view, insets ->
         val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
         val navBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
-        latestImeBottomInset = imeBottom
-        
-        content.externalSymbolInputView.setImeBottomInset(if (isExternalSymbolPageActive) imeBottom else 0)
-
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (isExternalSymbolPageActive) {
-            val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
-        } else {
-            view.translationY = 0f
-        }
+        latestImeBottomInset = if (isImeVisible) (imeBottom - navBottom).coerceAtLeast(0) else 0
+        updateSymbolInputPageAnchor(isExternalSymbolPageActive)
+        content.externalSymbolInputView.setImeBottomInset(if (isImeVisible) imeBottom else 0)
+        val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
+        view.translationY = targetTranslationY
 
         insets
     }
@@ -1071,6 +1068,7 @@ abstract class BaseEditorActivity :
                  val alpha = (1f - progress * 0.8f).coerceIn(0.2f, 1f)
                  content.headerContainer.alpha = alpha
                  content.cardView.alpha = alpha
+                 content.externalSymbolInputView.alpha = alpha
                  content.pageSwitchGestureBubble.alpha = (0.6f + 0.4f * (1f - progress)).coerceIn(0.4f, 1f)
              }
           }
@@ -1083,6 +1081,7 @@ abstract class BaseEditorActivity :
              }
              content.headerContainer.alpha = 1f
              content.cardView.alpha = 1f
+             content.externalSymbolInputView.alpha = 1f
              content.pageSwitchGestureBubble.alpha = 1f
           }
         }

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -74,6 +74,8 @@ class EdgeSnapBubbleView : View {
 
   fun setOrientation(newOrientation: Orientation) {
     orientation = newOrientation
+    requestLayout()
+    post { restorePosition() }
   }
 
   fun setMirrored(mirrored: Boolean) {
@@ -260,6 +262,13 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
     mWidth = finalWidth + 1
     thresholdLeft = (mWidth / 3).toFloat()
     thresholdRight = thresholdLeft * 2
+  }
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    if (w != oldw || h != oldh) {
+      post { restorePosition() }
+    }
   }
 
   override fun onDraw(canvas: Canvas) {


### PR DESCRIPTION
### Motivation
- 修复 `AdvancedSymbolInputView` 未按期望在屏幕底部、`bottom_sheet` 顶部或 IME 顶部锚定并同步显示的问题。 
- 确保在 IME 弹出时强制将符号输入面板切换并锚定到 IME 顶部，IME 收起后恢复到原有层级关系（`bottom_sheet` > 符号面板 > `header_container` > `EdgeSnapBubbleView`）。
- 解决首次启动时 `EdgeSnapBubbleView` 贝塞尔“驼峰”被挤压到屏幕左侧导致变形的问题。

### Description
- 在 `BaseEditorActivity.kt` 中调整符号页面锚定逻辑：优先检测 IME（`latestImeBottomInset`）并在 IME 可见时将 `symbol_input_page` 强制设置为底部重力锚定，IME 关闭后再恢复到以 `R.id.bottom_sheet` 为锚点的行为。 
- 统一 IME inset/translation 的处理：在 `applyExternalSymbolImeInset()`、`WindowInsetsAnimationCompat` 回调以及 `OnApplyWindowInsetsListener` 中同步维护 `symbol_input_page` 的 `translationY` 与 `externalSymbolInputView.setImeBottomInset()`，保证动画过程和最终位置都精确贴合 IME 顶部边缘。 
- 将手势拖拽的透明度联动扩展到 `externalSymbolInputView`，使其在 `EdgeSnapBubbleView` 拖拽期间和 `header_container` / `cardView` 一致地做渐变处理以保持视觉一致性。 
- 在 `EdgeSnapBubbleView.kt` 中加入布局/尺寸变化处理：在 `setOrientation()` 中调用 `requestLayout()` 并在下一帧 `post { restorePosition() }`，以及实现 `onSizeChanged()` 回调后 `post { restorePosition() }`，以确保首次布局或尺寸/方向变化后气泡恢复到正确位置，避免贝塞尔曲线被挤压到边缘。 

### Testing
- 尝试用 `./gradlew :core:app:compileDebugKotlin -x lint` 对修改进行编译验证，但构建在当前环境中提前失败（错误指向工具链/环境 `25.0.1`），因此未完成本次改动在设备/仿真器上的运行时验证。 
- 本次补丁局部修改 `BaseEditorActivity.kt` 与 `EdgeSnapBubbleView.kt`，已在代码中添加恢复位置与 IME 同步逻辑以便在后续环境可用时进行完整集成测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b3cb3154832fb743db536bbce034)