### PR TITLE
File tree: add auto-expand, persistent expanded state, and refined node actions

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitProjectsFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitProjectsFragment.kt
@@ -25,6 +25,7 @@ import com.itsaky.androidide.fragments.git.menu.GitBranchPopupManager
 import com.itsaky.androidide.fragments.git.tree.ListProjectFilesRequestEvent
 import com.itsaky.androidide.fragments.git.tree.TreeStateManager
 import com.itsaky.androidide.projects.IProjectManager
+import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.provider.IDEFileIconProvider
 import com.itsaky.androidide.viewmodel.FileTreeViewModel
 import java.io.File
@@ -74,7 +75,9 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
     super.onStop()
     if (EventBus.getDefault().isRegistered(this)) EventBus.getDefault().unregister(this)
     // 自动保存状态
-    fileTreeView?.let { viewModel.saveState(it) }
+    if (GeneralPreferences.treeRememberExpandedState) {
+      fileTreeView?.let { viewModel.saveState(it) }
+    }
   }
 
   override fun setupToolbar() {
@@ -93,7 +96,11 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
 
     // 刷新
     addToolbarAction(R.drawable.ic_refresh_file_24dp, getString(R.string.refresh)) {
-      fileTreeView?.reloadFileTreeSilently()
+      if (GeneralPreferences.treeRememberExpandedState) {
+        fileTreeView?.reloadFileTreeSilently()
+      } else {
+        listProjectFiles()
+      }
       Toast.makeText(context, "Refreshed silently", Toast.LENGTH_SHORT).show()
     }
 
@@ -112,7 +119,6 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
     val btnCollapse =
         addToolbarAction(R.drawable.ic_chevron_right, "Collapse All") {
           fileTreeView?.let {
-            stateManager.pushState(it)
             it.collapseAll()
           }
         }
@@ -128,7 +134,6 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
 
     addToolbarAction(R.drawable.ic_chevron_down, "Expand All") {
       fileTreeView?.let {
-        stateManager.pushState(it)
         it.expandAll()
       }
     }
@@ -279,6 +284,7 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
           setIconProvider(IDEFileIconProvider(ctx))
           setOnFileClickListener(this@GitProjectsFragment)
           setOnFileLongClickListener(this@GitProjectsFragment)
+          setAutoExpandSingleChildFolders(GeneralPreferences.treeAutoExpandSingleChild)
           loadFiles(file(projectRoot), true)
         }
 
@@ -293,7 +299,9 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
       )
 
       // 恢复状态
-      tree.post { tree.restoreState(viewModel.savedState) }
+      if (GeneralPreferences.treeRememberExpandedState) {
+        tree.post { tree.restoreState(viewModel.savedState) }
+      }
     }
   }
 
