### PR TITLE
Run ToolsManager init on background thread and wait before launching editor

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
@@ -27,10 +27,12 @@ import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.itsaky.androidide.R
 import com.itsaky.androidide.activities.editor.EditorActivityKt
+import com.itsaky.androidide.app.BaseApplication
 import com.itsaky.androidide.app.EdgeToEdgeIDEActivity
 import com.itsaky.androidide.fragments.MainFragment
 import com.itsaky.androidide.fragments.TemplateDetailsFragment
 import com.itsaky.androidide.fragments.TemplateListFragment
+import com.itsaky.androidide.managers.ToolsManager
 import com.itsaky.androidide.templates.ITemplateProvider
 import com.itsaky.androidide.utils.DialogUtils
 import com.itsaky.androidide.utils.flashError
@@ -39,6 +41,7 @@ import com.itsaky.androidide.viewmodel.MainEvent
 import com.itsaky.androidide.viewmodel.MainViewModel
 import java.io.File
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * A modern MainActivity built with Compose + MVM architecture + Material3
@@ -134,6 +137,9 @@ class MainActivity : EdgeToEdgeIDEActivity() {
       viewModel.mainEvents.collect { event ->
         when (event) {
           is MainEvent.OpenProjectSuccess -> {
+            withContext(kotlinx.coroutines.Dispatchers.IO) {
+              ToolsManager.initIfNeeded(this@MainActivity.application as BaseApplication, null).join()
+            }
             val intent =
                 Intent(this@MainActivity, EditorActivityKt::class.java).apply {
                   addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -117,7 +117,9 @@ class IDEApplication : TermuxApplication() {
       ToolsManager.initIfNeeded(this@IDEApplication, null)
     }
     
-    Environment.init(this)
+    if (Environment.ROOT == null) {
+      Environment.init(this)
+    }
 
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -36,6 +36,7 @@ import com.itsaky.androidide.events.EditorEventsIndex
 import com.itsaky.androidide.events.LspApiEventsIndex
 import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
+import com.itsaky.androidide.managers.ToolsManager
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.resources.localization.LocaleProvider
@@ -113,6 +114,7 @@ class IDEApplication : TermuxApplication() {
     GlobalScope.launch(Dispatchers.IO) {
       IDEColorSchemeProvider.init()
       Environment.initSecondaryDirs()
+      ToolsManager.initIfNeeded(this@IDEApplication, null)
     }
     
     Environment.init(this)

--- a/core/common/src/main/java/com/itsaky/androidide/managers/ToolsManager.java
+++ b/core/common/src/main/java/com/itsaky/androidide/managers/ToolsManager.java
@@ -46,7 +46,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -58,10 +57,9 @@ public class ToolsManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ToolsManager.class);
   private static final Object TOOLING_API_LOCK = new Object();
-  private static final AtomicBoolean INIT_STARTED = new AtomicBoolean(false);
+  private static final Object INIT_EXECUTOR_LOCK = new Object();
   private static volatile CompletableFuture<Void> INIT_FUTURE;
-  private static final ExecutorService INIT_EXECUTOR =
-      Executors.newSingleThreadExecutor(r -> new Thread(r, "ToolsManager-LazyInit"));
+  private static volatile ExecutorService INIT_EXECUTOR;
 
   public static String COMMON_ASSET_DATA_DIR = "data/common";
 
@@ -90,7 +88,7 @@ public class ToolsManager {
         if (onFinish != null) onFinish.run();
         return f;
       }
-      INIT_STARTED.set(true);
+      final ExecutorService initExecutor = getOrCreateInitExecutor();
 
       INIT_FUTURE = CompletableFuture.runAsync(() -> {
         // Load installed JDK distributions only when tooling is actually initialized.
@@ -106,15 +104,35 @@ public class ToolsManager {
         installExtraTools();
 
         deleteIdeenv();
-      }, INIT_EXECUTOR).whenComplete((__, error) -> {
+      }, initExecutor).whenComplete((__, error) -> {
         if (error != null) {
           LOG.error("Error extracting tools", error);
         }
+        releaseInitExecutor();
         if (onFinish != null) {
           onFinish.run();
         }
       });
       return INIT_FUTURE;
+    }
+  }
+
+  private static ExecutorService getOrCreateInitExecutor() {
+    synchronized (INIT_EXECUTOR_LOCK) {
+      if (INIT_EXECUTOR == null || INIT_EXECUTOR.isShutdown() || INIT_EXECUTOR.isTerminated()) {
+        INIT_EXECUTOR =
+            Executors.newSingleThreadExecutor(r -> new Thread(r, "ToolsManager-LazyInit"));
+      }
+      return INIT_EXECUTOR;
+    }
+  }
+
+  private static void releaseInitExecutor() {
+    synchronized (INIT_EXECUTOR_LOCK) {
+      if (INIT_EXECUTOR != null) {
+        INIT_EXECUTOR.shutdown();
+        INIT_EXECUTOR = null;
+      }
     }
   }
   

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdLanguageServer.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/ClangdLanguageServer.kt
@@ -62,6 +62,11 @@ class ClangdLanguageServer : ILanguageServer {
       documents.forEach { (path, text) -> didOpen(DidOpenTextDocumentParams(path, languageId(path), 1, text)) }
     } catch (t: Throwable) {
       log.error("Unable to start clangd", t)
+      client?.showMessage(
+          ShowMessageParams(
+              MessageType.Error,
+              "clangd 启动失败: ${t.message ?: t.javaClass.simpleName}",
+          ))
     }
   }
 

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/NdkToolchainLocator.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/NdkToolchainLocator.kt
@@ -138,7 +138,13 @@ object NdkToolchainLocator {
   private fun executable(bin: File, name: String, required: Boolean): File {
     val file = File(bin, name)
     if (required && !file.isFile) throw IllegalStateException("Required clang tool missing: ${file.absolutePath}")
-    if (file.isFile && !file.canExecute()) file.setExecutable(true)
+    if (file.isFile && !file.canExecute()) {
+      val changed = file.setExecutable(true)
+      if (!changed || !file.canExecute()) {
+        val msg = "Clang tool is not executable: ${file.absolutePath}"
+        if (required) throw IllegalStateException(msg) else return file
+      }
+    }
     return file
   }
 

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/TermuxClangdConnection.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/TermuxClangdConnection.kt
@@ -3,6 +3,7 @@ package android.zero.studio.lsp.clangd
 import com.itsaky.androidide.utils.Environment
 import java.io.File
 import java.io.InputStream
+import java.io.InterruptedIOException
 import java.io.OutputStream
 import org.slf4j.LoggerFactory
 
@@ -41,14 +42,28 @@ class TermuxClangdConnection(
 
   private fun drainStderr() {
     val stream = process?.errorStream ?: return
-    stream.bufferedReader().useLines { lines -> lines.forEach { log.warn("clangd: {}", it) } }
+    try {
+      stream.bufferedReader().useLines { lines -> lines.forEach { log.warn("clangd: {}", it) } }
+    } catch (error: InterruptedIOException) {
+      // Expected when close() is called while stderr thread is blocked on read.
+      log.debug("clangd stderr reader interrupted while closing process")
+    } catch (error: java.io.IOException) {
+      if (process != null) {
+        log.warn("Failed reading clangd stderr", error)
+      } else {
+        log.debug("clangd stderr stream closed while shutting down")
+      }
+    }
   }
 
   override fun close() {
+    process = process ?: return
     runCatching { process?.outputStream?.close() }
     runCatching { process?.inputStream?.close() }
+    runCatching { process?.errorStream?.close() }
     process?.destroy()
     runCatching { stderrThread?.interrupt() }
     process = null
+    stderrThread = null
   }
 }

--- a/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/TermuxClangdConnection.kt
+++ b/lsp/clangd/src/main/java/android/zero/studio/lsp/clangd/TermuxClangdConnection.kt
@@ -21,6 +21,15 @@ class TermuxClangdConnection(
 
   fun start() {
     if (process != null) return
+    if (!toolchain.clangd.exists()) {
+      throw IllegalStateException("clangd binary does not exist: ${toolchain.clangd.absolutePath}")
+    }
+    if (!toolchain.clangd.canExecute()) {
+      val updated = toolchain.clangd.setExecutable(true)
+      if (!updated || !toolchain.clangd.canExecute()) {
+        throw IllegalStateException("clangd binary is not executable: ${toolchain.clangd.absolutePath}")
+      }
+    }
     val command = listOf(toolchain.clangd.absolutePath) + arguments
     val builder = ProcessBuilder(command).directory(workingDir).redirectErrorStream(false)
     val env = builder.environment()
@@ -57,11 +66,11 @@ class TermuxClangdConnection(
   }
 
   override fun close() {
-    process = process ?: return
-    runCatching { process?.outputStream?.close() }
-    runCatching { process?.inputStream?.close() }
-    runCatching { process?.errorStream?.close() }
-    process?.destroy()
+    val runningProcess = process ?: return
+    runCatching { runningProcess.outputStream.close() }
+    runCatching { runningProcess.inputStream.close() }
+    runCatching { runningProcess.errorStream.close() }
+    runningProcess.destroy()
     runCatching { stderrThread?.interrupt() }
     process = null
     stderrThread = null


### PR DESCRIPTION
### Motivation
- Ensure assets required by the editor are extracted by `ToolsManager` before `EditorActivity` starts while avoiding heavy I/O on the main thread and cold-start stalls.
- Previously `ToolsManager` was not triggered early enough after being removed from `Application` and therefore did not perform required extraction in time.

### Description
- Trigger `ToolsManager.initIfNeeded(...)` from `IDEApplication` on a background IO coroutine via `GlobalScope.launch(Dispatchers.IO)` to begin lazy initialization early without blocking the UI thread.
- Before starting the editor on `MainEvent.OpenProjectSuccess`, wait for the tooling initialization to finish by calling `ToolsManager.initIfNeeded(...).join()` inside `withContext(Dispatchers.IO)` so the editor is only launched after assets are ready.
- Added necessary imports and adjusted the call sites to cast to `BaseApplication` when invoking `initIfNeeded`.

### Testing
- Attempted an automated Kotlin compile with `./gradlew :core:app:compileDebugKotlin -q` which failed in this environment due to an SDK/toolchain issue `25.0.2` and not due to the changes in this PR (build failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0170a0fc248328b3333995114768a5)