### PR TITLE
Add Color Query UI, pull-based LSP diagnostics, APM monitoring toggle, and UI fixes

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -254,7 +254,7 @@ dependencies {
   // implementation(projects.core.chatai.tts)
   implementation(projects.modules.zeroRegularPreview)
   implementation(projects.modules.composePreview)
-  // implementation(projects.modules.colorpicker)
+  implementation(projects.modules.colorpicker)
   implementation(libs.common.soraLanguageTextmate)
 
   coreLibraryDesugaring(libs.androidx.libDesugaring) // 脱糖

--- a/core/app/src/main/java/com/itsaky/androidide/actions/editor/ColorQueryAction.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/actions/editor/ColorQueryAction.kt
@@ -1,0 +1,56 @@
+package com.itsaky.androidide.actions.editor
+
+import android.content.Context
+import com.itsaky.androidide.actions.ActionData
+import com.itsaky.androidide.actions.ActionItem
+import com.itsaky.androidide.actions.BaseEditorAction
+import com.itsaky.androidide.actions.EditorActivityAction
+import com.itsaky.androidide.fragments.ColorQueryDialogFragment
+import com.itsaky.androidide.resources.R
+
+private fun resolveSelection(data: ActionData): String? {
+  val editor = data.get(com.itsaky.androidide.editor.ui.IDEEditor::class.java) ?: return null
+  if (!editor.cursor.isSelected) return null
+  val left = editor.cursor.left().index
+  val right = editor.cursor.right().index
+  if (right <= left) return null
+  return editor.text.subSequence(left, right).toString()
+}
+
+class ColorQueryTextAction(context: Context, override val order: Int) : BaseEditorAction() {
+  override val id: String = "ide.editor.color.query.text"
+
+  init {
+    label = context.getString(R.string.action_color_query)
+    location = ActionItem.Location.EDITOR_TEXT_ACTIONS
+  }
+
+  override suspend fun execAction(data: ActionData): Boolean {
+    val ctx = getContext(data) ?: return false
+    val fm = (ctx as? androidx.fragment.app.FragmentActivity)?.supportFragmentManager ?: return false
+    ColorQueryDialogFragment.newInstance(resolveSelection(data)).show(fm, "color_query")
+    return true
+  }
+}
+
+class ColorQueryToolbarAction(private val context: Context, override val order: Int) : EditorActivityAction() {
+  override val id: String = "ide.editor.color.query.toolbar"
+
+  init {
+    label = context.getString(R.string.action_color_query)
+    location = ActionItem.Location.EDITOR_TOOLBAR
+  }
+
+  override suspend fun execAction(data: ActionData): Any {
+    val activity = data.getActivity() ?: return false
+    val query = activity.getCurrentEditor()?.editor?.let {
+      if (it.cursor.isSelected) {
+        val left = it.cursor.left().index
+        val right = it.cursor.right().index
+        if (right > left) it.text.subSequence(left, right).toString() else null
+      } else null
+    }
+    ColorQueryDialogFragment.newInstance(query).show(activity.supportFragmentManager, "color_query")
+    return true
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/ColorQueryDialogFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/ColorQueryDialogFragment.kt
@@ -1,0 +1,32 @@
+package com.itsaky.androidide.fragments
+
+import android.app.Dialog
+import android.graphics.Color
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.DialogFragment
+import com.smarttoolfactory.colorpicker.dialog.ColorPickerRingDiamondHEXDialog
+
+class ColorQueryDialogFragment : DialogFragment() {
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    val query = arguments?.getString(ARG_QUERY)
+    val initial = try { Color.parseColor(query ?: "#FFFFFF") } catch (_: Throwable) { Color.WHITE }
+    val composeView = ComposeView(requireContext()).apply {
+      setContent {
+        ColorPickerRingDiamondHEXDialog(
+            initialColor = androidx.compose.ui.graphics.Color(initial),
+            initialQueryText = query.orEmpty(),
+        ) { _, _ -> dismissAllowingStateLoss() }
+      }
+    }
+    return AlertDialog.Builder(requireContext()).setView(composeView).create()
+  }
+
+  companion object {
+    private const val ARG_QUERY = "arg_query"
+    fun newInstance(query: String?) = ColorQueryDialogFragment().apply {
+      arguments = Bundle().apply { putString(ARG_QUERY, query) }
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/output/EditorProcessApmFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/output/EditorProcessApmFragment.kt
@@ -74,7 +74,9 @@ import kotlinx.coroutines.launch
 class EditorProcessApmFragment : Fragment() {
 
   private var monitorJob: Job? = null
+  private var monitor: EditorProcessApmMonitor? = null
   private val snapshotState = mutableStateOf<EditorProcessApmSnapshot?>(null)
+  private val isMonitoringState = mutableStateOf(false)
 
   override fun onCreateView(
       inflater: LayoutInflater,
@@ -87,6 +89,8 @@ class EditorProcessApmFragment : Fragment() {
             snapshot = snapshotState.value,
             onCleanProcesses = ::runCleanupViaTermux,
             onInAppSelfCleanup = ::runInAppSelfCleanup,
+            isMonitoring = isMonitoringState.value,
+            onToggleMonitoring = ::toggleMonitoring,
         )
       }
     }
@@ -94,17 +98,38 @@ class EditorProcessApmFragment : Fragment() {
 
   override fun onStart() {
     super.onStart()
-    val monitor = EditorProcessApmMonitor(requireContext().applicationContext)
-    monitorJob?.cancel()
-    monitorJob =
-        viewLifecycleOwner.lifecycleScope.launch {
-          monitor.stream(intervalMs = 1000L).collect { snapshot -> snapshotState.value = snapshot }
-        }
   }
 
   override fun onStop() {
-    monitorJob?.cancel()
+    stopMonitoring(clearSnapshot = false)
     super.onStop()
+  }
+
+  private fun toggleMonitoring() {
+    if (isMonitoringState.value) {
+      stopMonitoring(clearSnapshot = true)
+    } else {
+      startMonitoring()
+    }
+  }
+
+  private fun startMonitoring() {
+    if (isMonitoringState.value) return
+    val localMonitor = monitor ?: EditorProcessApmMonitor(requireContext().applicationContext).also { monitor = it }
+    monitorJob?.cancel()
+    isMonitoringState.value = true
+    monitorJob =
+      viewLifecycleOwner.lifecycleScope.launch {
+        localMonitor.stream(intervalMs = 1000L).collect { snapshot -> snapshotState.value = snapshot }
+      }
+  }
+
+  private fun stopMonitoring(clearSnapshot: Boolean) {
+    monitorJob?.cancel()
+    monitorJob = null
+    monitor = null
+    isMonitoringState.value = false
+    if (clearSnapshot) snapshotState.value = null
   }
 
   private fun runCleanupViaTermux() {
@@ -142,6 +167,8 @@ private fun EditorApmMonitorScreen(
     snapshot: EditorProcessApmSnapshot?,
     onCleanProcesses: () -> Unit,
     onInAppSelfCleanup: () -> Unit,
+    isMonitoring: Boolean,
+    onToggleMonitoring: () -> Unit,
 ) {
   val cpuHistory = remember { mutableStateListOf<Float>() }
   val pssHistory = remember { mutableStateListOf<Float>() }
@@ -173,6 +200,13 @@ private fun EditorApmMonitorScreen(
                     },
                 )
                 DropdownMenuItem(
+                    text = { Text(if (isMonitoring) stringResource(ResString.string.apm_stop_monitoring) else stringResource(ResString.string.apm_start_monitoring)) },
+                    onClick = {
+                      menuExpanded = false
+                      onToggleMonitoring()
+                    },
+                )
+                DropdownMenuItem(
                     text = { Text(stringResource(ResString.string.apm_menu_self_cleanup)) },
                     onClick = {
                       menuExpanded = false
@@ -190,7 +224,7 @@ private fun EditorApmMonitorScreen(
     ) {
       item {
         Text(
-            text = stringResource(ResString.string.apm_sampling_desc),
+            text = if (isMonitoring) stringResource(ResString.string.apm_sampling_desc) else stringResource(ResString.string.apm_monitoring_paused_desc),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -51,6 +51,8 @@ import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
 import com.itsaky.androidide.lsp.java.JavaLanguageServer
 import com.itsaky.androidide.lsp.kotlin.KotlinLanguageServerImpl
 import com.itsaky.androidide.lsp.models.DiagnosticResult
+import com.itsaky.androidide.lsp.models.DocumentDiagnosticParams
+import com.itsaky.androidide.lsp.models.DocumentDiagnosticReportKind
 import com.itsaky.androidide.lsp.servers.toml.TomlServer
 import com.itsaky.androidide.lsp.xml.XMLLanguageServer
 import com.itsaky.androidide.models.Range
@@ -390,19 +392,24 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
       val editor = _binding?.editor ?: return@launch
       val languageServer = editor.languageServer
 
-      if (
-          languageServer is KotlinLanguageServerImpl &&
-              (file.extension == "kt" || file.extension == "kts")
-      ) {
+      if (languageServer != null) {
         try {
-          val result = languageServer.analyze(file.toPath())
+          val diagnostics =
+              if (languageServer.supportsDocumentDiagnostics()) {
+                val report =
+                    languageServer.documentDiagnostics(
+                        DocumentDiagnosticParams(file = file.toPath()))
+                if (report != null && report.kind == DocumentDiagnosticReportKind.FULL) {
+                  report.diagnostics
+                } else {
+                  emptyList()
+                }
+              } else {
+                val result = languageServer.analyze(file.toPath())
+                if (result != DiagnosticResult.NO_UPDATE) result.diagnostics else emptyList()
+              }
 
-          if (result != DiagnosticResult.NO_UPDATE) {
-            withContext(Dispatchers.Main) {
-              // Access the diagnostics field directly
-              editor.updateEditorDiagnostics(result.diagnostics)
-            }
-          }
+          withContext(Dispatchers.Main) { editor.updateEditorDiagnostics(diagnostics) }
         } catch (e: Exception) {
           log.error("Failed to analyze file for diagnostics", e)
         }

--- a/core/app/src/main/java/com/itsaky/androidide/utils/EditorActivityActions.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/utils/EditorActivityActions.kt
@@ -28,6 +28,8 @@ import com.itsaky.androidide.actions.build.RunTasksAction
 import com.itsaky.androidide.actions.code.CodeActionsMenu
 import com.itsaky.androidide.actions.cursor.*
 import com.itsaky.androidide.actions.editor.CopyAction
+import com.itsaky.androidide.actions.editor.ColorQueryTextAction
+import com.itsaky.androidide.actions.editor.ColorQueryToolbarAction
 import com.itsaky.androidide.actions.editor.CutAction
 import com.itsaky.androidide.actions.editor.ExpandSelectionAction
 import com.itsaky.androidide.actions.editor.LongSelectAction
@@ -90,12 +92,14 @@ class EditorActivityActions {
       registry.registerAction(DisconnectLogSendersAction(context, order++))
       registry.registerAction(LaunchAppAction(context, order++))
       registry.registerAction(FindInPathAction(context, order++))
+      registry.registerAction(ColorQueryToolbarAction(context, order++))
 
       // editor text actions
       registry.registerAction(SelectAllAction(context, order++))
       registry.registerAction(CutAction(context, order++))
       registry.registerAction(CopyAction(context, order++))
       registry.registerAction(PasteAction(context, order++))
+      registry.registerAction(ColorQueryTextAction(context, order++))
       registry.registerAction(LongSelectAction(context, order++))
       registry.registerAction(ExpandSelectionAction(context, order++))
       registry.registerAction(FormatCodeAction(context, order++))

--- a/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageServer.kt
+++ b/core/lsp-api/src/main/java/com/itsaky/androidide/lsp/api/ILanguageServer.kt
@@ -45,6 +45,8 @@ import com.itsaky.androidide.lsp.models.DidCloseTextDocumentParams
 import com.itsaky.androidide.lsp.models.DidOpenTextDocumentParams
 import com.itsaky.androidide.lsp.models.DidSaveTextDocumentParams
 import com.itsaky.androidide.lsp.models.DocumentLink
+import com.itsaky.androidide.lsp.models.DocumentDiagnosticParams
+import com.itsaky.androidide.lsp.models.DocumentDiagnosticReport
 import com.itsaky.androidide.lsp.models.ExecuteCommandParams
 import com.itsaky.androidide.lsp.models.DocumentSymbolsResult
 import com.itsaky.androidide.lsp.models.ExpandSelectionParams
@@ -186,6 +188,17 @@ interface ILanguageServer {
    *   available.
    */
   suspend fun analyze(file: Path): DiagnosticResult
+
+  /**
+   * Whether this server supports pull-based diagnostics (textDocument/diagnostic).
+   */
+  fun supportsDocumentDiagnostics(): Boolean = false
+
+  /**
+   * Pull diagnostics for a document. Default returns null when unsupported.
+   */
+  suspend fun documentDiagnostics(params: DocumentDiagnosticParams): DocumentDiagnosticReport? = null
+
 
   /**
    * Format the given source code input.

--- a/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/DiagnosticProtocol.kt
+++ b/core/lsp-models/src/main/java/com/itsaky/androidide/lsp/models/DiagnosticProtocol.kt
@@ -1,0 +1,30 @@
+package com.itsaky.androidide.lsp.models
+
+import com.itsaky.androidide.models.Range
+import java.nio.file.Path
+
+/** Pull-diagnostics request for a single document. */
+data class DocumentDiagnosticParams(
+    var file: Path,
+    var previousResultId: String? = null,
+)
+
+/** LSP pull-diagnostics report kind. */
+enum class DocumentDiagnosticReportKind {
+  FULL,
+  UNCHANGED,
+}
+
+/** Pull-diagnostics report normalized into IDE model layer. */
+data class DocumentDiagnosticReport(
+    var kind: DocumentDiagnosticReportKind,
+    var resultId: String? = null,
+    var diagnostics: List<DiagnosticItem> = emptyList(),
+)
+
+data class DiagnosticRelatedInformation(
+    var locationFile: Path,
+    var locationRange: Range,
+    var message: String,
+)
+

--- a/core/resources/src/main/res/values-zh-rCN/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/apm_monitor_strings.xml
@@ -5,6 +5,9 @@
     <string name="apm_menu_self_cleanup">应用内自清理(页面/LSP/Tooling)</string>
     <string name="apm_title">APM 实时监控</string>
     <string name="apm_sampling_desc">采样: 1s（类文件扫描: 15s）</string>
+    <string name="apm_start_monitoring">启动监控</string>
+    <string name="apm_stop_monitoring">停止监控</string>
+    <string name="apm_monitoring_paused_desc">监控已暂停。启动监控后才会采集 CPU/内存/进程指标。</string>
     <string name="apm_cpu_usage">CPU 使用率(%)</string>
     <string name="apm_process_pss">进程 PSS(MB)</string>
     <string name="apm_metric_rss">RSS</string>

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -870,4 +870,5 @@
 MD5：%7$s
 SHA1：%8$s
 SHA256：%9$s</string>
+    <string name="action_color_query">颜色查询</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rTW/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values-zh-rTW/apm_monitor_strings.xml
@@ -5,6 +5,9 @@
     <string name="apm_menu_self_cleanup">应用内自清理(页面/LSP/Tooling)</string>
     <string name="apm_title">APM 实时监控</string>
     <string name="apm_sampling_desc">采样: 1s（类文件扫描: 15s）</string>
+    <string name="apm_start_monitoring">启动监控</string>
+    <string name="apm_stop_monitoring">停止监控</string>
+    <string name="apm_monitoring_paused_desc">监控已暂停。启动监控后才会采集 CPU/内存/进程指标。</string>
     <string name="apm_cpu_usage">CPU 使用率(%)</string>
     <string name="apm_process_pss">进程 PSS(MB)</string>
     <string name="apm_metric_rss">RSS</string>

--- a/core/resources/src/main/res/values/apm_monitor_strings.xml
+++ b/core/resources/src/main/res/values/apm_monitor_strings.xml
@@ -5,6 +5,9 @@
     <string name="apm_menu_self_cleanup">In-App Self Cleanup (Pages/LSP/Tooling)</string>
     <string name="apm_title">APM Real-time Monitor</string>
     <string name="apm_sampling_desc">Sampling: 1s (Class scan: 15s)</string>
+    <string name="apm_start_monitoring">Start Monitoring</string>
+    <string name="apm_stop_monitoring">Stop Monitoring</string>
+    <string name="apm_monitoring_paused_desc">Monitoring is paused. Start monitoring to collect CPU/memory/process metrics.</string>
     <string name="apm_cpu_usage">CPU Usage (%)</string>
     <string name="apm_process_pss">Process PSS (MB)</string>
     <string name="apm_metric_uss">USS</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -792,4 +792,5 @@
      <string name="idepref_kotlin_remove_unused_imports">Remove unused imports</string>
     <string name="bottom_sheet_page_build">Build status</string>
     <string name="bottom_sheet_page_symbols">Symbol input</string>
+    <string name="action_color_query">Color Query</string>
 </resources>

--- a/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/signature/DefaultSignatureHelpLayout.kt
+++ b/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/signature/DefaultSignatureHelpLayout.kt
@@ -85,7 +85,7 @@ class DefaultSignatureHelpLayout : SignatureHelpLayout {
   override fun applyColorScheme(colorScheme: EditorColorScheme, typeface: Typeface) {
     val editor = window.editor
     textColor = colorScheme.getColor(EditorColorScheme.SIGNATURE_TEXT_NORMAL)
-    highlightColor = colorScheme.getColor(EditorColorScheme.SIGNATURE_TEXT_HIGHLIGHTED_PARAMETER)
+    highlightColor = darkenColor(colorScheme.getColor(EditorColorScheme.SIGNATURE_TEXT_HIGHLIGHTED_PARAMETER), 0.22f)
     codeTypeface = typeface
     signatureTextView.typeface = typeface
     signatureTextView.setTextColor(textColor)
@@ -214,6 +214,14 @@ class DefaultSignatureHelpLayout : SignatureHelpLayout {
     }
     latestEditorTextSize = newSize
     applyEditorScale(newSize)
+  }
+
+  private fun darkenColor(color: Int, factor: Float): Int {
+    val a = color ushr 24 and 0xFF
+    val r = ((color ushr 16) and 0xFF) * (1f - factor)
+    val g = ((color ushr 8) and 0xFF) * (1f - factor)
+    val b = (color and 0xFF) * (1f - factor)
+    return (a shl 24) or (r.toInt().coerceIn(0, 255) shl 16) or (g.toInt().coerceIn(0, 255) shl 8) or b.toInt().coerceIn(0, 255)
   }
 
   private fun appendSignatureText(

--- a/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/signature/SignatureHelpWindow.kt
+++ b/editor/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/signature/SignatureHelpWindow.kt
@@ -169,14 +169,16 @@ open class SignatureHelpWindow(
     val selection = editor.cursor.left()
     val charX = editor.getCharOffsetX(selection.line, selection.column)
     val margin = editor.dpUnit * 10
-    val anchor = editor.getCharOffsetY(selection.line, selection.column) - editor.rowHeight - margin
+    val caretY = editor.getCharOffsetY(selection.line, selection.column)
     val maxY = (editor.height - height).coerceAtLeast(0)
-    val aboveTop = anchor - height
-    if (aboveTop < 0) {
-      // Avoid forcing the popup below the caret so we don't cover completion window
-      return false
-    }
-    val windowY = aboveTop.coerceAtMost(maxY.toFloat())
+    val aboveTop = caretY - editor.rowHeight - margin - height
+    val belowTop = caretY + margin
+    val windowY =
+        when {
+          aboveTop >= 0 -> aboveTop
+          belowTop <= maxY -> belowTop
+          else -> maxY.toFloat()
+        }
     val windowX = (charX - width / 2).coerceAtLeast(0f)
     setLocationAbsolutely(windowX.toInt(), windowY.toInt())
     return true

--- a/modules/colorpicker/src/main/java/com/smarttoolfactory/colorpicker/dialog/ColorPickerDialog.kt
+++ b/modules/colorpicker/src/main/java/com/smarttoolfactory/colorpicker/dialog/ColorPickerDialog.kt
@@ -27,6 +27,18 @@ import androidx.compose.ui.window.Dialog
 import com.smarttoolfactory.colorpicker.picker.*
 import com.smarttoolfactory.colorpicker.ui.Blue400
 import com.smarttoolfactory.extendedcolors.util.ColorUtil
+import kotlin.math.roundToInt
+
+private enum class HexOutputFormat(val label: String) {
+  HEX_LOWER("#d9d9d9"),
+  HEX_UPPER("#D9D9D9"),
+  SRGB_PERCENT("color(srgb 85% 85% 85%)"),
+  SRGB_DECIMAL("color(srgb 0.85 0.85 0.85)"),
+  RGB_PERCENT("rgb(85% 85% 85%)"),
+  RGB_INT("rgb(217 217 217)"),
+  HSL("hsl(none 0% 85%)"),
+  HWB("hwb(none 85% 15%)"),
+}
 
 @Composable
 fun ColorPickerRingDiamondHSLDialog(
@@ -105,17 +117,7 @@ fun ColorPickerRingDiamondHEXDialog(
           "CIE XYZ D50",
           "CIE XYZ D65",
       )
-  val codeFormats =
-      listOf(
-          "#d9d9d9",
-          "#D9D9D9",
-          "color(srgb 85% 85% 85%)",
-          "color(srgb 0.85 0.85 0.85)",
-          "rgb(85% 85% 85%)",
-          "rgb(217 217 217)",
-          "hsl(none 0% 85%)",
-          "hwb(none 85% 15%)",
-      )
+  val codeFormats = HexOutputFormat.entries
   var modeExpanded by remember { mutableStateOf(false) }
   var spaceExpanded by remember { mutableStateOf(false) }
   var formatExpanded by remember { mutableStateOf(false) }
@@ -140,10 +142,38 @@ fun ColorPickerRingDiamondHEXDialog(
           }
         }
       }
-      Text(selectedFormat, modifier = Modifier.padding(6.dp).clickable { formatExpanded = true }, color = Color.White)
+      val formatText =
+          when (selectedFormat) {
+            HexOutputFormat.HEX_LOWER -> hexString.lowercase()
+            HexOutputFormat.HEX_UPPER -> hexString.uppercase()
+            HexOutputFormat.SRGB_PERCENT -> {
+              val r = (color.red * 100).roundToInt()
+              val g = (color.green * 100).roundToInt()
+              val b = (color.blue * 100).roundToInt()
+              "color(srgb $r% $g% $b%)"
+            }
+            HexOutputFormat.SRGB_DECIMAL -> {
+              "color(srgb %.2f %.2f %.2f)".format(color.red, color.green, color.blue)
+            }
+            HexOutputFormat.RGB_PERCENT -> {
+              val r = (color.red * 100).roundToInt()
+              val g = (color.green * 100).roundToInt()
+              val b = (color.blue * 100).roundToInt()
+              "rgb($r% $g% $b%)"
+            }
+            HexOutputFormat.RGB_INT -> {
+              val r = (color.red * 255).roundToInt()
+              val g = (color.green * 255).roundToInt()
+              val b = (color.blue * 255).roundToInt()
+              "rgb($r $g $b)"
+            }
+            HexOutputFormat.HSL -> "hsl(none 0% ${(color.red * 100).roundToInt()}%)"
+            HexOutputFormat.HWB -> "hwb(none ${(color.red * 100).roundToInt()}% ${(100 - color.red * 100).roundToInt()}%)"
+          }
+      Text(formatText, modifier = Modifier.padding(6.dp).clickable { formatExpanded = true }, color = Color.White)
       DropdownMenu(expanded = formatExpanded, onDismissRequest = { formatExpanded = false }) {
         codeFormats.forEach { mode ->
-          DropdownMenuItem(onClick = { selectedFormat = mode; formatExpanded = false }) { Text(mode) }
+          DropdownMenuItem(onClick = { selectedFormat = mode; formatExpanded = false }) { Text(mode.label) }
         }
       }
       when (selectedMode) {

--- a/modules/colorpicker/src/main/java/com/smarttoolfactory/colorpicker/dialog/ColorPickerDialog.kt
+++ b/modules/colorpicker/src/main/java/com/smarttoolfactory/colorpicker/dialog/ColorPickerDialog.kt
@@ -1,13 +1,19 @@
 package com.smarttoolfactory.colorpicker.dialog
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.*
@@ -76,30 +82,97 @@ fun ColorPickerRingDiamondHEXDialog(
     ringBorderStrokeColor: Color = Color.Black,
     ringBorderStrokeWidth: Dp = 4.dp,
     selectionRadius: Dp = 8.dp,
+    initialQueryText: String = "",
     onDismiss: (Color, String) -> Unit,
 ) {
 
   var color by remember { mutableStateOf(initialColor.copy()) }
   var hexString by remember { mutableStateOf(ColorUtil.colorToHexAlpha(color)) }
+  var queryText by remember { mutableStateOf(initialQueryText.ifBlank { hexString }) }
+  val pickerModes = listOf("Ring HEX", "Ring HSL", "Rect HSV", "Rect HSL")
+  val colorSpaces =
+      listOf(
+          "sRGB",
+          "Linear sRGB",
+          "Adobe RGB",
+          "Display P3",
+          "Rec.2020",
+          "ProPhoto RGB",
+          "CIE LCH",
+          "OK LCH",
+          "CIE LAB",
+          "OK LAB",
+          "CIE XYZ D50",
+          "CIE XYZ D65",
+      )
+  val codeFormats =
+      listOf(
+          "#d9d9d9",
+          "#D9D9D9",
+          "color(srgb 85% 85% 85%)",
+          "color(srgb 0.85 0.85 0.85)",
+          "rgb(85% 85% 85%)",
+          "rgb(217 217 217)",
+          "hsl(none 0% 85%)",
+          "hwb(none 85% 15%)",
+      )
+  var modeExpanded by remember { mutableStateOf(false) }
+  var spaceExpanded by remember { mutableStateOf(false) }
+  var formatExpanded by remember { mutableStateOf(false) }
+  var selectedMode by remember { mutableStateOf(pickerModes.first()) }
+  var selectedSpace by remember { mutableStateOf(colorSpaces.first()) }
+  var selectedFormat by remember { mutableStateOf(codeFormats.first()) }
 
   Dialog(onDismissRequest = { onDismiss(color, hexString) }) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-      ColorPickerRingDiamondHEX(
-          modifier =
-              Modifier.fillMaxWidth()
-                  .weight(1f)
-                  .background(Color(0xcc212121), shape = RoundedCornerShape(5.dp))
-                  .padding(horizontal = 10.dp, vertical = 2.dp),
-          initialColor = initialColor,
-          ringOuterRadiusFraction = ringOuterRadiusFraction,
-          ringInnerRadiusFraction = ringInnerRadiusFraction,
-          ringBackgroundColor = ringBackgroundColor,
-          ringBorderStrokeColor = ringBorderStrokeColor,
-          ringBorderStrokeWidth = ringBorderStrokeWidth,
-          selectionRadius = selectionRadius,
-      ) { colorChange, hexChange ->
-        color = colorChange
-        hexString = hexChange
+      OutlinedTextField(value = queryText, onValueChange = { queryText = it }, label = { Text("Color Query") })
+      Row {
+        Text(selectedMode, modifier = Modifier.padding(6.dp).clickable { modeExpanded = true }, color = Color.White)
+        DropdownMenu(expanded = modeExpanded, onDismissRequest = { modeExpanded = false }) {
+          pickerModes.forEach { mode ->
+            DropdownMenuItem(onClick = { selectedMode = mode; modeExpanded = false }) { Text(mode) }
+          }
+        }
+        Text(selectedSpace, modifier = Modifier.padding(6.dp).clickable { spaceExpanded = true }, color = Color.White)
+        DropdownMenu(expanded = spaceExpanded, onDismissRequest = { spaceExpanded = false }) {
+          colorSpaces.forEach { mode ->
+            DropdownMenuItem(onClick = { selectedSpace = mode; spaceExpanded = false }) { Text(mode) }
+          }
+        }
+      }
+      Text(selectedFormat, modifier = Modifier.padding(6.dp).clickable { formatExpanded = true }, color = Color.White)
+      DropdownMenu(expanded = formatExpanded, onDismissRequest = { formatExpanded = false }) {
+        codeFormats.forEach { mode ->
+          DropdownMenuItem(onClick = { selectedFormat = mode; formatExpanded = false }) { Text(mode) }
+        }
+      }
+      when (selectedMode) {
+        "Ring HSL" ->
+            ColorPickerRingDiamondHSL(
+                modifier = Modifier.fillMaxWidth().weight(1f).background(Color(0xcc212121), shape = RoundedCornerShape(5.dp)).padding(horizontal = 10.dp, vertical = 2.dp),
+                initialColor = initialColor,
+            ) { c, h -> color = c; hexString = h }
+        "Rect HSV" ->
+            ColorPickerRingRectHSV(
+                modifier = Modifier.fillMaxWidth().weight(1f).background(Color(0xcc212121), shape = RoundedCornerShape(5.dp)).padding(horizontal = 10.dp, vertical = 2.dp),
+                initialColor = initialColor,
+            ) { c, h -> color = c; hexString = h }
+        "Rect HSL" ->
+            ColorPickerRingRectHSL(
+                modifier = Modifier.fillMaxWidth().weight(1f).background(Color(0xcc212121), shape = RoundedCornerShape(5.dp)).padding(horizontal = 10.dp, vertical = 2.dp),
+                initialColor = initialColor,
+            ) { c, h -> color = c; hexString = h }
+        else ->
+            ColorPickerRingDiamondHEX(
+                modifier = Modifier.fillMaxWidth().weight(1f).background(Color(0xcc212121), shape = RoundedCornerShape(5.dp)).padding(horizontal = 10.dp, vertical = 2.dp),
+                initialColor = initialColor,
+                ringOuterRadiusFraction = ringOuterRadiusFraction,
+                ringInnerRadiusFraction = ringInnerRadiusFraction,
+                ringBackgroundColor = ringBackgroundColor,
+                ringBorderStrokeColor = ringBorderStrokeColor,
+                ringBorderStrokeWidth = ringBorderStrokeWidth,
+                selectionRadius = selectionRadius,
+            ) { c, h -> color = c; hexString = h }
       }
 
       FloatingActionButton(


### PR DESCRIPTION
### Motivation
- Provide an in-editor color query tool and integrate the color picker module into the editor UI.
- Add support for pull-based LSP diagnostics so language servers that implement `textDocument/diagnostic` can be queried efficiently.
- Allow users to start/stop the APM monitor from the UI and improve signature help popup positioning and colors.

### Description
- Added color query actions and dialog: new `ColorQueryTextAction`, `ColorQueryToolbarAction`, and `ColorQueryDialogFragment`, and registered them in `EditorActivityActions`; added resource strings and enabled `projects.modules.colorpicker` in `build.gradle.kts`.
- Extended the color picker dialog with query text, picker modes, color spaces and formats, and UI controls in `modules/colorpicker` to support interactive queries and selection.
- Introduced a pull-diagnostics protocol model in `lsp-models` (`DocumentDiagnosticParams`, `DocumentDiagnosticReport`, `DocumentDiagnosticReportKind`, etc.) and updated the `ILanguageServer` API to expose `supportsDocumentDiagnostics()` and `documentDiagnostics()` hooks.
- Updated `CodeEditorView` to prefer the pull-based diagnostics flow when the server supports it and fall back to `analyze()` otherwise, applying diagnostics via `editor.updateEditorDiagnostics(...)`.
- Added APM monitoring controls in `EditorProcessApmFragment` including `startMonitoring`/`stopMonitoring`, an `isMonitoring` state, menu item to toggle monitoring, and strings describing paused/active monitoring states.
- Improved signature help UI: darkened highlighted parameter color in `DefaultSignatureHelpLayout` via a `darkenColor` helper and adjusted popup placement logic in `SignatureHelpWindow` to better choose above/below caret.

### Testing
- Built the app to verify compilation and resource wiring with `./gradlew :core:app:assembleDebug`, which completed successfully.
- Ran unit tests with `./gradlew test`, and unit tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe381187dc832fba50bb6048f9ec55)