### PR TITLE
feat(editor): sync symbol input fade/translate with bottom sheet slide

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -338,9 +338,13 @@ class EditorBottomSheet @JvmOverloads constructor(
             
             // 为了视觉体验，我们让 Header 提前消失（例如滑到一半 0.5 时就全透）
             val alphaValue = max(0f, 1f - (slideOffset * 2f))
+            val translateY = slideOffset.coerceIn(0f, 1f) * 8f * resources.displayMetrics.density
             
             binding.headerContentWrapper.alpha = alphaValue
+            binding.headerContentWrapper.translationY = translateY
             binding.pageSwitchGestureBubble.alpha = alphaValue
+            binding.pageSwitchGestureBubble.translationY = translateY
+            binding.externalSymbolInputView.applyBottomSheetGestureProgress(slideOffset)
             
             // 当完全展开且全透时，可以设置 GONE 彻底不阻挡点击，但这由底层事件接管也可以。
             

--- a/modules/zero-Symbol-input-view/src/main/kotlin/android/zero/studio/widget/editor/symbolinput/AdvancedSymbolInputView.kt
+++ b/modules/zero-Symbol-input-view/src/main/kotlin/android/zero/studio/widget/editor/symbolinput/AdvancedSymbolInputView.kt
@@ -26,6 +26,7 @@ import androidx.viewpager.widget.ViewPager
 import com.google.android.material.tabs.TabLayout
 import io.github.rosemoe.sora.widget.CodeEditor
 import kotlin.math.roundToInt
+import kotlin.math.max
 
 /**
  * AdvancedSymbolInputView 的核心实现。
@@ -204,6 +205,16 @@ class AdvancedSymbolInputView @JvmOverloads constructor(
         val currentHeight = viewPager.layoutParams.height.coerceAtLeast(collapsedHeightPx)
         val range = (expandedHeightPx - collapsedHeightPx).coerceAtLeast(1)
         return ((currentHeight - collapsedHeightPx).toFloat() / range.toFloat()).coerceIn(0f, 1f)
+    }
+
+    /**
+     * 跟随 BottomSheet 的 slideOffset（0~1）执行与 Header/Bubble 一致的渐隐与上下平移动画参数。
+     */
+    fun applyBottomSheetGestureProgress(slideOffset: Float) {
+        val clampedOffset = slideOffset.coerceIn(0f, 1f)
+        val alphaValue = max(0f, 1f - (clampedOffset * 2f))
+        alpha = alphaValue
+        translationY = clampedOffset * 8f * resources.displayMetrics.density
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Keep `AdvancedSymbolInputView` visually consistent with the header area and `EdgeSnapBubbleView` during BottomSheet drag gestures by applying the same gradual hide/show and vertical translation behavior.

### Description
- Added `applyBottomSheetGestureProgress(slideOffset: Float)` to `AdvancedSymbolInputView` to compute and apply the same alpha and `translationY` mapping used by the header/bubble (alpha = max(0, 1 - slideOffset*2), vertical translation based on density).
- Updated `EditorBottomSheet` `onSlide` callback to also set `translationY` for `headerContentWrapper` and `pageSwitchGestureBubble`, and to forward `slideOffset` into the symbol input view via `binding.externalSymbolInputView.applyBottomSheetGestureProgress(slideOffset)`.
- Minor import addition (`kotlin.math.max`) to support the new calculations.

### Testing
- Attempted an automated Kotlin compile of the app module with `./gradlew :core:app:compileDebugKotlin -x lint`, which failed in this environment due to a Gradle/toolchain issue (`25.0.2`), so full compile verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfbce345083319b6f6b3d1ee9c57c)