### PR TITLE
Sync bottom-sheet slide & IME with external symbol page; simplify sheet sizing and bubble layout

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -815,7 +815,8 @@ abstract class BaseEditorActivity :
               val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)
               
               this.bottomSheet.onSlide(slideOffset)
-              
+              updateLayoutBinding(slideOffset = slideOffset)
+
               this.viewContainer.scaleX = editorScale
               this.viewContainer.scaleY = editorScale
             }
@@ -962,7 +963,7 @@ abstract class BaseEditorActivity :
       content.symbolInputPage.translationY = 0f
       
       updateSymbolInputPageAnchor(false)
-      content.bottomSheet.resetSymbolInputPageHeight()
+      content.bottomSheet.resetSymbolInputPageAnchor()
     }
     
     content.pageSwitchGestureBubble.bringToFront()
@@ -979,20 +980,22 @@ abstract class BaseEditorActivity :
     content.symbolInputPage.translationY = 0f
     val targetImeInset = if (isExternalSymbolPageActive) latestImeBottomInset else 0
     content.externalSymbolInputView.setImeBottomInset(targetImeInset)
+    updateLayoutBinding(imeInset = targetImeInset)
   }
 
   private fun setupExternalSymbolImeSync() {
     if (_binding == null) return
     val symbolInputPage = content.symbolInputPage
+    val symbolInputView = content.externalSymbolInputView
 
     ViewCompat.setWindowInsetsAnimationCallback(
-        symbolInputPage,
+        symbolInputView,
         object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
             var startTranslationY = 0f
             var endTranslationY = 0f
 
             override fun onPrepare(animation: WindowInsetsAnimationCompat) {
-                startTranslationY = symbolInputPage.translationY
+                startTranslationY = symbolInputView.translationY
                 super.onPrepare(animation)
             }
 
@@ -1000,7 +1003,7 @@ abstract class BaseEditorActivity :
                 animation: WindowInsetsAnimationCompat,
                 bounds: WindowInsetsAnimationCompat.BoundsCompat
             ): WindowInsetsAnimationCompat.BoundsCompat {
-                val insets = ViewCompat.getRootWindowInsets(symbolInputPage)
+                val insets = ViewCompat.getRootWindowInsets(symbolInputView)
                 val imeBottom = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0
                 val navBottom = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
                 
@@ -1017,7 +1020,7 @@ abstract class BaseEditorActivity :
                 val imeAnimation = runningAnimations.find { it.typeMask and WindowInsetsCompat.Type.ime() != 0 }
                 if (imeAnimation != null) {
                     val fraction = imeAnimation.interpolatedFraction
-                    symbolInputPage.translationY = startTranslationY + (endTranslationY - startTranslationY) * fraction
+                    symbolInputView.translationY = startTranslationY + (endTranslationY - startTranslationY) * fraction
                 }
                 return insets
             }
@@ -1034,13 +1037,39 @@ abstract class BaseEditorActivity :
         val isImeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
         if (isExternalSymbolPageActive) {
             val targetTranslationY = if (isImeVisible && imeBottom > 0) -(imeBottom - navBottom).toFloat().coerceAtMost(0f) else 0f
-            view.translationY = targetTranslationY
+            updateLayoutBinding(imeInset = imeBottom)
         } else {
-            view.translationY = 0f
+            updateLayoutBinding(imeInset = 0)
         }
 
         insets
     }
