### PR TITLE
fix(chatai): use existing catalog aliases for Compose and KSP plugins

### DIFF
--- a/core/chatai/build.gradle.kts
+++ b/core/chatai/build.gradle.kts
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
   alias(libs.plugins.android.application) apply false
-  alias(libs.plugins.kotlin.compose) apply false
+  alias(libs.plugins.org.jetbrains.kotlin.plugin.compose) apply false
   alias(libs.plugins.android.library) apply false
-  alias(libs.plugins.ksp) apply false
+  alias(libs.plugins.com.google.devtools.ksp) apply false
   alias(libs.plugins.google.services) apply false
   alias(libs.plugins.firebase.crashlytics) apply false
   alias(libs.plugins.android.test) apply false


### PR DESCRIPTION
### Motivation
- The top-level plugin aliases in `core/chatai/build.gradle.kts` referenced keys not present in the version catalog, causing Gradle script compilation failures for `compose` and `ksp`.

### Description
- Replaced `libs.plugins.kotlin.compose` with `libs.plugins.org.jetbrains.kotlin.plugin.compose` and `libs.plugins.ksp` with `libs.plugins.com.google.devtools.ksp` in `core/chatai/build.gradle.kts` to match `gradle/libs.versions.toml`.

### Testing
- Ran `./gradlew :core:chatai:help -q`, which resolved the unresolved-alias script compilation errors; the build then failed later due to an unrelated environment/toolchain issue reporting `25.0.2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcab064168833186ae0bfd35346d69)