### PR TITLE
Fix Gradle version catalog accessor clash for commons-text

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,7 +161,6 @@ junit-jupiter = "5.10.2"
 # Added from core/chatai version catalog
 coreKtx = "1.18.0"
 junitVersion = "1.3.0"
-commons-text = "1.15.0"
 material3 = "1.5.0-alpha19"
 nav3Material = "1.0.0-SNAPSHOT"
 markdown = "66a56dffca"
@@ -639,5 +638,4 @@ com-jaredsburrows-license = { id = "com.jaredsburrows.license", version = "0.8.4
 gradle-publish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
 realm-gradle-plugin = { id = "io.realm:realm-gradle-plugin", version.ref = "iorealm" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
-
 


### PR DESCRIPTION
### Motivation
- Resolve a Gradle version-catalog accessor name clash caused by duplicate version keys `commonsText` and `commons-text` that prevented dependency accessor generation.

### Description
- Removed the duplicate `commons-text` version entry from `gradle/libs.versions.toml` and kept the existing `commonsText` version alias referenced by the `commons-text` library mapping.

### Testing
- Ran `./gradlew help --warning-mode all` which advanced past the accessor generation error but the build now fails later due to an unrelated environment/toolchain issue (`25.0.2`); no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02364e79b48328ad80214e63d0e4f2)