+  }
+
+  private fun updateLayoutBinding(slideOffset: Float = bottomSheetSlideOffset, imeInset: Int = latestImeBottomInset) {
+    if (_binding == null) return
+    val sheetTop = content.bottomSheet.top.toFloat()
+    val symbolHeight = content.externalSymbolInputView.height.toFloat()
+    val imeActive = isImeVisible && imeInset > 0
+    val targetBottomY = if (imeActive) {
+      (content.realContainer.height - imeInset).toFloat()
+    } else {
+      sheetTop
+    }
+    val symbolTop = targetBottomY - symbolHeight
+    content.externalSymbolInputView.translationY = symbolTop - content.externalSymbolInputView.top
+
+    val hide = slideOffset.coerceIn(0f, 1f)
+    val headerShift = -content.headerContainer.height * hide
+    content.headerContainer.translationY = headerShift
+    content.headerContainer.alpha = 1f - hide
+    content.headerContainer.scaleX = 1f - 0.08f * hide
+    content.headerContainer.scaleY = 1f - 0.08f * hide
+
+    content.pageSwitchGestureBubble.translationY = headerShift - (content.pageSwitchGestureBubble.height * 0.35f * hide)
+    content.pageSwitchGestureBubble.alpha = 1f - hide
+    content.pageSwitchGestureBubble.scaleX = 1f - 0.12f * hide
+    content.pageSwitchGestureBubble.scaleY = 1f - 0.12f * hide
   }
 
   private fun resetEditorSurfaceTransform() {
@@ -1068,10 +1097,13 @@ abstract class BaseEditorActivity :
           override fun onDrag(fraction: Float) {
              if (_binding != null) {
                  val progress = fraction.coerceIn(0f, 1f)
-                 val alpha = (1f - progress * 0.8f).coerceIn(0.2f, 1f)
-                 content.headerContainer.alpha = alpha
-                 content.cardView.alpha = alpha
-                 content.pageSwitchGestureBubble.alpha = (0.6f + 0.4f * (1f - progress)).coerceIn(0.4f, 1f)
+                 editorBottomSheet?.let { behavior ->
+                   val target = if (progress >= 0.5f) BottomSheetBehavior.STATE_HALF_EXPANDED else BottomSheetBehavior.STATE_COLLAPSED
+                   if (behavior.state != BottomSheetBehavior.STATE_DRAGGING) {
+                     behavior.state = target
+                   }
+                 }
+                 updateLayoutBinding(slideOffset = progress)
              }
           }
 
@@ -1081,9 +1113,7 @@ abstract class BaseEditorActivity :
              } else {
                 requestBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
              }
-             content.headerContainer.alpha = 1f
-             content.cardView.alpha = 1f
-             content.pageSwitchGestureBubble.alpha = 1f
+             updateLayoutBinding(slideOffset = if (fraction > 0.15f) 1f else 0f)
           }
         }
     )

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -31,9 +31,7 @@ import androidx.appcompat.widget.TooltipCompat
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
-import androidx.core.view.updatePaddingRelative
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.transition.TransitionManager
@@ -66,7 +64,6 @@ import java.nio.file.Path
 import java.nio.file.StandardOpenOption.CREATE_NEW
 import java.nio.file.StandardOpenOption.WRITE
 import java.util.concurrent.Callable
