### PR TITLE
ci: install Bun in APK build workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install Bun
         run: |
           curl -fsSL https://bun.com/install | bash
+          export PATH="$HOME/.bun/bin:$PATH"
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
           bun --version
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -40,11 +40,14 @@ jobs:
         with:
           gradle-version: '8.13'
 
-      - name: Install Bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Verify Bun
         run: |
-          curl -fsSL https://bun.com/install | bash
-          export PATH="$HOME/.bun/bin:$PATH"
-          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+          which bun
           bun --version
 
       - name: Install the specified NDK and Android SDK CMake (3.22.1)

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           gradle-version: '8.13'
 
+      - name: Install Bun
+        run: |
+          curl -fsSL https://bun.com/install | bash
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+          bun --version
+
       - name: Install the specified NDK and Android SDK CMake (3.22.1)
         run: |
           yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -50,6 +50,11 @@ jobs:
           which bun
           bun --version
 
+      - name: Install web-ui dependencies with Bun
+        working-directory: core/chatai/web-ui
+        run: |
+          bun install --frozen-lockfile
+
       - name: Install the specified NDK and Android SDK CMake (3.22.1)
         run: |
           yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses

--- a/core/chatai/web/build.gradle.kts
+++ b/core/chatai/web/build.gradle.kts
@@ -5,12 +5,27 @@ plugins {
 val webUiDir = rootProject.layout.projectDirectory.dir("core/chatai/web-ui")
 val webStaticResourcesDir = layout.projectDirectory.dir("src/main/resources/static")
 
+val installWebUiDependencies = tasks.register<Exec>("installWebUiDependencies") {
+    group = "build"
+    description = "Install web-ui dependencies with Bun."
+
+    workingDir = webUiDir.asFile
+    commandLine("bun", "install", "--frozen-lockfile")
+
+    inputs.files(
+        webUiDir.file("package.json"),
+        webUiDir.file("bun.lock")
+    )
+    outputs.dir(webUiDir.dir("node_modules"))
+}
+
 val buildWebUi = tasks.register<Exec>("buildWebUi") {
     group = "build"
     description = "Build web-ui and copy its static output into the web module resources."
 
     workingDir = webUiDir.asFile
     commandLine("bun", "run", "build")
+    dependsOn(installWebUiDependencies)
 
     inputs.files(
         webUiDir.file("package.json"),


### PR DESCRIPTION
### Motivation
- The APK build can fail during `:core:chatai:web:buildWebUi` because `bun` is not available in the runner, so the workflow must install Bun before build steps run.

### Description
- Add an `Install Bun` step to `.github/workflows/build-apk.yml` that runs `curl -fsSL https://bun.com/install | bash`, appends `$HOME/.bun/bin` to `GITHUB_PATH`, and runs `bun --version` to verify installation.

### Testing
- Verified the change by running `git status --short`, committing the update with `git commit`, and inspecting the workflow with `nl -ba .github/workflows/build-apk.yml` to confirm the new step, and all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0393a6ddd08328ab4258b482634798)