### PR TITLE
Editor bottom anchoring and IME sync: anchor symbol_input_page, drive external_symbol_input_view, and fix bubble startup

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -815,7 +815,8 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              updateLayoutBinding(slideOffset = slideOffset)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -979,20 +980,22 @@ abstract class BaseEditorActivity :
     content.symbolInputPage.translationY = 0f
     val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
+    updateLayoutBinding(imeInset = targetImeInset)
   }
 
   private fun setupExternalSymbolImeSync() {
     if (_binding == null) return
     val symbolInputPage = content.symbolInputPage
+    val symbolInputView = content.externalSymbolInputView
 
     ViewCompat.setWindowInsetsAnimationCallback(
-        symbolInputPage,
+        symbolInputView,
         object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
             var startTranslationY = 0f
             var endTranslationY = 0f
 
             override fun onPrepare(animation: WindowInsetsAnimationCompat) {
-                startTranslationY = symbolInputPage.translationY
+                startTranslationY = symbolInputView.translationY
                 super.onPrepare(animation)
             }
 
@@ -1000,7 +1003,7 @@ abstract class BaseEditorActivity :
                 animation: WindowInsetsAnimationCompat,
                 bounds: WindowInsetsAnimationCompat.BoundsCompat
             ): WindowInsetsAnimationCompat.BoundsCompat {
-                val insets = ViewCompat.getRootWindowInsets(symbolInputPage)
+                val insets = ViewCompat.getRootWindowInsets(symbolInputView)
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
@@ -1017,7 +1020,7 @@ abstract class BaseEditorActivity :
                 val imeAnimation = runningAnimations.find { it.typeMask and WindowInsetsCompat.Type.ime() != 0 }
                 if (imeAnimation != null) {
                     val fraction = imeAnimation.interpolatedFraction
-                    symbolInputPage.translationY = startTranslationY + (endTranslationY - startTranslationY) * fraction
+                    symbolInputView.translationY = startTranslationY + (endTranslationY - startTranslationY) * fraction
                 }
                 return insets
             }
@@ -1034,13 +1037,39 @@ abstract class BaseEditorActivity :
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
         if (isExternalSymbolPageActive) {
             val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
+            updateLayoutBinding(imeInset = imeBottom)
         } else {
-            view.translationY = 0f
+            updateLayoutBinding(imeInset = 0)
         }
 
         insets
     }
+  }
+
+  private fun updateLayoutBinding(slideOffset: Float = bottomSheetSlideOffset, imeInset: Int = latestImeBottomInset) {
+    if (_binding == null) return
+    val sheetTop = content.bottomSheet.top.toFloat()
+    val symbolHeight = content.externalSymbolInputView.height.toFloat()
+    val imeActive = isImeVisible && imeInset > 0
+    val targetBottomY = if (imeActive) {
+      (content.realContainer.height - imeInset).toFloat()
+    } else {
+      sheetTop
+    }
+    val symbolTop = targetBottomY - symbolHeight
+    content.externalSymbolInputView.translationY = symbolTop - content.externalSymbolInputView.top
+
+    val hide = slideOffset.coerceIn(0f, 1f)
+    val headerShift = -content.headerContainer.height * hide
+    content.headerContainer.translationY = headerShift
+    content.headerContainer.alpha = 1f - hide
+    content.headerContainer.scaleX = 1f - 0.08f * hide
+    content.headerContainer.scaleY = 1f - 0.08f * hide
+
+    content.pageSwitchGestureBubble.translationY = headerShift - (content.pageSwitchGestureBubble.height * 0.35f * hide)
+    content.pageSwitchGestureBubble.alpha = 1f - hide
+    content.pageSwitchGestureBubble.scaleX = 1f - 0.12f * hide
+    content.pageSwitchGestureBubble.scaleY = 1f - 0.12f * hide
   }
 
   private fun resetEditorSurfaceTransform() {
@@ -1068,10 +1097,13 @@ abstract class BaseEditorActivity :
           override fun onDrag(fraction: Float) {
              if (_binding != null) {
                  val progress = fraction.coerceIn(0f, 1f)
-                 val alpha = (1f - progress * 0.8f).coerceIn(0.2f, 1f)
-                 content.headerContainer.alpha = alpha
-                 content.cardView.alpha = alpha
-                 content.pageSwitchGestureBubble.alpha = (0.6f + 0.4f * (1f - progress)).coerceIn(0.4f, 1f)
+                 editorBottomSheet?.let { behavior ->
+                   val target = if (progress >= 0.5f) BottomSheetBehavior.STATE_HALF_EXPANDED else BottomSheetBehavior.STATE_COLLAPSED
+                   if (behavior.state != BottomSheetBehavior.STATE_DRAGGING) {
+                     behavior.state = target
+                   }
+                 }
+                 updateLayoutBinding(slideOffset = progress)
              }
           }
 
@@ -1081,9 +1113,7 @@ abstract class BaseEditorActivity :
              } else {
                 requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
              }
