### PR TITLE
Fix ProjectManagerFragment Kotlin compile errors (reload overload + manifest parsing)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ProjectManagerFragment.kt
@@ -374,6 +374,10 @@ class ProjectManagerFragment : BaseFragment() {
     loadTabProjects(viewLifecycleScope, selectedTab, forceRefresh)
   }
 
+  private fun reloadProjectList(scope: CoroutineScope, tab: ProjectTab, forceRefresh: Boolean = true) {
+    loadTabProjects(scope, tab, forceRefresh)
+  }
+
   private fun scanTopLevelProjects(tab: ProjectTab): List<String> {
     tab.filePath?.let { root ->
       return File(root).listFiles { file -> file.isDirectory }?.map { it.absolutePath }.orEmpty()
@@ -442,14 +446,25 @@ class ProjectManagerFragment : BaseFragment() {
   private fun digest(alg: String, text: String): String = MessageDigest.getInstance(alg).digest(text.toByteArray()).joinToString("") { "%02x".format(it) }
 
   companion object {
+    private data class ManifestMetaRefs(val iconRef: String?, val labelRef: String?)
+
     private fun parseProjectDisplayInfo(projectDir: File): ProjectDisplayInfo {
       val appModule = findApplicationModule(projectDir) ?: return ProjectDisplayInfo(projectDir.name, null)
       val meta = parseManifestMetaForAppModule(appModule)
       val resDir = File(appModule, "src/main/res")
-      val iconFile = iconRef?.let { resolveDrawableResourceFile(resDir, it) }
-      val resolvedLabel = resolveLabel(projectDir.name, resDir, labelRef)
+      val iconFile = meta.iconRef?.let { resolveDrawableResourceFile(resDir, it) }
+      val resolvedLabel = resolveLabel(projectDir.name, resDir, meta.labelRef)
       val label = "${projectDir.name} : $resolvedLabel"
       return ProjectDisplayInfo(label, iconFile)
+    }
+
+    private fun parseManifestMetaForAppModule(appModule: File): ManifestMetaRefs {
+      val manifest = File(appModule, "src/main/AndroidManifest.xml")
+      if (!manifest.exists()) return ManifestMetaRefs(iconRef = null, labelRef = null)
+      val xml = runCatching { manifest.readText() }.getOrDefault("")
+      val iconRef = Regex("android:icon=\"([^\"]+)\"").find(xml)?.groupValues?.getOrNull(1)
+      val labelRef = Regex("android:label=\"([^\"]+)\"").find(xml)?.groupValues?.getOrNull(1)
+      return ManifestMetaRefs(iconRef = iconRef, labelRef = labelRef)
     }
 
     private fun findApplicationModule(projectDir: File): File? {


### PR DESCRIPTION
### Motivation
- Resolve Kotlin compile errors where call sites passed a `CoroutineScope`/`ProjectTab` pair to `reloadProjectList` and the existing signature only accepted a `Boolean` flag. 
- Fix unresolved references and type-inference problems caused by missing manifest parsing helpers (`parseManifestMetaForAppModule`, `iconRef`, `labelRef`).
- Ensure project display metadata (icon and label) are properly extracted from an app module's `AndroidManifest.xml` so icons/labels can be shown in the UI.

### Description
- Added a scoped overload `private fun reloadProjectList(scope: CoroutineScope, tab: ProjectTab, forceRefresh: Boolean = true)` that delegates to `loadTabProjects(...)` so existing call sites passing `scope` and `tab` compile. 
- Introduced `private data class ManifestMetaRefs(val iconRef: String?, val labelRef: String?)` in the companion object and implemented `private fun parseManifestMetaForAppModule(appModule: File): ManifestMetaRefs` to extract `android:icon` and `android:label` from `app/src/main/AndroidManifest.xml`. 
- Updated `parseProjectDisplayInfo` to consume the parsed `ManifestMetaRefs` (`meta.iconRef` and `meta.labelRef`) and resolve drawable/label lookup via existing helper functions. 

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin --no-daemon` to validate compilation, but the build aborted due to an environment/toolchain error reporting `25.0.1`, so full Kotlin compilation could not be completed in this environment. 
- No automated tests were run beyond the attempted Gradle compile due to the build environment failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb71c5f9a48331ae8d7770fffe2031)