### PR TITLE
Sync bottom-sheet header elements with gesture hide/show animation

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -353,9 +353,10 @@ class EditorBottomSheet @JvmOverloads constructor(
               view.alpha = alphaValue
               view.translationY = translateY
             }
-            binding.externalSymbolInputView.applyBottomSheetGestureProgress(slideOffset)
 
-            // 当完全展开且全透时，可以设置 GONE 彻底不阻挡点击，但这由底层事件接管也可以。
+            val hideHeaderArea = slideOffset >= 1f
+            binding.floatingHeaderArea.visibility = if (hideHeaderArea) View.GONE else View.VISIBLE
+            binding.externalSymbolInputView.applyBottomSheetGestureProgress(slideOffset)
 
             onSlideAction?.invoke(slideOffset)
           }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -340,7 +340,7 @@ class EditorBottomSheet @JvmOverloads constructor(
             val alphaValue = max(0f, 1f - (slideOffset * 2f))
             val translateY = slideOffset.coerceIn(0f, 1f) * 8f * resources.displayMetrics.density
             
-            val syncedHeaderViews = listOf(
+            val syncedHeaderViews = listOf<View>(
               binding.floatingHeaderArea,
               binding.headerContentWrapper,
               binding.headerInnerContent,

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -340,14 +340,23 @@ class EditorBottomSheet @JvmOverloads constructor(
             val alphaValue = max(0f, 1f - (slideOffset * 2f))
             val translateY = slideOffset.coerceIn(0f, 1f) * 8f * resources.displayMetrics.density
             
-            binding.headerContentWrapper.alpha = alphaValue
-            binding.headerContentWrapper.translationY = translateY
-            binding.pageSwitchGestureBubble.alpha = alphaValue
-            binding.pageSwitchGestureBubble.translationY = translateY
+            val syncedHeaderViews = listOf(
+              binding.floatingHeaderArea,
+              binding.headerContentWrapper,
+              binding.headerInnerContent,
+              binding.headerDivider,
+              binding.border,
+              binding.cardView,
+              binding.pageSwitchGestureBubble,
+            )
+            syncedHeaderViews.forEach { view ->
+              view.alpha = alphaValue
+              view.translationY = translateY
+            }
             binding.externalSymbolInputView.applyBottomSheetGestureProgress(slideOffset)
-            
+
             // 当完全展开且全透时，可以设置 GONE 彻底不阻挡点击，但这由底层事件接管也可以。
-            
+
             onSlideAction?.invoke(slideOffset)
           }
         }

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -345,7 +345,7 @@ class EditorBottomSheet @JvmOverloads constructor(
               binding.headerContentWrapper,
               binding.headerInnerContent,
               binding.headerDivider,
-              binding.border,
+              binding.border.root,
               binding.cardView,
               binding.pageSwitchGestureBubble,
             )


### PR DESCRIPTION
### Motivation
- Ensure all header-area views participate in the BottomSheet slide gesture so the header region hides/shows gradually and consistently. 
- Align the header behavior with existing `AdvancedSymbolInputView` and `EdgeSnapBubbleView` animations to avoid visual mismatch during sheet dragging.

### Description
- Updated the `onSlide` callback in `core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt` to apply the same `alpha` and `translationY` values to a synced list of header views instead of only the wrapper and bubble. 
- The synced views are `floating_header_area`, `header_content_wrapper`, `header_inner_content`, `header_divider`, `border`, `cardView`, and `page_switch_gesture_bubble`, and they are updated in a loop with the computed `alphaValue` and `translateY`. 
- Kept the existing call to `externalSymbolInputView.applyBottomSheetGestureProgress(slideOffset)` so the symbol input view continues following the same slide progress. 

### Testing
- Attempted automated build with `./gradlew :core:app:compileDebugKotlin -q`, which failed due to a local toolchain/environment issue (`25.0.2`) unrelated to the change, so the compile did not complete successfully. 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe02abc298832f9563ef5eb05162af)