### PR TITLE
Fix BaseEditorActivity Kotlin compile errors

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -20,6 +20,7 @@ package com.itsaky.androidide.activities.editor
 import android.content.Intent
 import android.content.pm.PackageInstaller.SessionCallback
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.os.Process
 import android.text.SpannableStringBuilder
@@ -619,7 +620,8 @@ abstract class BaseEditorActivity :
 
   fun refreshSymbolInput(editor: CodeEditorView) {
     if (isDestroying || _binding == null) return
-    content.bottomSheet.binding.externalSymbolInputView.bindEditor(editor.editor)
+    val codeEditor = editor.editor ?: return
+    content.bottomSheet.binding.externalSymbolInputView.bindEditor(codeEditor)
   }
 
   private fun checkIsDestroying() {


### PR DESCRIPTION
### Motivation
- Resolve two Kotlin compile errors: a nullability/type mismatch when binding the symbol input editor and an unresolved `GradientDrawable` reference during diagnostic info setup.

### Description
- Safely unwrap the editor instance in `refreshSymbolInput(editor: CodeEditorView)` by using `val codeEditor = editor.editor ?: return` before calling `bindEditor(codeEditor)`, preventing an `IDEEditor?` to `CodeEditor` mismatch.
- Add the missing import `import android.graphics.drawable.GradientDrawable` so `setupDiagnosticInfo()` can construct and configure a `GradientDrawable` instance.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin --console=plain`; source-level Kotlin errors addressed, but the build in this environment aborts early due to an Android SDK/tooling issue (`* What went wrong: 25.0.2`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc51c52a788331bfc313d3f6c5522f)