-import kotlin.math.roundToInt
 import org.slf4j.LoggerFactory
 
 /**
@@ -83,10 +80,6 @@ constructor(
     defStyleRes: Int = 0,
 ) : RelativeLayout(context, attrs, defStyleAttr, defStyleRes) {
 
-  private val collapsedHeight: Float by lazy {
-    val localContext = getContext() ?: return@lazy 0f
-    localContext.resources.getDimension(R.dimen.editor_sheet_collapsed_height)
-  }
   private val behavior: BottomSheetBehavior<EditorBottomSheet> by lazy {
     BottomSheetBehavior.from(this).apply {
       isFitToContents = false
@@ -112,6 +105,7 @@ constructor(
   var onActionTextChanged: ((CharSequence) -> Unit)? = null
   var onActionProgressChanged: ((Int) -> Unit)? = null
   var onStatusChanged: ((CharSequence, Int) -> Unit)? = null
+  var onSheetProgressChanged: ((Float) -> Unit)? = null
 
   private val insetBottom: Int
     get() = if (isImeVisible) 0 else windowInsets?.bottom ?: 0
@@ -119,8 +113,6 @@ constructor(
   companion object {
 
     private val log = LoggerFactory.getLogger(EditorBottomSheet::class.java)
-    private const val COLLAPSE_HEADER_AT_OFFSET = 0.5f
-
     const val CHILD_HEADER = 0
     const val CHILD_ACTION = 1
     const val STATE_EXTERNAL_SYMBOL = -1
@@ -222,7 +214,9 @@ constructor(
             }
           }
 
-          override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+          override fun onSlide(bottomSheet: View, slideOffset: Float) {
+            onSheetProgressChanged?.invoke(slideOffset.coerceIn(0f, 1f))
+          }
         }
     )
     behaviorCallbackAttached = true
@@ -248,51 +242,22 @@ constructor(
             behavior.isGestureInsetBottomIgnored = isImeVisible
 
             binding.root.updatePadding(bottom = anchorOffset + insetBottom)
-            
-            resetSymbolInputPageHeight()
+            resetSymbolInputPageAnchor()
           }
         }
 
     view.viewTreeObserver.addOnGlobalLayoutListener(listener)
   }
 
-  fun resetSymbolInputPageHeight() {
-      if (!isExternalSymbolMode) {
-          symbolInputPage?.apply {
-              updatePaddingRelative(bottom = paddingBottom + insetBottom)
-              updateLayoutParams<ViewGroup.LayoutParams> {
-                  height = (collapsedHeight + insetBottom).roundToInt()
-              }
-              alpha = 1f
-          }
-      }
+  fun resetSymbolInputPageAnchor() {
+    if (isExternalSymbolMode) return
+    symbolInputPage?.alpha = 1f
+    symbolInputPage?.translationY = 0f
   }
 
   fun onSlide(sheetOffset: Float) {
     if (isExternalSymbolMode) return
-
-    val heightScale =
-        if (sheetOffset >= COLLAPSE_HEADER_AT_OFFSET) {
-          ((COLLAPSE_HEADER_AT_OFFSET - sheetOffset) + COLLAPSE_HEADER_AT_OFFSET) * 2f
-        } else {
-          1f
-        }
-
-    val paddingScale =
-        if (!isImeVisible && sheetOffset <= COLLAPSE_HEADER_AT_OFFSET) {
-          ((1f - sheetOffset) * 2f) - 1f
-        } else {
-          0f
-        }
-
-    val padding = insetBottom * paddingScale
-    symbolInputPage?.apply {
-      updateLayoutParams<ViewGroup.LayoutParams> {
-        height = ((collapsedHeight + padding) * heightScale).roundToInt()
-      }
-      updatePaddingRelative(bottom = padding.roundToInt())
-      alpha = heightScale
-    }
+    onSheetProgressChanged?.invoke(sheetOffset.coerceIn(0f, 1f))
   }
 
   fun showChild(index: Int) {

--- a/core/app/src/main/res/layout/content_editor.xml
+++ b/core/app/src/main/res/layout/content_editor.xml
@@ -120,6 +120,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="bottom"
+          app:layout_anchor="@id/bottom_sheet"
           app:layout_anchorGravity="top"
           android:orientation="vertical"
           android:elevation="0dp"

--- a/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
+++ b/core/common/src/main/java/com/itsaky/androidide/ui/EdgeSnapBubbleView.kt
@@ -244,7 +244,28 @@ override fun onTouchEvent(ev: MotionEvent): Boolean {
     canvas.drawPath(arrowPath!!, arrowPaint!!)
   }
 
-  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+  
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    post {
+      if (parent is View) {
+        val parentWidth = (parent as View).width
+        if (parentWidth > 0 && width != parentWidth) {
+          layoutParams = layoutParams.apply { this.width = parentWidth }
+        }
+      }
+      requestLayout()
+      invalidate()
+    }
+  }
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    mWidth = w.coerceAtLeast(1)
+    thresholdLeft = (mWidth / 3f)
+    thresholdRight = thresholdLeft * 2f
+  }
+override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     var finalWidth = MeasureSpec.getSize(widthMeasureSpec)
     var finalHeight = MeasureSpec.getSize(heightMeasureSpec)
 


### PR DESCRIPTION
### Motivation
- Ensure the external symbol input view, header and gesture bubble animate and position consistently with bottom-sheet slide and IME changes. 
- Reduce duplicated layout math in the activity and move responsibilities for sheet progress reporting into the bottom-sheet view. 
- Fix sizing/measurement issues for the edge-snap gesture bubble and anchor the symbol input page to the bottom sheet.

### Description
- Added `updateLayoutBinding` to `BaseEditorActivity` to centralize updates for `externalSymbolInputView` translation, header and page-switch bubble transforms, and invoked it from bottom-sheet `onSlide`, IME inset handling, and page-switch gesture handlers. 
- Replaced old symbol-page height logic with `resetSymbolInputPageAnchor` and updated calls to use the new method. 
- Changed `EditorBottomSheet` to expose `onSheetProgressChanged`, call it from `BottomSheetBehavior`'s `onSlide`, and simplified sheet anchor/peek handling (removed collapsed height math and per-slide height updates). 
- Anchored `symbol_input_page` to the `bottom_sheet` in `content_editor.xml` so the page follows sheet positioning. 
- Improved `EdgeSnapBubbleView` measurement and sizing by setting width to match parent on attach, handling `onSizeChanged`, and adjusting threshold computation to avoid incorrect layouts.

### Testing
- Ran a debug build with `./gradlew assembleDebug`, and the build completed successfully. 
- Executed unit tests with `./gradlew test`, and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d4e3c37483318c3614c4d1214371)