### PR TITLE
feat: add ProjectManager tab and ProjectManagerFragment (folder-tab project browser)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
@@ -132,6 +132,18 @@ class MainFragment : BaseFragment() {
             )
             NavigationBarItem(
                 selected = false,
+                onClick = {
+                  parentFragmentManager
+                      .beginTransaction()
+                      .replace(id, ProjectManagerFragment())
+                      .addToBackStack(ProjectManagerFragment::class.java.simpleName)
+                      .commit()
+                },
+                icon = { Icon(Icons.Default.Folder, null) },
+                label = { Text(stringResource(R.string.main_nav_projects)) },
+            )
+            NavigationBarItem(
+                selected = false,
                 onClick = {},
                 icon = { Icon(Icons.Default.History, null) },
                 label = { Text(stringResource(R.string.main_nav_history)) },

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
@@ -1,13 +1,15 @@
 package com.itsaky.androidide.fragments
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.provider.DocumentsContract
+import android.os.Environment as AndroidEnvironment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,11 +31,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -43,41 +47,47 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.documentfile.provider.DocumentFile
+import androidx.fragment.app.viewModels
 import com.itsaky.androidide.utils.Environment
+import com.itsaky.androidide.viewmodel.MainViewModel
 import java.io.File
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
 
 class ProjectManagerFragment : BaseFragment() {
 
-  private data class ProjectTab(val title: String, val filePath: String? = null, val treeUri: Uri? = null)
+  private data class ProjectTab(val title: String, val filePath: String? = null, val treeUri: Uri? = null) {
+    fun stableKey(): String = filePath ?: treeUri.toString()
+  }
 
+  private val viewModel by viewModels<MainViewModel>(ownerProducer = { requireActivity() })
   private val tabState = mutableStateListOf<ProjectTab>()
+  private val tabProjectsState = mutableStateMapOf<String, List<String>>()
+  private val loadingState = mutableStateMapOf<String, Boolean>()
 
   private val folderPicker = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
     uri ?: return@registerForActivityResult
     val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
     runCatching { requireContext().contentResolver.takePersistableUriPermission(uri, flags) }
     val tabName = DocumentFile.fromTreeUri(requireContext(), uri)?.name ?: "Folder"
-    tabState.add(ProjectTab(title = tabName, treeUri = uri))
+    val filePath = tryResolvePathFromTreeUri(uri)
+    val newTab = ProjectTab(title = tabName, filePath = filePath, treeUri = uri)
+    if (tabState.none { it.stableKey() == newTab.stableKey() }) {
+      tabState.add(newTab)
+    }
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     if (tabState.isEmpty()) {
-      tabState.add(
-          ProjectTab(
-              title = Environment.PROJECTS_FOLDER,
-              filePath = Environment.PROJECTS_DIR.absolutePath,
-          ))
+      tabState.add(ProjectTab(title = Environment.PROJECTS_FOLDER, filePath = Environment.PROJECTS_DIR.absolutePath))
     }
   }
 
-  override fun onCreateView(
-      inflater: LayoutInflater,
-      container: ViewGroup?,
-      savedInstanceState: Bundle?,
-  ): View {
+  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
     return ComposeView(requireContext()).apply {
       setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
       setContent { MaterialTheme { ProjectManagerScreen() } }
@@ -87,26 +97,25 @@ class ProjectManagerFragment : BaseFragment() {
   @Composable
   private fun ProjectManagerScreen() {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
+    val scope = remember { CoroutineScope(Dispatchers.Main.immediate) }
 
-    if (selectedTabIndex > tabState.lastIndex) {
-      selectedTabIndex = 0
-    }
-
+    if (selectedTabIndex > tabState.lastIndex) selectedTabIndex = 0
     val selectedTab = tabState.getOrNull(selectedTabIndex)
-    val projects by produceState(initialValue = emptyList<String>(), selectedTab) {
-      val tab = selectedTab
-      value = if (tab == null) emptyList() else loadProjects(tab)
+
+    selectedTab?.let { tab ->
+      val key = tab.stableKey()
+      if (!tabProjectsState.containsKey(key) && loadingState[key] != true) {
+        loadTabProjects(scope, tab, forceRefresh = false)
+      }
     }
 
     Column(modifier = Modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
       Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         ScrollableTabRow(selectedTabIndex = selectedTabIndex, modifier = Modifier.weight(1f)) {
           tabState.forEachIndexed { index, tab ->
-            Tab(
-                selected = selectedTabIndex == index,
-                onClick = { selectedTabIndex = index },
-                text = { Text(tab.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-            )
+            Tab(selected = selectedTabIndex == index, onClick = { selectedTabIndex = index }, text = {
+              Text(tab.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            })
           }
         }
         FloatingActionButton(onClick = { folderPicker.launch(null) }, modifier = Modifier.padding(start = 8.dp)) {
@@ -115,44 +124,105 @@ class ProjectManagerFragment : BaseFragment() {
       }
 
       if (selectedTab == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-          CircularProgressIndicator()
-        }
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
         return
       }
 
-      LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        items(projects, key = { it }) { projectName ->
-          Card(modifier = Modifier.fillMaxWidth(), elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-            Row(modifier = Modifier.fillMaxWidth().padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
-              Icon(Icons.Default.Folder, contentDescription = null)
-              Text(text = projectName, modifier = Modifier.padding(start = 10.dp), style = MaterialTheme.typography.titleMedium)
-            }
+      val key = selectedTab.stableKey()
+      val projects = tabProjectsState[key].orEmpty()
+      val isLoading = loadingState[key] == true
+
+      PullToRefreshBox(isRefreshing = isLoading, onRefresh = { loadTabProjects(scope, selectedTab, forceRefresh = true) }) {
+        LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          items(projects, key = { it }) { projectPath ->
+            val name = File(projectPath).name
+            Card(
+                modifier =
+                    Modifier.fillMaxWidth().clickable {
+                      viewModel.openProject(requireContext(), File(projectPath))
+                    },
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
+                  Row(modifier = Modifier.fillMaxWidth().padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Folder, contentDescription = null)
+                    Text(text = name, modifier = Modifier.padding(start = 10.dp), style = MaterialTheme.typography.titleMedium)
+                  }
+                }
           }
         }
       }
     }
   }
 
-  private suspend fun loadProjects(tab: ProjectTab): List<String> = withContext(Dispatchers.IO) {
+  private fun loadTabProjects(scope: CoroutineScope, tab: ProjectTab, forceRefresh: Boolean) {
+    val key = tab.stableKey()
+    if (!forceRefresh) {
+      val cached = readCache(requireContext(), key)
+      if (cached.isNotEmpty()) {
+        tabProjectsState[key] = cached
+      }
+    }
+
+    scope.launch {
+      loadingState[key] = true
+      val merged = withContext(Dispatchers.IO) { scanAndMergeProjects(tab, tabProjectsState[key].orEmpty()) }
+      tabProjectsState[key] = merged
+      writeCache(requireContext(), key, merged)
+      loadingState[key] = false
+    }
+  }
+
+  private fun scanAndMergeProjects(tab: ProjectTab, current: List<String>): List<String> {
+    val scanned = scanTopLevelProjects(tab)
+    if (scanned.isEmpty()) return current.distinct().sortedBy { File(it).name.lowercase() }
+    return (current + scanned).distinct().sortedBy { File(it).name.lowercase() }
+  }
+
+  private fun scanTopLevelProjects(tab: ProjectTab): List<String> {
     if (tab.filePath != null) {
-      File(tab.filePath)
+      return File(tab.filePath)
           .listFiles { file -> file.isDirectory }
           ?.asSequence()
-          ?.sortedBy { it.name.lowercase() }
-          ?.map { it.name }
-          ?.toList()
-          .orEmpty()
-    } else {
-      val uri = tab.treeUri ?: return@withContext emptyList()
-      DocumentFile.fromTreeUri(requireContext(), uri)
-          ?.listFiles()
-          ?.asSequence()
-          ?.filter { it.isDirectory }
-          ?.mapNotNull { it.name }
-          ?.sortedBy { it.lowercase() }
+          ?.map { it.absolutePath }
+          ?.distinct()
           ?.toList()
           .orEmpty()
     }
+
+    val treeUri = tab.treeUri ?: return emptyList()
+    return DocumentFile.fromTreeUri(requireContext(), treeUri)
+        ?.listFiles()
+        ?.asSequence()
+        ?.filter { it.isDirectory }
+        ?.mapNotNull { tryResolvePathFromTreeUri(it.uri) }
+        ?.distinct()
+        ?.toList()
+        .orEmpty()
+  }
+
+  private fun readCache(context: Context, key: String): List<String> {
+    val raw = context.getSharedPreferences("project_manager_cache", Context.MODE_PRIVATE).getString(key, null) ?: return emptyList()
+    return runCatching {
+      val arr = JSONArray(raw)
+      buildList {
+        for (i in 0 until arr.length()) {
+          val path = arr.optString(i)
+          if (path.isNotBlank()) add(path)
+        }
+      }
+    }.getOrDefault(emptyList()).distinct()
+  }
+
+  private fun writeCache(context: Context, key: String, data: List<String>) {
+    val unique = data.distinct()
+    val arr = JSONArray()
+    unique.forEach { arr.put(it) }
+    context.getSharedPreferences("project_manager_cache", Context.MODE_PRIVATE).edit().putString(key, arr.toString()).apply()
+  }
+
+  private fun tryResolvePathFromTreeUri(uri: Uri): String? {
+    val docId = DocumentFile.fromTreeUri(requireContext(), uri)?.uri?.lastPathSegment ?: return null
+    val normalized = docId.substringAfter(':', "")
+    if (normalized.isBlank()) return null
+    return File(AndroidEnvironment.getExternalStorageDirectory(), normalized).absolutePath
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
@@ -52,10 +52,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.viewModels
+import com.itsaky.androidide.resources.R
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.viewmodel.MainViewModel
 import java.io.File
@@ -87,7 +89,7 @@ class ProjectManagerFragment : BaseFragment() {
     uri ?: return@registerForActivityResult
     val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
     runCatching { requireContext().contentResolver.takePersistableUriPermission(uri, flags) }
-    val tabName = DocumentFile.fromTreeUri(requireContext(), uri)?.name ?: "Folder"
+    val tabName = DocumentFile.fromTreeUri(requireContext(), uri)?.name ?: getString(R.string.project_manager_folder)
     val filePath = uriToPath(uri)
     val tab = ProjectTab(tabName, filePath, uri)
     if (tabState.none { it.stableKey() == tab.stableKey() }) tabState.add(tab)
@@ -137,7 +139,7 @@ class ProjectManagerFragment : BaseFragment() {
           }
         }
         FloatingActionButton(onClick = { folderPicker.launch(null) }, modifier = Modifier.padding(start = 8.dp)) {
-          Icon(Icons.Default.Add, contentDescription = "Add folder")
+          Icon(Icons.Default.Add, contentDescription = stringResource(R.string.project_manager_add_folder))
         }
       }
 
@@ -152,7 +154,7 @@ class ProjectManagerFragment : BaseFragment() {
             moveClipboardToTab(scope, selectedTab)
           }) {
             Icon(Icons.Default.ContentPaste, null)
-            Text("粘贴到当前Tab", modifier = Modifier.padding(start = 6.dp))
+            Text(stringResource(R.string.project_manager_paste_current_tab), modifier = Modifier.padding(start = 6.dp))
           }
         }
       }
@@ -175,25 +177,25 @@ class ProjectManagerFragment : BaseFragment() {
                     }
                   }
               DropdownMenu(expanded = menuProjectPath == projectPath, onDismissRequest = { menuProjectPath = null }) {
-                DropdownMenuItem(text = { Text("重命名") }, onClick = {
+                DropdownMenuItem(text = { Text(stringResource(R.string.project_manager_rename)) }, onClick = {
                   renameTarget = projectPath
                   renameInput = File(projectPath).name
                   menuProjectPath = null
                 })
-                DropdownMenuItem(text = { Text("剪切") }, onClick = {
+                DropdownMenuItem(text = { Text(stringResource(R.string.project_manager_cut)) }, onClick = {
                   clipboardState = ClipboardProject(projectPath)
                   menuProjectPath = null
                 })
-                DropdownMenuItem(text = { Text("移动到...") }, onClick = {
+                DropdownMenuItem(text = { Text(stringResource(R.string.project_manager_move_to)) }, onClick = {
                   clipboardState = ClipboardProject(projectPath)
                   moveClipboardToTab(scope, selectedTab)
                   menuProjectPath = null
                 })
-                DropdownMenuItem(text = { Text("删除") }, onClick = {
+                DropdownMenuItem(text = { Text(stringResource(R.string.project_manager_delete)) }, onClick = {
                   deleteProject(scope, selectedTab, projectPath)
                   menuProjectPath = null
                 })
-                DropdownMenuItem(text = { Text("属性") }, onClick = {
+                DropdownMenuItem(text = { Text(stringResource(R.string.project_manager_properties)) }, onClick = {
                   showPropertiesFor = projectPath
                   menuProjectPath = null
                 })
@@ -211,10 +213,10 @@ class ProjectManagerFragment : BaseFragment() {
             TextButton(onClick = {
               renameProject(path, renameInput)
               renameTarget = null
-            }) { Text("确定") }
+            }) { Text(stringResource(R.string.confirm)) }
           },
-          dismissButton = { TextButton(onClick = { renameTarget = null }) { Text("取消") } },
-          title = { Text("重命名") },
+          dismissButton = { TextButton(onClick = { renameTarget = null }) { Text(stringResource(R.string.cancel)) } },
+          title = { Text(stringResource(R.string.project_manager_rename)) },
           text = { TextField(value = renameInput, onValueChange = { renameInput = it }) },
       )
     }
@@ -223,8 +225,8 @@ class ProjectManagerFragment : BaseFragment() {
       val props = remember(path) { collectProperties(path) }
       AlertDialog(
           onDismissRequest = { showPropertiesFor = null },
-          confirmButton = { TextButton(onClick = { showPropertiesFor = null }) { Text("关闭") } },
-          title = { Text("属性") },
+          confirmButton = { TextButton(onClick = { showPropertiesFor = null }) { Text(stringResource(R.string.project_manager_close)) } },
+          title = { Text(stringResource(R.string.project_manager_properties)) },
           text = { Text(props) },
       )
     }
@@ -306,15 +308,15 @@ class ProjectManagerFragment : BaseFragment() {
 
   private fun collectProperties(path: String): String {
     val file = File(path)
-    if (!file.exists()) return "路径不存在"
+    if (!file.exists()) return getString(R.string.project_manager_path_not_exists)
     val size = folderSize(file)
     val time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date(file.lastModified()))
     val md5 = digest("MD5", path)
     val sha1 = digest("SHA-1", path)
     val sha256 = digest("SHA-256", path)
     val perms = (if (file.canRead()) "r" else "-") + (if (file.canWrite()) "w" else "-") + (if (file.canExecute()) "x" else "-")
-    val uidGid = runCatching { Os.stat(path) }.getOrNull()?.let { "uid=${it.st_uid}, gid=${it.st_gid}" } ?: "uid/gid: unknown"
-    return "路径: ${file.absolutePath}\n类型: 文件夹\n大小: $size bytes\n修改时间: $time\n权限: $perms\n$uidGid\nMD5: $md5\nSHA1: $sha1\nSHA256: $sha256"
+    val uidGid = runCatching { Os.stat(path) }.getOrNull()?.let { "uid=${it.st_uid}, gid=${it.st_gid}" } ?: getString(R.string.project_manager_uid_gid_unknown)
+    return getString(R.string.project_manager_properties_template, file.absolutePath, getString(R.string.project_manager_type_folder), size, time, perms, uidGid, md5, sha1, sha256)
   }
 
   private fun folderSize(file: File): Long = file.walkTopDown().filter { it.isFile }.sumOf { it.length() }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
@@ -213,9 +213,9 @@ class ProjectManagerFragment : BaseFragment() {
             TextButton(onClick = {
               renameProject(path, renameInput)
               renameTarget = null
-            }) { Text(stringResource(R.string.confirm)) }
+            }) { Text(stringResource(android.R.string.ok)) }
           },
-          dismissButton = { TextButton(onClick = { renameTarget = null }) { Text(stringResource(R.string.cancel)) } },
+          dismissButton = { TextButton(onClick = { renameTarget = null }) { Text(stringResource(android.R.string.cancel)) } },
           title = { Text(stringResource(R.string.project_manager_rename)) },
           text = { TextField(value = renameInput, onValueChange = { renameInput = it }) },
       )

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.Environment as AndroidEnvironment
+import android.provider.DocumentsContract
+import android.system.Os
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,16 +23,22 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -51,6 +59,10 @@ import androidx.fragment.app.viewModels
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.viewmodel.MainViewModel
 import java.io.File
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -58,32 +70,33 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 
 class ProjectManagerFragment : BaseFragment() {
-
   private data class ProjectTab(val title: String, val filePath: String? = null, val treeUri: Uri? = null) {
     fun stableKey(): String = filePath ?: treeUri.toString()
+    fun rootPathOrNull(): String? = filePath ?: treeUri?.let { uriToPath(it) }
   }
+
+  private data class ClipboardProject(val sourcePath: String)
 
   private val viewModel by viewModels<MainViewModel>(ownerProducer = { requireActivity() })
   private val tabState = mutableStateListOf<ProjectTab>()
   private val tabProjectsState = mutableStateMapOf<String, List<String>>()
   private val loadingState = mutableStateMapOf<String, Boolean>()
+  private var clipboardState by mutableStateOf<ClipboardProject?>(null)
 
   private val folderPicker = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
     uri ?: return@registerForActivityResult
     val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
     runCatching { requireContext().contentResolver.takePersistableUriPermission(uri, flags) }
     val tabName = DocumentFile.fromTreeUri(requireContext(), uri)?.name ?: "Folder"
-    val filePath = tryResolvePathFromTreeUri(uri)
-    val newTab = ProjectTab(title = tabName, filePath = filePath, treeUri = uri)
-    if (tabState.none { it.stableKey() == newTab.stableKey() }) {
-      tabState.add(newTab)
-    }
+    val filePath = uriToPath(uri)
+    val tab = ProjectTab(tabName, filePath, uri)
+    if (tabState.none { it.stableKey() == tab.stableKey() }) tabState.add(tab)
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     if (tabState.isEmpty()) {
-      tabState.add(ProjectTab(title = Environment.PROJECTS_FOLDER, filePath = Environment.PROJECTS_DIR.absolutePath))
+      tabState.add(ProjectTab(Environment.PROJECTS_FOLDER, Environment.PROJECTS_DIR.absolutePath))
     }
   }
 
@@ -94,10 +107,15 @@ class ProjectManagerFragment : BaseFragment() {
     }
   }
 
+  @OptIn(ExperimentalFoundationApi::class)
   @Composable
   private fun ProjectManagerScreen() {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
     val scope = remember { CoroutineScope(Dispatchers.Main.immediate) }
+    var menuProjectPath by remember { mutableStateOf<String?>(null) }
+    var showPropertiesFor by remember { mutableStateOf<String?>(null) }
+    var renameTarget by remember { mutableStateOf<String?>(null) }
+    var renameInput by remember { mutableStateOf("") }
 
     if (selectedTabIndex > tabState.lastIndex) selectedTabIndex = 0
     val selectedTab = tabState.getOrNull(selectedTabIndex)
@@ -105,7 +123,7 @@ class ProjectManagerFragment : BaseFragment() {
     selectedTab?.let { tab ->
       val key = tab.stableKey()
       if (!tabProjectsState.containsKey(key) && loadingState[key] != true) {
-        loadTabProjects(scope, tab, forceRefresh = false)
+        loadTabProjects(scope, tab, false)
       }
     }
 
@@ -123,33 +141,125 @@ class ProjectManagerFragment : BaseFragment() {
         }
       }
 
-      if (selectedTab == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
-        return
-      }
-
+      if (selectedTab == null) return
       val key = selectedTab.stableKey()
       val projects = tabProjectsState[key].orEmpty()
       val isLoading = loadingState[key] == true
 
-      PullToRefreshBox(isRefreshing = isLoading, onRefresh = { loadTabProjects(scope, selectedTab, forceRefresh = true) }) {
-        LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-          items(projects, key = { it }) { projectPath ->
-            val name = File(projectPath).name
-            Card(
-                modifier =
-                    Modifier.fillMaxWidth().clickable {
-                      viewModel.openProject(requireContext(), File(projectPath))
-                    },
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-                  Row(modifier = Modifier.fillMaxWidth().padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.Folder, contentDescription = null)
-                    Text(text = name, modifier = Modifier.padding(start = 10.dp), style = MaterialTheme.typography.titleMedium)
-                  }
-                }
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+        if (clipboardState != null) {
+          TextButton(onClick = {
+            moveClipboardToTab(scope, selectedTab)
+          }) {
+            Icon(Icons.Default.ContentPaste, null)
+            Text("粘贴到当前Tab", modifier = Modifier.padding(start = 6.dp))
           }
         }
       }
+
+      PullToRefreshBox(isRefreshing = isLoading, onRefresh = { loadTabProjects(scope, selectedTab, true) }) {
+        LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          items(projects, key = { it }) { projectPath ->
+            val name = File(projectPath).name
+            Box {
+              Card(
+                  modifier =
+                      Modifier.fillMaxWidth().combinedClickable(
+                          onClick = { viewModel.openProject(requireContext(), File(projectPath)) },
+                          onLongClick = { menuProjectPath = projectPath },
+                      ),
+                  elevation = CardDefaults.cardElevation(2.dp)) {
+                    Row(modifier = Modifier.fillMaxWidth().padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+                      Icon(Icons.Default.Folder, null)
+                      Text(name, modifier = Modifier.padding(start = 10.dp), style = MaterialTheme.typography.titleMedium)
+                    }
+                  }
+              DropdownMenu(expanded = menuProjectPath == projectPath, onDismissRequest = { menuProjectPath = null }) {
+                DropdownMenuItem(text = { Text("重命名") }, onClick = {
+                  renameTarget = projectPath
+                  renameInput = File(projectPath).name
+                  menuProjectPath = null
+                })
+                DropdownMenuItem(text = { Text("剪切") }, onClick = {
+                  clipboardState = ClipboardProject(projectPath)
+                  menuProjectPath = null
+                })
+                DropdownMenuItem(text = { Text("移动到...") }, onClick = {
+                  clipboardState = ClipboardProject(projectPath)
+                  moveClipboardToTab(scope, selectedTab)
+                  menuProjectPath = null
+                })
+                DropdownMenuItem(text = { Text("删除") }, onClick = {
+                  deleteProject(scope, selectedTab, projectPath)
+                  menuProjectPath = null
+                })
+                DropdownMenuItem(text = { Text("属性") }, onClick = {
+                  showPropertiesFor = projectPath
+                  menuProjectPath = null
+                })
+              }
+            }
+          }
+        }
+      }
+    }
+
+    renameTarget?.let { path ->
+      AlertDialog(
+          onDismissRequest = { renameTarget = null },
+          confirmButton = {
+            TextButton(onClick = {
+              renameProject(path, renameInput)
+              renameTarget = null
+            }) { Text("确定") }
+          },
+          dismissButton = { TextButton(onClick = { renameTarget = null }) { Text("取消") } },
+          title = { Text("重命名") },
+          text = { TextField(value = renameInput, onValueChange = { renameInput = it }) },
+      )
+    }
+
+    showPropertiesFor?.let { path ->
+      val props = remember(path) { collectProperties(path) }
+      AlertDialog(
+          onDismissRequest = { showPropertiesFor = null },
+          confirmButton = { TextButton(onClick = { showPropertiesFor = null }) { Text("关闭") } },
+          title = { Text("属性") },
+          text = { Text(props) },
+      )
+    }
+  }
+
+  private fun moveClipboardToTab(scope: CoroutineScope, tab: ProjectTab) {
+    val clip = clipboardState ?: return
+    val targetRoot = tab.rootPathOrNull() ?: return
+    scope.launch(Dispatchers.IO) {
+      val src = File(clip.sourcePath)
+      val dst = File(targetRoot, src.name)
+      if (src.exists() && src.absolutePath != dst.absolutePath && !dst.exists()) {
+        src.renameTo(dst)
+      }
+      clipboardState = null
+      withContext(Dispatchers.Main) { loadTabProjects(this@launch, tab, true) }
+    }
+  }
+
+  private fun renameProject(path: String, newName: String) {
+    if (newName.isBlank()) return
+    val src = File(path)
+    val dst = File(src.parentFile, newName)
+    if (!dst.exists()) src.renameTo(dst)
+    tabState.forEach { tab ->
+      tabProjectsState[tab.stableKey()] = tabProjectsState[tab.stableKey()].orEmpty().map {
+        if (it == path) dst.absolutePath else it
+      }
+    }
+  }
+
+  private fun deleteProject(scope: CoroutineScope, tab: ProjectTab, path: String) {
+    scope.launch(Dispatchers.IO) {
+      File(path).deleteRecursively()
+      withContext(Dispatchers.Main) { loadTabProjects(this@launch, tab, true) }
     }
   }
 
@@ -157,11 +267,8 @@ class ProjectManagerFragment : BaseFragment() {
     val key = tab.stableKey()
     if (!forceRefresh) {
       val cached = readCache(requireContext(), key)
-      if (cached.isNotEmpty()) {
-        tabProjectsState[key] = cached
-      }
+      if (cached.isNotEmpty()) tabProjectsState[key] = cached
     }
-
     scope.launch {
       loadingState[key] = true
       val merged = withContext(Dispatchers.IO) { scanAndMergeProjects(tab, tabProjectsState[key].orEmpty()) }
@@ -173,30 +280,12 @@ class ProjectManagerFragment : BaseFragment() {
 
   private fun scanAndMergeProjects(tab: ProjectTab, current: List<String>): List<String> {
     val scanned = scanTopLevelProjects(tab)
-    if (scanned.isEmpty()) return current.distinct().sortedBy { File(it).name.lowercase() }
-    return (current + scanned).distinct().sortedBy { File(it).name.lowercase() }
+    return (current + scanned).distinct().filter { File(it).exists() }.sortedBy { File(it).name.lowercase() }
   }
 
   private fun scanTopLevelProjects(tab: ProjectTab): List<String> {
-    if (tab.filePath != null) {
-      return File(tab.filePath)
-          .listFiles { file -> file.isDirectory }
-          ?.asSequence()
-          ?.map { it.absolutePath }
-          ?.distinct()
-          ?.toList()
-          .orEmpty()
-    }
-
-    val treeUri = tab.treeUri ?: return emptyList()
-    return DocumentFile.fromTreeUri(requireContext(), treeUri)
-        ?.listFiles()
-        ?.asSequence()
-        ?.filter { it.isDirectory }
-        ?.mapNotNull { tryResolvePathFromTreeUri(it.uri) }
-        ?.distinct()
-        ?.toList()
-        .orEmpty()
+    val root = tab.rootPathOrNull() ?: return emptyList()
+    return File(root).listFiles { file -> file.isDirectory }?.map { it.absolutePath }.orEmpty()
   }
 
   private fun readCache(context: Context, key: String): List<String> {
@@ -204,25 +293,43 @@ class ProjectManagerFragment : BaseFragment() {
     return runCatching {
       val arr = JSONArray(raw)
       buildList {
-        for (i in 0 until arr.length()) {
-          val path = arr.optString(i)
-          if (path.isNotBlank()) add(path)
-        }
+        for (i in 0 until arr.length()) arr.optString(i).takeIf { it.isNotBlank() }?.let(::add)
       }
     }.getOrDefault(emptyList()).distinct()
   }
 
   private fun writeCache(context: Context, key: String, data: List<String>) {
-    val unique = data.distinct()
     val arr = JSONArray()
-    unique.forEach { arr.put(it) }
+    data.distinct().forEach(arr::put)
     context.getSharedPreferences("project_manager_cache", Context.MODE_PRIVATE).edit().putString(key, arr.toString()).apply()
   }
 
-  private fun tryResolvePathFromTreeUri(uri: Uri): String? {
-    val docId = DocumentFile.fromTreeUri(requireContext(), uri)?.uri?.lastPathSegment ?: return null
-    val normalized = docId.substringAfter(':', "")
-    if (normalized.isBlank()) return null
-    return File(AndroidEnvironment.getExternalStorageDirectory(), normalized).absolutePath
+  private fun collectProperties(path: String): String {
+    val file = File(path)
+    if (!file.exists()) return "路径不存在"
+    val size = folderSize(file)
+    val time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date(file.lastModified()))
+    val md5 = digest("MD5", path)
+    val sha1 = digest("SHA-1", path)
+    val sha256 = digest("SHA-256", path)
+    val perms = (if (file.canRead()) "r" else "-") + (if (file.canWrite()) "w" else "-") + (if (file.canExecute()) "x" else "-")
+    val uidGid = runCatching { Os.stat(path) }.getOrNull()?.let { "uid=${it.st_uid}, gid=${it.st_gid}" } ?: "uid/gid: unknown"
+    return "路径: ${file.absolutePath}\n类型: 文件夹\n大小: $size bytes\n修改时间: $time\n权限: $perms\n$uidGid\nMD5: $md5\nSHA1: $sha1\nSHA256: $sha256"
+  }
+
+  private fun folderSize(file: File): Long = file.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+
+  private fun digest(alg: String, text: String): String {
+    val md = MessageDigest.getInstance(alg)
+    return md.digest(text.toByteArray()).joinToString("") { "%02x".format(it) }
+  }
+
+  companion object {
+    private fun uriToPath(uri: Uri): String? {
+      val docId = runCatching { DocumentsContract.getTreeDocumentId(uri) }.getOrNull() ?: return null
+      val parts = docId.split(':', limit = 2)
+      if (parts.size < 2) return null
+      return "/storage/${parts[0]}/${parts[1]}"
+    }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
@@ -1,0 +1,158 @@
+package com.itsaky.androidide.fragments
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.DocumentsContract
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.documentfile.provider.DocumentFile
+import com.itsaky.androidide.utils.Environment
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ProjectManagerFragment : BaseFragment() {
+
+  private data class ProjectTab(val title: String, val filePath: String? = null, val treeUri: Uri? = null)
+
+  private val tabState = mutableStateListOf<ProjectTab>()
+
+  private val folderPicker = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+    uri ?: return@registerForActivityResult
+    val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+    runCatching { requireContext().contentResolver.takePersistableUriPermission(uri, flags) }
+    val tabName = DocumentFile.fromTreeUri(requireContext(), uri)?.name ?: "Folder"
+    tabState.add(ProjectTab(title = tabName, treeUri = uri))
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    if (tabState.isEmpty()) {
+      tabState.add(
+          ProjectTab(
+              title = Environment.PROJECTS_FOLDER,
+              filePath = Environment.PROJECTS_DIR.absolutePath,
+          ))
+    }
+  }
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?,
+  ): View {
+    return ComposeView(requireContext()).apply {
+      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+      setContent { MaterialTheme { ProjectManagerScreen() } }
+    }
+  }
+
+  @Composable
+  private fun ProjectManagerScreen() {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+
+    if (selectedTabIndex > tabState.lastIndex) {
+      selectedTabIndex = 0
+    }
+
+    val selectedTab = tabState.getOrNull(selectedTabIndex)
+    val projects by produceState(initialValue = emptyList<String>(), selectedTab) {
+      val tab = selectedTab
+      value = if (tab == null) emptyList() else loadProjects(tab)
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        ScrollableTabRow(selectedTabIndex = selectedTabIndex, modifier = Modifier.weight(1f)) {
+          tabState.forEachIndexed { index, tab ->
+            Tab(
+                selected = selectedTabIndex == index,
+                onClick = { selectedTabIndex = index },
+                text = { Text(tab.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            )
+          }
+        }
+        FloatingActionButton(onClick = { folderPicker.launch(null) }, modifier = Modifier.padding(start = 8.dp)) {
+          Icon(Icons.Default.Add, contentDescription = "Add folder")
+        }
+      }
+
+      if (selectedTab == null) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          CircularProgressIndicator()
+        }
+        return
+      }
+
+      LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        items(projects, key = { it }) { projectName ->
+          Card(modifier = Modifier.fillMaxWidth(), elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
+            Row(modifier = Modifier.fillMaxWidth().padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+              Icon(Icons.Default.Folder, contentDescription = null)
+              Text(text = projectName, modifier = Modifier.padding(start = 10.dp), style = MaterialTheme.typography.titleMedium)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private suspend fun loadProjects(tab: ProjectTab): List<String> = withContext(Dispatchers.IO) {
+    if (tab.filePath != null) {
+      File(tab.filePath)
+          .listFiles { file -> file.isDirectory }
+          ?.asSequence()
+          ?.sortedBy { it.name.lowercase() }
+          ?.map { it.name }
+          ?.toList()
+          .orEmpty()
+    } else {
+      val uri = tab.treeUri ?: return@withContext emptyList()
+      DocumentFile.fromTreeUri(requireContext(), uri)
+          ?.listFiles()
+          ?.asSequence()
+          ?.filter { it.isDirectory }
+          ?.mapNotNull { it.name }
+          ?.sortedBy { it.lowercase() }
+          ?.toList()
+          .orEmpty()
+    }
+  }
+}

--- a/core/resources/src/main/res/values-ar-rSA/strings_b.xml
+++ b/core/resources/src/main/res/values-ar-rSA/strings_b.xml
@@ -289,4 +289,25 @@
      <string name="template_support_toml">دعم TOML</string>
      <string name="title_template_native_build_imgui_description">واجهة المستخدم الرسومية الأصلية لأندرويد</string>
      <string name="title_template_no_activity_desc">ليس لديه أي نشاط</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-bn-rIN/strings_b.xml
+++ b/core/resources/src/main/res/values-bn-rIN/strings_b.xml
@@ -305,4 +305,25 @@
      <string name="template_support_toml">টমল সমর্থন</string>
      <string name="title_template_native_build_imgui_description">অ্যান্ড্রয়েড নেটিভ গ্রাফিক্যাল ইউজার ইন্টারফেস</string>
      <string name="title_template_no_activity_desc">এটির কোনো কার্যক্রম নেই</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-de-rDE/strings_b.xml
+++ b/core/resources/src/main/res/values-de-rDE/strings_b.xml
@@ -297,4 +297,25 @@
      <string name="template_support_toml">TOML-Unterstützung</string>
      <string name="title_template_native_build_imgui_description">Android Native Graphische Benutzeroberfläche</string>
      <string name="title_template_no_activity_desc">Es hat keine Aktivität</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-es-rES/strings_b.xml
+++ b/core/resources/src/main/res/values-es-rES/strings_b.xml
@@ -289,4 +289,25 @@
      <string name="template_support_toml">Compatibilidad con TOML</string>
      <string name="title_template_native_build_imgui_description">Interfaz Gráfica de Usuario Nativa de Android</string>
      <string name="title_template_no_activity_desc">No tiene actividad</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-fa/strings_b.xml
+++ b/core/resources/src/main/res/values-fa/strings_b.xml
@@ -277,4 +277,25 @@
     <string name="template_support_toml">پشتیبانی از TOML</string>
     <string name="title_template_native_build_imgui_description">رابط کاربری گرافیکی بومی اندروید</string>
     <string name="title_template_no_activity_desc">هیچ فعالیتی ندارد</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-fr-rFR/strings_b.xml
+++ b/core/resources/src/main/res/values-fr-rFR/strings_b.xml
@@ -289,4 +289,25 @@
      <string name="template_support_toml">Support TOML</string>
      <string name="title_template_native_build_imgui_description">Interface graphique native Android</string>
      <string name="title_template_no_activity_desc">Il n\'a aucune activité</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-hi-rIN/strings_b.xml
+++ b/core/resources/src/main/res/values-hi-rIN/strings_b.xml
@@ -289,4 +289,25 @@
      <string name="template_support_toml">TOML समर्थन</string>
      <string name="title_template_native_build_imgui_description">एंड्रॉइड मूल ग्राफिकल यूज़र इंटरफ़ेस</string>
      <string name="title_template_no_activity_desc">इसका कोई सक्रियता नहीं है</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-in-rID/strings_b.xml
+++ b/core/resources/src/main/res/values-in-rID/strings_b.xml
@@ -289,4 +289,25 @@
      <string name="template_support_toml">Dukungan TOML</string>
      <string name="title_template_native_build_imgui_description">Antarmuka Pengguna Grafis Bawaan Android</string>
      <string name="title_template_no_activity_desc">Tidak ada aktivitas</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-it/strings_b.xml
+++ b/core/resources/src/main/res/values-it/strings_b.xml
@@ -289,4 +289,25 @@
      <string name="template_support_toml">Supporto TOML</string>
      <string name="title_template_native_build_imgui_description">Interfaccia Grafica Nativa di Android</string>
      <string name="title_template_no_activity_desc">Non ha attività</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-ja/strings_b.xml
+++ b/core/resources/src/main/res/values-ja/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">TOMLサポート</string>
      <string name="title_template_native_build_imgui_description">Androidネイティブグラフィカルユーザーインターフェース</string>
      <string name="title_template_no_activity_desc">それには活動がありません</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-ko/strings_b.xml
+++ b/core/resources/src/main/res/values-ko/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">TOML 지원</string>
      <string name="title_template_native_build_imgui_description">안드로이드 네이티브 그래픽 사용자 인터페이스</string>
      <string name="title_template_no_activity_desc">활동이 없습니다</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-ml/strings_b.xml
+++ b/core/resources/src/main/res/values-ml/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">TOML പിന്തുണ</string>
      <string name="title_template_native_build_imgui_description">ആൻഡ്രോയിഡ് നാട്ടുവഴി ഗ്രാഫിക്കൽ ഉപയോക്തൃ ഇന്റർഫേസ്</string>
      <string name="title_template_no_activity_desc">ഇതിന് ഏതെങ്കിലും പ്രവർത്തനമില്ല</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-pl/strings_b.xml
+++ b/core/resources/src/main/res/values-pl/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">Obsługa TOML</string>
      <string name="title_template_native_build_imgui_description">Natywny interfejs użytkownika Androida</string>
      <string name="title_template_no_activity_desc">Nie ma żadnej aktywności</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-pt-rBR/strings_b.xml
+++ b/core/resources/src/main/res/values-pt-rBR/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">Suporte a TOML</string>
      <string name="title_template_native_build_imgui_description">Interface Gráfica Nativa do Android</string>
      <string name="title_template_no_activity_desc">Não tem atividade</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-ro-rRO/strings_b.xml
+++ b/core/resources/src/main/res/values-ro-rRO/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">Suport TOML</string>
      <string name="title_template_native_build_imgui_description">Interfață grafică nativă Android</string>
      <string name="title_template_no_activity_desc">Nu are activitate</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-ru-rRU/strings_b.xml
+++ b/core/resources/src/main/res/values-ru-rRU/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">Поддержка TOML</string>
      <string name="title_template_native_build_imgui_description">Нативный графический пользовательский интерфейс Android</string>
      <string name="title_template_no_activity_desc">У него нет активности</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-ta/strings_b.xml
+++ b/core/resources/src/main/res/values-ta/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">TOML ஆதரவு</string>
      <string name="title_template_native_build_imgui_description">ஆண்ட்ராய்டு தேசிய காட்சியியல் பயனர் இடைமுகம்</string>
      <string name="title_template_no_activity_desc">அதற்கு எந்த செயல்பாடும் இல்லை</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-th/strings_b.xml
+++ b/core/resources/src/main/res/values-th/strings_b.xml
@@ -277,4 +277,25 @@
      <string name="template_support_toml">การสนับสนุน TOML</string>
      <string name="title_template_native_build_imgui_description">อินเทอร์เฟซผู้ใช้กราฟิกเนทีฟของแอนดรอยด์</string>
      <string name="title_template_no_activity_desc">มันไม่มีการเคลื่อนไหว</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-tm-rTM/strings_b.xml
+++ b/core/resources/src/main/res/values-tm-rTM/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">TOML Goldawy</string>
      <string name="title_template_native_build_imgui_description">Android Özümiçi Grafiki Ulanyjy Interfeýsi</string>
      <string name="title_template_no_activity_desc">Ol işjeňligi ýok</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-tr-rTR/strings_b.xml
+++ b/core/resources/src/main/res/values-tr-rTR/strings_b.xml
@@ -287,4 +287,25 @@
      <string name="template_support_toml">TOML Desteği</string>
      <string name="title_template_native_build_imgui_description">Android Yerel Grafiksel Kullanıcı Arayüzü</string>
      <string name="title_template_no_activity_desc">Hiç etkinliği yok</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-uk/strings_b.xml
+++ b/core/resources/src/main/res/values-uk/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">Підтримка TOML</string>
      <string name="title_template_native_build_imgui_description">Нативний графічний інтерфейс користувача Android</string>
      <string name="title_template_no_activity_desc">Воно не має активності</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-vi/strings_b.xml
+++ b/core/resources/src/main/res/values-vi/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">Hỗ trợ TOML</string>
      <string name="title_template_native_build_imgui_description">Giao diện người dùng đồ họa gốc Android</string>
      <string name="title_template_no_activity_desc">Nó không có hoạt động</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -849,4 +849,25 @@
 <string name="summary_open_source_licenses">查看开放源代码许可。</string>
 <string name="idepref_jdkVersion_title">JDK 版本</string>
 <string name="idepref_jdkVersion_summary">当前选择：%1$s（更改需重启）</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -849,25 +849,25 @@
 <string name="summary_open_source_licenses">查看开放源代码许可。</string>
 <string name="idepref_jdkVersion_title">JDK 版本</string>
 <string name="idepref_jdkVersion_summary">当前选择：%1$s（更改需重启）</string>
-    <string name="project_manager_folder">Folder</string>
-    <string name="project_manager_add_folder">Add folder</string>
-    <string name="project_manager_paste_current_tab">Paste to current tab</string>
-    <string name="project_manager_rename">Rename</string>
-    <string name="project_manager_cut">Cut</string>
-    <string name="project_manager_move_to">Move to...</string>
-    <string name="project_manager_delete">Delete</string>
-    <string name="project_manager_properties">Properties</string>
-    <string name="project_manager_close">Close</string>
-    <string name="project_manager_path_not_exists">Path does not exist</string>
-    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
-    <string name="project_manager_type_folder">Folder</string>
-    <string name="project_manager_properties_template">Path: %1$s
-Type: %2$s
-Size: %3$d bytes
-Modified: %4$s
-Permission: %5$s
+    <string name="project_manager_folder">文件夹</string>
+    <string name="project_manager_add_folder">添加文件夹</string>
+    <string name="project_manager_paste_current_tab">粘贴到当前标签页</string>
+    <string name="project_manager_rename">重命名</string>
+    <string name="project_manager_cut">剪切</string>
+    <string name="project_manager_move_to">移动到…</string>
+    <string name="project_manager_delete">删除</string>
+    <string name="project_manager_properties">属性</string>
+    <string name="project_manager_close">关闭</string>
+    <string name="project_manager_path_not_exists">路径不存在</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid：未知</string>
+    <string name="project_manager_type_folder">文件夹</string>
+    <string name="project_manager_properties_template">路径：%1$s
+类型：%2$s
+大小：%3$d 字节
+修改时间：%4$s
+权限：%5$s
 %6$s
-MD5: %7$s
-SHA1: %8$s
-SHA256: %9$s</string>
+MD5：%7$s
+SHA1：%8$s
+SHA256：%9$s</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rTW/strings_b.xml
+++ b/core/resources/src/main/res/values-zh-rTW/strings_b.xml
@@ -288,4 +288,25 @@
      <string name="template_support_toml">TOML 支援</string>
      <string name="title_template_native_build_imgui_description">Android 原生圖形使用者介面</string>
      <string name="title_template_no_activity_desc">它沒有活動</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>

--- a/core/resources/src/main/res/values/strings_b.xml
+++ b/core/resources/src/main/res/values/strings_b.xml
@@ -72,6 +72,7 @@
      <string name="main_action_open">Open</string>
      <string name="main_nav_home">Home</string>
      <string name="main_nav_history">History</string>
+    <string name="main_nav_projects">Projects</string>
      <string name="main_nav_tools">Tools</string>
      <string name="main_nav_mine">Me</string>
      <string name="msg_unimplemented_feature">This feature is not yet available, coming soon</string>

--- a/core/resources/src/main/res/values/strings_b.xml
+++ b/core/resources/src/main/res/values/strings_b.xml
@@ -311,4 +311,25 @@
      <string name="title_template_native_build_imgui">C++ image gui</string>
      <string name="title_template_native_build_imgui_description">Android Native Graphical User Interface</string>
      <string name="title_template_no_activity_desc">It has no activity</string>
+    <string name="project_manager_folder">Folder</string>
+    <string name="project_manager_add_folder">Add folder</string>
+    <string name="project_manager_paste_current_tab">Paste to current tab</string>
+    <string name="project_manager_rename">Rename</string>
+    <string name="project_manager_cut">Cut</string>
+    <string name="project_manager_move_to">Move to...</string>
+    <string name="project_manager_delete">Delete</string>
+    <string name="project_manager_properties">Properties</string>
+    <string name="project_manager_close">Close</string>
+    <string name="project_manager_path_not_exists">Path does not exist</string>
+    <string name="project_manager_uid_gid_unknown">uid/gid: unknown</string>
+    <string name="project_manager_type_folder">Folder</string>
+    <string name="project_manager_properties_template">Path: %1$s
+Type: %2$s
+Size: %3$d bytes
+Modified: %4$s
+Permission: %5$s
+%6$s
+MD5: %7$s
+SHA1: %8$s
+SHA256: %9$s</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Provide a dedicated Projects manager that lists every subfolder in `Environment.PROJECTS_DIR` as a project and allow adding user-selected folders as persistent tabs. 
- Expose the manager from the main bottom navigation so users can quickly browse and open project folders.

### Description
- Added `ProjectManagerFragment` implemented with Jetpack Compose + Material3 that shows a tabbed folder browser and lists only subfolders as projects. 
- The fragment initializes a default tab using `Environment.PROJECTS_FOLDER` and `Environment.PROJECTS_DIR`, and allows adding new tabs via the system folder picker (`ActivityResultContracts.OpenDocumentTree`) while taking persistable URI permissions. 
- Project listing is loaded on `Dispatchers.IO` via `loadProjects(...)` and displayed with `LazyColumn` and `items(key=...)` to improve rendering and scroll performance. 
- Integrated a new `NavigationBarItem` in `MainFragment` (inserted before History) to open `ProjectManagerFragment`, and added `main_nav_projects` string resource.

### Testing
- Performed a Kotlin compile check with `./gradlew :core:app:compileDebugKotlin -q`, which failed in this environment with a Gradle/platform error reporting `25.0.1` (environment/dependency issue), so build could not be verified here. 
- No other automated tests were executed in this rollout due to the build environment failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad392b5d4832f8e92f122f4a97c0c)