### PR TITLE
Fix clangd Kotlin build errors and API compatibility

### DIFF
--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdLanguageServer.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdLanguageServer.kt
@@ -27,6 +27,7 @@ import com.itsaky.androidide.models.Range
 import com.itsaky.androidide.projects.IWorkspace
 import java.io.File
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import org.json.JSONArray
 import org.json.JSONObject
@@ -214,7 +215,7 @@ class ClangdLanguageServer : ILanguageServer {
             val future = rpcMessenger!!.sendRequest("textDocument/completion", requestParams)
             var waitedMs = 0L
             while (!future.isDone && waitedMs < SYNC_TIMEOUT_MS) {
-                if (params.cancelChecker.isCancelled) {
+                if (params.cancelChecker.isCancelled()) {
                     future.cancel(true)
                     return CompletionResult.EMPTY
                 }
@@ -326,6 +327,10 @@ class ClangdLanguageServer : ILanguageServer {
         return advancedProvider!!.codeActions(file.toUri().toString(), range, diagnostics)
     }
 
+    override suspend fun expandSelection(params: ExpandSelectionParams): Range {
+        return params.selection
+    }
+
     override suspend fun analyze(file: Path): DiagnosticResult {
         return DiagnosticResult.NO_UPDATE
     }
@@ -390,9 +395,11 @@ class ClangdLanguageServer : ILanguageServer {
         val endObj = obj.optJSONObject("range")?.optJSONObject("end") ?: return null
         
         return Location(
-            File(filePath),
-            startObj.optInt("line", 0), startObj.optInt("character", 0),
-            endObj.optInt("line", 0), endObj.optInt("character", 0)
+            Paths.get(filePath),
+            Range(
+                Position(startObj.optInt("line", 0), startObj.optInt("character", 0)),
+                Position(endObj.optInt("line", 0), endObj.optInt("character", 0))
+            )
         )
     }
 

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdPreferences.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdPreferences.kt
@@ -18,7 +18,10 @@
 package android.zero.studio.lsp.clangd
 
 import android.content.Context
+import android.os.Parcel
+import android.os.Parcelable
 import androidx.preference.Preference
+import com.itsaky.androidide.lsp.clangd.R
 import com.itsaky.androidide.app.BaseApplication
 import com.itsaky.androidide.preferences.IPreference
 import com.itsaky.androidide.preferences.IPreferenceScreen
@@ -35,8 +38,7 @@ object ClangdPreferences : IPreferenceScreen() {
 
     override val key: String = "screen_clangd_preferences"
     
-    // AndroidIDE 默认取 string resource ID，为了灵活这里用 0，在 onCreateView 重写 title
-    override val title: Int = 0 
+    override val title: Int = R.string.clangd_preferences_title
 
     override val children: List<IPreference> = listOf(
         NdkVersionSelectorPreference
@@ -44,10 +46,22 @@ object ClangdPreferences : IPreferenceScreen() {
 
     override fun onCreateView(context: Context): Preference {
         val pref = super.onCreateView(context)
-        pref.title = "Clangd (C/C++) LSP Settings"
+        pref.title = context.getString(title)
         pref.summary = "Configure NDK toolchain and Clangd behavior"
         return pref
     }
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {}
+
+    @JvmField
+    val CREATOR =
+        object : Parcelable.Creator<ClangdPreferences> {
+            override fun createFromParcel(source: Parcel?): ClangdPreferences = ClangdPreferences
+
+            override fun newArray(size: Int): Array<ClangdPreferences> = Array(size) { ClangdPreferences }
+        }
 }
 
 /**
@@ -57,11 +71,11 @@ object ClangdPreferences : IPreferenceScreen() {
 object NdkVersionSelectorPreference : SingleChoicePreference() {
     
     override val key: String = ClangdServerSettings.KEY_TARGET_NDK_VERSION
-    override val title: Int = 0 
+    override val title: Int = R.string.clangd_ndk_version_title
 
     override fun onCreateView(context: Context): Preference {
         val pref = super.onCreateView(context)
-        pref.title = "NDK Toolchain Version"
+        pref.title = context.getString(title)
         
         val currentVersion = BaseApplication.getBaseInstance().prefManager.getString(key, "")
         pref.summary = if (currentVersion.isNullOrBlank()) {
@@ -101,4 +115,16 @@ object NdkVersionSelectorPreference : SingleChoicePreference() {
             "Selected: $selectedVersion"
         }
     }
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {}
+
+    @JvmField
+    val CREATOR =
+        object : Parcelable.Creator<NdkVersionSelectorPreference> {
+            override fun createFromParcel(source: Parcel?): NdkVersionSelectorPreference = NdkVersionSelectorPreference
+
+            override fun newArray(size: Int): Array<NdkVersionSelectorPreference> = Array(size) { NdkVersionSelectorPreference }
+        }
 }

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdProcessConnection.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdProcessConnection.kt
@@ -115,11 +115,10 @@ class ClangdProcessConnection(
 
     private fun getPidFallback(p: Process?): String {
         return try {
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                p?.pid()?.toString() ?: "Unknown"
-            } else {
-                "Fallback-Legacy"
+            val pidMethod = p?.javaClass?.methods?.firstOrNull { method ->
+                method.name == "pid" && method.parameterTypes.isEmpty()
             }
+            pidMethod?.invoke(p)?.toString() ?: "Unknown"
         } catch (e: Exception) {
             "Unknown"
         }

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/CompileCommandsLocator.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/CompileCommandsLocator.kt
@@ -77,9 +77,10 @@ object CompileCommandsLocator {
         if (cxxFiles.isNotEmpty()) {
             try {
                 val toolchain = ClangdSysrootResolver.resolve(projectDir)
-                val generated = CompileCommandsGenerator.generateCompileCommands(
-                    projectRoot = projectDir,
+                val generated = CompileCommandsGenerator.generate(
+                    projectPath = projectDir.absolutePath,
                     sourceFiles = cxxFiles,
+                    toolchainInfo = toolchain,
                     includeDirs = listOf(File(toolchain.sysrootDir, "usr/include"))
                 )
                 if (generated.exists()) {

--- a/lsp/clangd/src/main/res/values/strings.xml
+++ b/lsp/clangd/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="clangd_preferences_title">Clangd (C/C++) LSP Settings</string>
+    <string name="clangd_ndk_version_title">NDK Toolchain Version</string>
+</resources>


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by API/signature mismatches and model changes in the clangd LSP module.
- Make preference objects Parcelable and use proper string resources to avoid runtime/resource issues in preference UI.
- Improve platform compatibility for process PID access and fix incorrect compile-commands generator usage.

### Description
- Implemented missing `expandSelection` to satisfy `ILanguageServer` contract and updated completion cancellation to call `ICancelChecker.isCancelled()` (fixed function invocation). (`ClangdLanguageServer.kt`)
- Adjusted location parsing to construct `Location(Path, Range)` using `Paths.get(...)` and `Range(Position, Position)` to match current models. (`ClangdLanguageServer.kt`)
- Added `Parcelable` implementations and moved preference titles to Android string resources, importing module `R` and adding `strings.xml` entries; updated `ClangdPreferences` and `NdkVersionSelectorPreference` to use `context.getString(title)`. (`ClangdPreferences.kt`, `lsp/clangd/src/main/res/values/strings.xml`)
- Replaced direct `Process.pid()` usage with a reflective lookup/invocation to be safe across Android/Java runtimes. (`ClangdProcessConnection.kt`)
- Fixed incorrect call to a non-existent `generateCompileCommands` by invoking the existing `CompileCommandsGenerator.generate(...)` API and passing `toolchainInfo`. (`CompileCommandsLocator.kt`)

### Testing
- Ran `git diff --check` to validate workspace diffs; check passed.
- Attempted to compile the clangd Kotlin module with `./gradlew :lsp:clangd:compileDebugKotlin`; build failed due to environment/resolution issues (JDK 25 initially caused tooling error, then switching to Java 17 resulted in dependency resolution failures for `com.mooltiverse.oss.nyx:gradle:2.5.2`). These failures are environmental (Maven central 403 and missing offline cache) and not caused by the code changes.
- Attempted offline build with `./gradlew ... --offline` which failed because the required plugin artifact was not present in the local cache.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff7ab57808323a051afea0646e88a)