### PR TITLE
Fix nullable child access in FileTree traversal

### DIFF
--- a/utilities/FileTree/src/main/java/android/zero/studio/view/filetree/widget/FileTree.kt
+++ b/utilities/FileTree/src/main/java/android/zero/studio/view/filetree/widget/FileTree.kt
@@ -284,7 +284,7 @@ class FileTree : RecyclerView {
         fileTreeAdapter.expandNode(currentNode)
       }
       val next =
-          currentNode.child.firstOrNull {
+          (currentNode.child ?: emptyList()).firstOrNull {
             targetAbsolutePath.startsWith(it.value.getAbsolutePath().trimEnd('/') + "/") ||
                 it.value.getAbsolutePath() == targetAbsolutePath
           }
@@ -303,9 +303,10 @@ class FileTree : RecyclerView {
       if (!onlyChild.value.isDirectory()) {
         break
       }
-      if (current.child.any { it.value.getAbsolutePath() == onlyChild.value.getAbsolutePath() }) {
+      val currentChildren = current.child ?: emptyList()
+      if (currentChildren.any { it.value.getAbsolutePath() == onlyChild.value.getAbsolutePath() }) {
         val next =
-            current.child.first { it.value.getAbsolutePath() == onlyChild.value.getAbsolutePath() }
+            currentChildren.first { it.value.getAbsolutePath() == onlyChild.value.getAbsolutePath() }
         if (!next.isExpand) {
           fileTreeAdapter.expandNode(next)
         }


### PR DESCRIPTION
### Motivation
- Fix Kotlin null-safety issues in the file-tree traversal logic that caused compile errors when accessing a nullable `child` list of type `List<Node<FileObject>>?` in `FileTree`.

### Description
- Update `utilities/FileTree/src/main/java/android/zero/studio/view/filetree/widget/FileTree.kt` to guard nullable `child` lists with `?: emptyList()` and introduce a `currentChildren` local to avoid unsafe `first`/`any` calls on a nullable receiver.

### Testing
- Attempted `./gradlew :utilities:FileTree:compileDebugKotlin`, but the build failed in this environment with a Gradle/SDK error `25.0.2` so compilation could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0228f57d8c8328abcb08fc3e5d8378)