### PR TITLE
Fix unresolved `flashError` reference in BaseEditorActivity

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -104,6 +104,7 @@ import com.itsaky.androidide.utils.DialogUtils.newMaterialDialogBuilder
 import com.itsaky.androidide.utils.InstallationResultHandler.onResult
 import com.itsaky.androidide.utils.IntentUtils
 import com.itsaky.androidide.utils.MemoryUsageWatcher
+import com.itsaky.androidide.utils.flashError
 import com.itsaky.androidide.utils.resolveAttr
 import com.itsaky.androidide.viewmodel.EditorViewModel
 import com.itsaky.androidide.xml.resources.ResourceTableRegistry


### PR DESCRIPTION
### Motivation
- Resolve the Kotlin compile error caused by an unresolved `flashError` reference at `BaseEditorActivity.kt:491` by restoring the missing import.

### Description
- Add the import `import com.itsaky.androidide.utils.flashError` to `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt`.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin -x lint`, which did not complete due to an environment/toolchain issue (`* What went wrong: 25.0.1`) unrelated to the import change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7bcf2f608331a2ad8b1384b50e42)