@@ -303,7 +311,9 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
   }
 
   override fun onClick(node: Node<FileObject>) {
-    fileTreeView?.let { stateManager.pushState(it) } // 记录点击前的状态
+    if (node.value.isDirectory()) {
+      stateManager.recordAction(node.value.getAbsolutePath(), node.isExpand)
+    }
 
     val target = IDEFileIconProvider.extractNativeFile(node.value) ?: return
     if (target.isFile) {
@@ -323,7 +333,11 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
 
   @Subscribe(threadMode = ThreadMode.MAIN)
   fun onListProjectFilesRequest(event: ListProjectFilesRequestEvent?) {
-    fileTreeView?.reloadFileTreeSilently()
+    if (GeneralPreferences.treeRememberExpandedState) {
+      fileTreeView?.reloadFileTreeSilently()
+    } else {
+      listProjectFiles()
+    }
   }
 
   override fun onDestroyView() {

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/tree/TreeStateManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/tree/TreeStateManager.kt
@@ -9,37 +9,39 @@ import java.util.Stack
  * @author android_zero
  */
 class TreeStateManager {
-  private val undoStack = Stack<String>()
-  private val redoStack = Stack<String>()
+  data class NodeAction(val path: String, val expandedAfterAction: Boolean)
+
+  private val undoStack = Stack<NodeAction>()
+  private val redoStack = Stack<NodeAction>()
   private val MAX_HISTORY_SIZE = 50
 
-  /** 记录当前状态（在发生展开/折叠动作前调用） */
-  fun pushState(treeView: FileTree) {
-    val state = treeView.getSaveState()
-    if (undoStack.isNotEmpty() && undoStack.peek() == state) return
-
-    undoStack.push(state)
+  fun recordAction(path: String, expandedAfterAction: Boolean) {
+    val action = NodeAction(path = path, expandedAfterAction = expandedAfterAction)
+    if (undoStack.isNotEmpty() && undoStack.peek() == action) return
+    undoStack.push(action)
     if (undoStack.size > MAX_HISTORY_SIZE) undoStack.removeAt(0)
     redoStack.clear()
   }
 
   fun undo(treeView: FileTree) {
     if (undoStack.isEmpty()) return
-    val currentState = treeView.getSaveState()
-    redoStack.push(currentState)
-
-    val previousState = undoStack.pop()
-    treeView.collapseAll()
-    treeView.restoreState(previousState)
+    val action = undoStack.pop()
+    if (action.expandedAfterAction) {
+      treeView.collapseByPath(action.path)
+    } else {
+      treeView.expandByPath(action.path)
+    }
+    redoStack.push(action)
   }
 
   fun redo(treeView: FileTree) {
     if (redoStack.isEmpty()) return
-    val currentState = treeView.getSaveState()
-    undoStack.push(currentState)
-
-    val nextState = redoStack.pop()
-    treeView.collapseAll()
-    treeView.restoreState(nextState)
+    val action = redoStack.pop()
+    if (action.expandedAfterAction) {
+      treeView.expandByPath(action.path)
+    } else {
+      treeView.collapseByPath(action.path)
+    }
+    undoStack.push(action)
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/sidebar/DataFileTreeFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/sidebar/DataFileTreeFragment.kt
@@ -24,6 +24,7 @@ import com.itsaky.androidide.eventbus.events.filetree.FileClickEvent
 import com.itsaky.androidide.eventbus.events.filetree.FileLongClickEvent
 import com.itsaky.androidide.events.ExpandTreeNodeRequestEvent
 import com.itsaky.androidide.events.ListProjectFilesRequestEvent
+import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.utils.doOnApplyWindowInsets
 import com.itsaky.androidide.viewmodel.DataFileTreeViewModel
 import java.io.File
@@ -140,6 +141,7 @@ class DataFileTreeFragment : BottomSheetDialogFragment(), FileClickListener, Fil
           setIconProvider(IDEFileIconProvider(requireContext()))
           setOnFileClickListener(this@DataFileTreeFragment)
           setOnFileLongClickListener(this@DataFileTreeFragment)
+          setAutoExpandSingleChildFolders(GeneralPreferences.treeAutoExpandSingleChild)
           loadFiles(virtualRoot, false) // false 意味着隐藏顶级 "Root" 虚拟节点，直接展示盘符
           fileTreeView = this
         }
@@ -154,7 +156,9 @@ class DataFileTreeFragment : BottomSheetDialogFragment(), FileClickListener, Fil
             ),
         )
 
-    tree.post { tree.restoreState(viewModel.savedState) }
+    if (GeneralPreferences.treeRememberExpandedState) {
+      tree.post { tree.restoreState(viewModel.savedState) }
+    }
   }
 
   // 虚拟根目录包装类 (用于容纳多个磁盘入口)
@@ -190,7 +194,9 @@ class DataFileTreeFragment : BottomSheetDialogFragment(), FileClickListener, Fil
   }
 
   fun saveTreeState() {
-    viewModel.saveState(fileTreeView)
+    if (GeneralPreferences.treeRememberExpandedState) {
+      viewModel.saveState(fileTreeView)
+    }
   }
 
   override fun onClick(node: Node<FileObject>) {

--- a/core/app/src/main/java/com/itsaky/androidide/preferences/generalPrefExts.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/preferences/generalPrefExts.kt
@@ -71,6 +71,8 @@ class ProjectConfig(
   init {
     addPreference(OpenLastProject())
     addPreference(ConfirmProjectOpen())
+    addPreference(TreeAutoExpandSingleChildPreference())
+    addPreference(TreeRememberExpandedStatePreference())
   }
 }
 
@@ -249,6 +251,43 @@ class UseSytemShell(
 
   override fun onPreferenceChanged(preference: Preference, newValue: Any?): Boolean {
     GeneralPreferences.useSystemShell = newValue as Boolean? ?: GeneralPreferences.useSystemShell
+    return true
+  }
+}
+
+@Parcelize
+class TreeAutoExpandSingleChildPreference(
+    override val key: String = GeneralPreferences.TREE_AUTO_EXPAND_SINGLE_CHILD,
+    override val title: Int = R.string.idepref_tree_auto_expand_single_child_title,
+    override val summary: Int? = R.string.idepref_tree_auto_expand_single_child_summary,
+    override val icon: Int? = drawable.ic_chevron_down,
+) :
+    SwitchPreference(
+        setValue = { GeneralPreferences.treeAutoExpandSingleChild = it },
+        getValue = { GeneralPreferences.treeAutoExpandSingleChild },
+    ) {
+
+  override fun onPreferenceChanged(preference: Preference, newValue: Any?): Boolean {
+    GeneralPreferences.treeAutoExpandSingleChild =
+        newValue as? Boolean ?: GeneralPreferences.treeAutoExpandSingleChild
+    return true
+  }
+}
+
+@Parcelize
+class TreeRememberExpandedStatePreference(
+    override val key: String = GeneralPreferences.TREE_REMEMBER_EXPANDED_STATE,
+    override val title: Int = R.string.idepref_tree_remember_state_title,
+    override val summary: Int? = R.string.idepref_tree_remember_state_summary,
+    override val icon: Int? = drawable.ic_history,
+) :
+    SwitchPreference(
+        setValue = { GeneralPreferences.treeRememberExpandedState = it },
+        getValue = { GeneralPreferences.treeRememberExpandedState },
+    ) {
+  override fun onPreferenceChanged(preference: Preference, newValue: Any?): Boolean {
+    GeneralPreferences.treeRememberExpandedState =
+        newValue as? Boolean ?: GeneralPreferences.treeRememberExpandedState
     return true
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/provider/IDEFileIconProvider.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/provider/IDEFileIconProvider.kt
@@ -7,6 +7,7 @@ import android.zero.studio.view.filetree.interfaces.FileObject
 import android.zero.studio.view.filetree.model.Node
 import android.zero.studio.view.filetree.provider.file
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import com.itsaky.androidide.R
 import com.itsaky.androidide.models.FileExtension
 import java.io.File
@@ -18,7 +19,15 @@ import java.io.File
  */
 class IDEFileIconProvider(private val context: Context) : FileIconProvider {
   private val chevronRight = ContextCompat.getDrawable(context, R.drawable.ic_chevron_right)
-  private val expandMore = ContextCompat.getDrawable(context, R.drawable.ic_chevron_down)
+  private val expandMore by lazy {
+    val raw = ContextCompat.getDrawable(context, R.drawable.ic_chevron_down)?.mutate()
+    val isNight = (context.resources.configuration.uiMode and 0x30) == 0x20
+    val tint = if (isNight) 0xFFFFFFFF.toInt() else 0xFF1F2937.toInt()
+    raw?.let {
+      DrawableCompat.setTint(it, tint)
+      it
+    }
+  }
 
   override fun getIcon(node: Node<FileObject>): Drawable? {
     val fileObj =
@@ -26,11 +35,7 @@ class IDEFileIconProvider(private val context: Context) : FileIconProvider {
             ?: return ContextCompat.getDrawable(context, R.drawable.ic_file_type_unknown)
 
     val iconRes =
-        when {
-          fileObj.isDirectory -> R.drawable.ic_folder
-          fileObj.name == "gradlew" || fileObj.name == "gradlew.bat" -> R.drawable.ic_terminal
-          else -> FileExtension.Factory.forFile(fileObj).icon
-        }
+        FileExtension.Factory.forFile(fileObj).icon
     return ContextCompat.getDrawable(context, iconRes)
   }
 

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -790,6 +790,10 @@
      <string name="idepref_kotlin_chained_hints">Chained hints</string>
      <string name="idepref_kotlin_diagnostics">Diagnostics</string>
      <string name="idepref_kotlin_remove_unused_imports">Remove unused imports</string>
+    <string name="idepref_tree_auto_expand_single_child_title">Auto expand single-child folders in tree</string>
+    <string name="idepref_tree_auto_expand_single_child_summary">Automatically expands folder chains until a branch with multiple items is reached.</string>
+    <string name="idepref_tree_remember_state_title">Remember tree expanded state</string>
+    <string name="idepref_tree_remember_state_summary">Keep expanded paths after refresh/reload; if disabled, tree resets to collapsed root state.</string>
     <string name="bottom_sheet_page_build">Build status</string>
     <string name="bottom_sheet_page_symbols">Symbol input</string>
     <string name="action_color_query">Color Query</string>

--- a/utilities/FileTree/src/main/java/android/zero/studio/view/filetree/adapters/FileTreeAdapter.kt
+++ b/utilities/FileTree/src/main/java/android/zero/studio/view/filetree/adapters/FileTreeAdapter.kt
@@ -39,6 +39,7 @@ import android.zero.studio.view.filetree.widget.FileTree
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
 
 class ViewHolder(v: View) : RecyclerView.ViewHolder(v) {
   val expandView: ImageView = v.findViewById(R.id.expand)
@@ -134,7 +135,8 @@ class FileTreeAdapter(private val context: Context, val fileTree: FileTree) :
     fileView.layoutParams = layoutParams
 
     // Set padding based on node level
-    holder.itemView.setPadding(node.level * dpToPx(17f), dpToPx(5f), 0, 0)
+    holder.itemView.minimumWidth = max(fileTree.width, fileTree.measuredWidth)
+    holder.itemView.setPadding(node.level * dpToPx(17f), dpToPx(5f), dpToPx(8f), dpToPx(5f))
     fileView.setImageDrawable(iconProvider?.getIcon(node))
 
     val icChevronRight = iconProvider?.getChevronRight()
@@ -152,7 +154,7 @@ class FileTreeAdapter(private val context: Context, val fileTree: FileTree) :
       expandView.visibility = View.GONE
     }
 
-    holder.textView.text = "  ${node.value.getName()}  "
+    holder.textView.text = node.value.getName()
 
     // 处理定位高亮效果 (闪烁动画)
     if (node.isHighlighted) {

--- a/utilities/FileTree/src/main/java/android/zero/studio/view/filetree/widget/FileTree.kt
+++ b/utilities/FileTree/src/main/java/android/zero/studio/view/filetree/widget/FileTree.kt
@@ -47,6 +47,7 @@ class FileTree : RecyclerView {
 
   private var isTreeInitialized = false
   private var isRootNodeVisible: Boolean = true
+  private var autoExpandSingleChildFolders: Boolean = false
 
   constructor(context: Context) : super(context)
 
@@ -63,6 +64,11 @@ class FileTree : RecyclerView {
     setItemViewCacheSize(100)
     layoutManager = LinearLayoutManager(context)
     fileTreeAdapter = FileTreeAdapter(context, this)
+    layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+  }
+
+  fun setAutoExpandSingleChildFolders(enabled: Boolean) {
+    autoExpandSingleChildFolders = enabled
   }
 
   /**
@@ -157,6 +163,9 @@ class FileTree : RecyclerView {
   fun expandNode(node: Node<FileObject>) {
     if (!node.isExpand) {
       fileTreeAdapter.expandNode(node)
+      if (autoExpandSingleChildFolders) {
+        autoExpandUntilBranch(node)
+      }
     }
   }
 
@@ -170,16 +179,36 @@ class FileTree : RecyclerView {
     }
   }
 
+  fun expandByPath(path: String): Boolean {
+    expandPathOnce(path)
+    val node = fileTreeAdapter.currentList.firstOrNull { it.value.getAbsolutePath() == path } ?: return false
+    if (!node.isExpand && node.value.isDirectory()) {
+      fileTreeAdapter.expandNode(node)
+    }
+    return true
+  }
+
+  fun collapseByPath(path: String): Boolean {
+    val node = fileTreeAdapter.currentList.firstOrNull { it.value.getAbsolutePath() == path } ?: return false
+    if (node.isExpand && node.value.isDirectory()) {
+      collapseNode(node)
+    }
+    return true
+  }
+
   fun collapseAll() {
-    fileTreeAdapter.currentList.filter { it.isExpand }.reversed().forEach { collapseNode(it) }
+    val expanded = fileTreeAdapter.currentList.filter { it.isExpand }.sortedByDescending { it.level }
+    expanded.forEach { collapseNode(it) }
   }
 
   fun expandAll() {
-    val list = fileTreeAdapter.currentList.toMutableList()
-    list.forEach {
-      if (it.value.isDirectory() && !it.isExpand) {
-        expandNode(it)
+    var cursor = 0
+    while (cursor < fileTreeAdapter.currentList.size) {
+      val node = fileTreeAdapter.currentList[cursor]
+      if (node.value.isDirectory() && !node.isExpand) {
+        fileTreeAdapter.expandNode(node)
       }
+      cursor++
     }
   }
 
@@ -208,26 +237,9 @@ class FileTree : RecyclerView {
   /** 精准定位文件位置。通过路径逐级比对并展开父目录，最后滚动到目标。 */
   fun locateFileAndScroll(targetAbsolutePath: String) {
     post {
-      var targetIndex = -1
-
-      var retry = true
-      while (retry) {
-        retry = false
-        val list = fileTreeAdapter.currentList.toList()
-        for ((index, node) in list.withIndex()) {
-          val path = node.value.getAbsolutePath()
-          if (path == targetAbsolutePath) {
-            targetIndex = index
-            break
-          }
-
-          if (targetAbsolutePath.startsWith(path + "/") && !node.isExpand) {
-            expandNode(node)
-            retry = true
-            break
-          }
-        }
-      }
+      expandPathOnce(targetAbsolutePath)
+      val targetIndex =
+          fileTreeAdapter.currentList.indexOfFirst { it.value.getAbsolutePath() == targetAbsolutePath }
 
       if (targetIndex != -1) {
         val lm = layoutManager as LinearLayoutManager
@@ -249,6 +261,58 @@ class FileTree : RecyclerView {
                 },
                 2500,
             )
+      }
+    }
+  }
+
+  private fun expandPathOnce(targetAbsolutePath: String) {
+    val pathParts = targetAbsolutePath.split("/").filter { it.isNotEmpty() }
+    if (pathParts.isEmpty()) return
+    var currentNode: Node<FileObject>? =
+        fileTreeAdapter.currentList.firstOrNull { it.value.getAbsolutePath() == rootFileObject.getAbsolutePath() }
+
+    if (currentNode == null && !isRootNodeVisible) {
+      currentNode =
+          fileTreeAdapter.currentList.firstOrNull {
+            targetAbsolutePath.startsWith(it.value.getAbsolutePath().trimEnd('/') + "/") ||
+                it.value.getAbsolutePath() == targetAbsolutePath
+          }
+    }
+
+    while (currentNode != null && currentNode.value.isDirectory()) {
+      if (!currentNode.isExpand) {
+        fileTreeAdapter.expandNode(currentNode)
+      }
+      val next =
+          currentNode.child.firstOrNull {
+            targetAbsolutePath.startsWith(it.value.getAbsolutePath().trimEnd('/') + "/") ||
+                it.value.getAbsolutePath() == targetAbsolutePath
+          }
+      currentNode = next
+    }
+  }
+
+  private fun autoExpandUntilBranch(startNode: Node<FileObject>) {
+    var current = startNode
+    while (current.value.isDirectory()) {
+      val children = Sorter.sort(current.value)
+      if (children.size != 1) {
+        break
+      }
+      val onlyChild = children.first()
+      if (!onlyChild.value.isDirectory()) {
+        break
+      }
+      if (current.child.any { it.value.getAbsolutePath() == onlyChild.value.getAbsolutePath() }) {
+        val next =
+            current.child.first { it.value.getAbsolutePath() == onlyChild.value.getAbsolutePath() }
+        if (!next.isExpand) {
+          fileTreeAdapter.expandNode(next)
+        }
+        current = next
+      } else {
+        fileTreeAdapter.expandNode(onlyChild)
+        current = onlyChild
       }
     }
   }

--- a/utilities/FileTree/src/main/res/layout/recycler_view_item.xml
+++ b/utilities/FileTree/src/main/res/layout/recycler_view_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/item_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="44dp"
@@ -24,8 +25,9 @@
 
     <TextView
         android:id="@+id/text_view"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
         android:textSize="16sp"
         android:maxLines="1"
         android:ellipsize="end"

--- a/utilities/preferences/src/main/java/com/itsaky/androidide/preferences/internal/GeneralPreferences.kt
+++ b/utilities/preferences/src/main/java/com/itsaky/androidide/preferences/internal/GeneralPreferences.kt
@@ -31,6 +31,8 @@ object GeneralPreferences {
   const val OPEN_PROJECTS = "idepref_general_autoOpenProjects"
   const val CONFIRM_PROJECT_OPEN = "idepref_general_confirmProjectOpen"
   const val TERMINAL_USE_SYSTEM_SHELL = "idepref_general_terminalShell"
+  const val TREE_AUTO_EXPAND_SINGLE_CHILD = "idepref_tree_auto_expand_single_child"
+  const val TREE_REMEMBER_EXPANDED_STATE = "idepref_tree_remember_expanded_state"
   const val LAST_OPENED_PROJECT = "ide_last_project"
 
   const val PREF_LOTTIE_ANIMATION = "idepref_splash_lottie_animation"
@@ -89,6 +91,18 @@ object GeneralPreferences {
     get() = prefManager.getBoolean(TERMINAL_USE_SYSTEM_SHELL, false)
     set(value) {
       prefManager.putBoolean(TERMINAL_USE_SYSTEM_SHELL, value)
+    }
+
+  var treeAutoExpandSingleChild: Boolean
+    get() = prefManager.getBoolean(TREE_AUTO_EXPAND_SINGLE_CHILD, true)
+    set(value) {
+      prefManager.putBoolean(TREE_AUTO_EXPAND_SINGLE_CHILD, value)
+    }
+
+  var treeRememberExpandedState: Boolean
+    get() = prefManager.getBoolean(TREE_REMEMBER_EXPANDED_STATE, true)
+    set(value) {
+      prefManager.putBoolean(TREE_REMEMBER_EXPANDED_STATE, value)
     }
 
   var lastOpenedProject: String


### PR DESCRIPTION
### Motivation
- Provide user controls for auto-expanding single-child folder chains and for remembering tree-expanded state across reloads to improve navigation UX.
- Replace coarse full-state snapshots for undo/redo with precise node-level actions for more predictable history behavior.
- Fix icon tinting and item layout issues so the file tree renders consistently across themes and sizes.

### Description
- Add two preferences and APIs: `TREE_AUTO_EXPAND_SINGLE_CHILD` and `TREE_REMEMBER_EXPANDED_STATE` in `GeneralPreferences`, and register corresponding switches in `generalPrefExts.kt` with new string resources.
- Honor `GeneralPreferences.treeRememberExpandedState` when saving/restoring and reloading trees in `GitProjectsFragment` and `DataFileTreeFragment`, and apply `GeneralPreferences.treeAutoExpandSingleChild` when building `FileTree` instances.
- Implement auto-expand behavior and path-based operations in `FileTree`: added `setAutoExpandSingleChildFolders`, `expandByPath`, `collapseByPath`, `locateFileAndScroll` optimizations, `expandPathOnce`, and `autoExpandUntilBranch`, plus improved `expandAll`/`collapseAll` logic.
- Replace previous state-stack approach in `TreeStateManager` with `NodeAction(path, expandedAfterAction)` recording and undo/redo by path, and adapt `GitProjectsFragment` to record node actions on interaction.
- UI and adapter fixes: tint `expandMore` drawable in `IDEFileIconProvider`, simplify icon selection, adjust `FileTreeAdapter` padding/width/text handling, and update `recycler_view_item.xml` layout.

### Testing
- Executed the project unit test suite via `./gradlew test` and the available automated integration checks, and they completed without failures.
- Ran the project's automated UI smoke tests where available and observed no regressions in file-tree interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020b179c508328ac40d41d644e835a)