### PR TITLE
Fix TerminalThemeManager prefs property scope

### DIFF
--- a/termux/application/src/main/java/android/zero/studio/terminal/TermuxFragment.java
+++ b/termux/application/src/main/java/android/zero/studio/terminal/TermuxFragment.java
@@ -1076,7 +1076,7 @@ public class TermuxFragment extends BaseIDEFragment implements ServiceConnection
 
         if (!hasSessions && mTermuxService != null && !mTermuxService.wantsToStop()) {
             Intent stopServiceIntent = new Intent(requireActivity(), TermuxService.class);
-            stopServiceIntent.setAction(com.termux.shared.termux.TermuxConstants.TERMUX_SERVICE.ACTION_STOP_SERVICE);
+            stopServiceIntent.setAction(com.termux.shared.termux.TermuxConstants.TERMUX_APP.TERMUX_SERVICE.ACTION_STOP_SERVICE);
             requireActivity().startService(stopServiceIntent);
         }
     }

--- a/termux/application/src/main/java/android/zero/studio/terminal/ui/theme/TerminalThemeManager.kt
+++ b/termux/application/src/main/java/android/zero/studio/terminal/ui/theme/TerminalThemeManager.kt
@@ -1107,7 +1107,8 @@ class TerminalThemeManager(private val context: Context) {
     }
     fragment.terminalView?.onScreenUpdated()
   }
-}
+
   private val prefs by lazy {
     context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
   }
+}


### PR DESCRIPTION
### Motivation
- Fix unresolved Kotlin compilation errors caused by the `prefs` property being declared outside the `TerminalThemeManager` class so `context`, `PREFS_NAME`, and SharedPreferences APIs were out of scope.

### Description
- Move the `prefs` lazy property into the `TerminalThemeManager` class body and initialize it with `context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)` so references resolve during compilation.

### Testing
- Ran `./gradlew :termux:application:compileDebugKotlin -q` and `./gradlew :termux:application:compileDebugKotlin --stacktrace`, but both runs failed before module compilation due to an environment/toolchain error (`IllegalArgumentException: 25.0.2`), so full verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b598bf0c8328a29ee8ccd67dec21)