-             content.headerContainer.alpha = 1f
-             content.cardView.alpha = 1f
-             content.pageSwitchGestureBubble.alpha = 1f
+             updateLayoutBinding(slideOffset = if (fraction > 0.15f) 1f else 0f)
           }
         }
     )

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -31,14 +31,11 @@ import androidx.appcompat.widget.TooltipCompat
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
-import androidx.core.view.updatePaddingRelative
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.transition.TransitionManager
 import com.blankj.utilcode.util.KeyboardUtils
-import com.blankj.utilcode.util.SizeUtils
 import com.blankj.utilcode.util.ThreadUtils.runOnUiThread
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
@@ -66,7 +63,6 @@ import java.nio.file.Path
 import java.nio.file.StandardOpenOption.CREATE_NEW
 import java.nio.file.StandardOpenOption.WRITE
 import java.util.concurrent.Callable
-import kotlin.math.roundToInt
 import org.slf4j.LoggerFactory
 
 /**
@@ -83,10 +79,6 @@ constructor(
     defStyleRes: Int = 0,
 ) : RelativeLayout(context, attrs, defStyleAttr, defStyleRes) {
 
-  private val collapsedHeight: Float by lazy {
-    val localContext = getContext() ?: return@lazy 0f
-    localContext.resources.getDimension(R.dimen.editor_sheet_collapsed_height)
-  }
   private val behavior: BottomSheetBehavior<EditorBottomSheet> by lazy {
     BottomSheetBehavior.from(this).apply {
       isFitToContents = false
@@ -105,7 +97,6 @@ constructor(
   private var expandBlocked = false
   private var behaviorCallbackAttached = false
   
-  private var symbolInputPage: View? = null
   var isExternalSymbolMode = false
 
   var onHeaderPageChanged: ((Int) -> Unit)? = null
@@ -119,9 +110,7 @@ constructor(
   companion object {
 
     private val log = LoggerFactory.getLogger(EditorBottomSheet::class.java)
-    private const val COLLAPSE_HEADER_AT_OFFSET = 0.5f
-
-    const val CHILD_HEADER = 0
+      const val CHILD_HEADER = 0
     const val CHILD_ACTION = 1
     const val STATE_EXTERNAL_SYMBOL = -1
   }
@@ -234,66 +223,26 @@ constructor(
     behavior.isGestureInsetBottomIgnored = isVisible
   }
 
-  fun setOffsetAnchor(view: View, symbolInputPage: View) {
-    this.symbolInputPage = symbolInputPage
+  fun setOffsetAnchor(view: View, @Suppress("UNUSED_PARAMETER") symbolInputPage: View) {
     val listener =
         object : ViewTreeObserver.OnGlobalLayoutListener {
           override fun onGlobalLayout() {
             view.viewTreeObserver.removeOnGlobalLayoutListener(this)
-            anchorOffset = view.height + SizeUtils.dp2px(1f)
-
-            // 设置 peekHeight 为 0，当折叠时完全隐藏 sheet，只显示锚定在其上方的 symbol_input_page
+            anchorOffset = view.height
             behavior.peekHeight = 0
+            behavior.halfExpandedRatio = 0.5f
             behavior.expandedOffset = anchorOffset
             behavior.isGestureInsetBottomIgnored = isImeVisible
-
             binding.root.updatePadding(bottom = anchorOffset + insetBottom)
-            
-            resetSymbolInputPageHeight()
           }
         }
 
     view.viewTreeObserver.addOnGlobalLayoutListener(listener)
   }
 
-  fun resetSymbolInputPageHeight() {
-      if (!isExternalSymbolMode) {
-          symbolInputPage?.apply {
-              updatePaddingRelative(bottom = paddingBottom + insetBottom)
-              updateLayoutParams<ViewGroup.LayoutParams> {
-                  height = (collapsedHeight + insetBottom).roundToInt()
-              }
-              alpha = 1f
-          }
-      }
-  }
+  fun resetSymbolInputPageHeight() = Unit
 
-  fun onSlide(sheetOffset: Float) {
-    if (isExternalSymbolMode) return
-
-    val heightScale =
-        if (sheetOffset >= COLLAPSE_HEADER_AT_OFFSET) {
-          ((COLLAPSE_HEADER_AT_OFFSET - sheetOffset) + COLLAPSE_HEADER_AT_OFFSET) * 2f
-        } else {
-          1f
-        }
-
-    val paddingScale =
-        if (!isImeVisible && sheetOffset <= COLLAPSE_HEADER_AT_OFFSET) {
-          ((1f - sheetOffset) * 2f) - 1f
-        } else {
-          0f
-        }
-
-    val padding = insetBottom * paddingScale
-    symbolInputPage?.apply {
-      updateLayoutParams<ViewGroup.LayoutParams> {
-        height = ((collapsedHeight + padding) * heightScale).roundToInt()
-      }
-      updatePaddingRelative(bottom = padding.roundToInt())
-      alpha = heightScale
-    }
-  }
+  fun onSlide(@Suppress("UNUSED_PARAMETER") sheetOffset: Float) = Unit
 
   fun showChild(index: Int) {
     onHeaderPageChanged?.invoke(if (index == CHILD_ACTION) CHILD_ACTION else CHILD_HEADER)

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -120,6 +120,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="bottom"
+          app:layout_anchor="@id/bottom_sheet"
           app:layout_anchorGravity="top"
           android:orientation="vertical"
           android:elevation="0dp"

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -244,7 +244,28 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
     canvas.drawPath(arrowPath!!, arrowPaint!!)
   }
 
-  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+  
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    post {
+      if (parent is View) {
+        val parentWidth = (parent as View).width
+        if (parentWidth > 0 && width != parentWidth) {
+          layoutParams = layoutParams.apply { this.width = parentWidth }
+        }
+      }
+      requestLayout()
+      invalidate()
+    }
+  }
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    mWidth = w.coerceAtLeast(1)
+    thresholdLeft = (mWidth / 3f)
+    thresholdRight = thresholdLeft * 2f
+  }
+override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     var finalWidth = MeasureSpec.getSize(widthMeasureSpec)
     var finalHeight = MeasureSpec.getSize(heightMeasureSpec)
 


### PR DESCRIPTION
### Motivation
- 解决底部交互层级与锚点绑定不稳定的问题，保证 `external_symbol_input_view` 在抽屉态与 IME 态下能始终正确吸附到目标顶部边缘。 
- 修复 `EdgeSnapBubbleView` 首次启动时贝塞尔曲线因父宽度未就绪导致的驼峰偏左/变形问题。 
- 统一抽屉滑动与 IME 升起时的布局驱动入口，避免“松手后才计算”造成的延迟与抖动。 

### Description
- 在布局中将 `symbol_input_page` 明确锚定到 `bottom_sheet`（`core/app/src/main/res/layout/content_editor.xml`），以实现指定的垂直堆叠链（`bottom_sheet` → `external_symbol_input_view` → `header_container` → `EdgeSnapBubbleView`）。
- 在 `BaseEditorActivity` 中新增 `updateLayoutBinding(...)` 方法以统一计算与应用位置/变换，负责：驱动 `external_symbol_input_view` 的 `translationY`（抽屉态与 IME 态共用），以及对 `header_container` 和 `pageSwitchGestureBubble` 的平移/缩放/透明度联动以实现 3D 风格隐藏效果（文件：`core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt`）。
- 将 IME 动画回调的目标从 `symbol_input_page` 切换为 `external_symbol_input_view` 并在 insets 变更时调用 `updateLayoutBinding(...)`，确保符号输入栏逐帧同步键盘升起/收回（文件：同上，`setupExternalSymbolImeSync`、`applyExternalSymbolImeInset` 调整）。
- 修改 `pageSwitchGestureBubble` 的手势回调逻辑，使气泡拖拽期间以线性进度驱动 `updateLayoutBinding(...)` 并在拖拽过程里尝试将抽屉状态与拖动进度合并驱动，从而实现手指实时跟随（同一 Activity 文件）。
- 在 `EdgeSnapBubbleView` 中添加 `onAttachedToWindow` 延后校正父宽度和 `onSizeChanged` 阶段阈值重算，避免首次测量时 `mWidth`/阈值错误导致的驼峰偏移与变形（文件：`core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt`）。

### Testing
- 运行 `./gradlew -q :core:app:compileDebugKotlin` 以做一次本地编译检查，但构建在当前环境中失败（工具链/环境错误，报错 `25.0.1`），该失败为环境问题而非本次逻辑变更直接引起。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d4e3c37483318c3614c4d1214371)