### PR TITLE
Fix unresolved test dependency aliases in speech Gradle module

### DIFF
--- a/core/chatai/speech/build.gradle.kts
+++ b/core/chatai/speech/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":common"))
+    implementation(projects.core.common)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.okhttp)

--- a/core/chatai/speech/build.gradle.kts
+++ b/core/chatai/speech/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material3)
 
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
+    testImplementation(libs.tests.junit)
+    androidTestImplementation(libs.tests.androidx.junit)
+    androidTestImplementation(libs.tests.androidx.espresso.core)
 }

--- a/core/chatai/speech/build.gradle.kts
+++ b/core/chatai/speech/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation(libs.androidx.media3.common)
 
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.material3)
+    implementation(libs.androidx.compose.material3)
 
     testImplementation(libs.tests.junit)
     androidTestImplementation(libs.tests.androidx.junit)


### PR DESCRIPTION
### Motivation
- Resolve script compilation errors in `core/chatai/speech/build.gradle.kts` caused by incorrect version-catalog aliases for test libraries that produced "Unresolved reference" errors during Gradle build.

### Description
- Replace `libs.junit` with `libs.tests.junit`, `libs.androidx.junit` with `libs.tests.androidx.junit`, and `libs.androidx.espresso.core` with `libs.tests.androidx.espresso.core` in `core/chatai/speech/build.gradle.kts`.

### Testing
- Ran `./gradlew :core:chatai:speech:tasks --all` which confirmed the alias resolution errors are fixed but the Gradle run later aborted with an environment/tooling error reporting `25.0.2`, unrelated to these dependency alias fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0335ea81e08328a2577cdf2280cb47)