### PR TITLE
Limit editor bottom sheet expansion to progress indicator bottom

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -22,6 +22,7 @@ import android.content.pm.PackageInstaller.SessionCallback
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
+import android.zero.studio.widget.editor.symbolinput.SymbolManagerActivity
 import android.os.Process
 import android.text.SpannableStringBuilder
 import android.text.Spanned
@@ -623,6 +624,9 @@ abstract class BaseEditorActivity :
     val codeEditor = editor.editor ?: return
     // 直接指向底栏内部绑定的符号工具栏
     content.bottomSheet.binding.externalSymbolInputView.bindEditor(codeEditor)
+    content.bottomSheet.binding.externalSymbolInputView.onOpenManagerListener = {
+      startActivity(Intent(this, SymbolManagerActivity::class.java))
+    }
   }
 
   private fun checkIsDestroying() {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -753,8 +753,23 @@ abstract class BaseEditorActivity :
 
   private fun setupBottomSheet() {
     if (_binding == null) return
-    editorBottomSheet = BottomSheetBehavior.from<View>(content.bottomSheet)
-    
+    val behavior = BottomSheetBehavior.from<View>(content.bottomSheet)
+    editorBottomSheet = behavior
+
+    val applyExpandedOffset = {
+      val progressBottom = content.progressIndicator.bottom
+      if (progressBottom > 0) {
+        behavior.expandedOffset = progressBottom
+      }
+    }
+    content.progressIndicator.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+      applyExpandedOffset()
+    }
+    content.editorAppBarLayout.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+      applyExpandedOffset()
+    }
+    content.realContainer.post { applyExpandedOffset() }
+
     content.bottomSheet.onSlideAction = { slideOffset ->
       if (!isDestroying && _binding != null) {
           val editorScale = 1 - slideOffset * (1 - EDITOR_CONTAINER_SCALE_FACTOR)


### PR DESCRIPTION
### Motivation
- Prevent the editor `bottom_sheet` from fully expanded covering the `editor_appBarLayout` by clamping its top when expanded to not exceed the bottom of the `progress_indicator`.

### Description
- Replace direct assignment to `editorBottomSheet` with a local `behavior` (`BottomSheetBehavior.from<View>(content.bottomSheet)`) and assign it to `editorBottomSheet`.
- Compute and apply a maximum expanded top by setting `behavior.expandedOffset` to `content.progressIndicator.bottom` when available via a helper `applyExpandedOffset` lambda.
- Add layout listeners on `content.progressIndicator` and `content.editorAppBarLayout` and an initial `content.realContainer.post { ... }` to keep the `expandedOffset` in sync after layout changes.
- Preserve existing `content.bottomSheet.onSlideAction` scaling behavior unchanged so editor scaling during slide remains the same.

### Testing
- Ran `./gradlew :core:app:compileDebugKotlin -x test` to compile the modified module, which failed in this environment due to SDK/build-tools version error (`25.0.2`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1be761f4832fa73205b8a9739645)