### PR TITLE
Exclude incomplete Android Studio template ports from templates-impl build

### DIFF
--- a/utilities/templates-impl/build.gradle.kts
+++ b/utilities/templates-impl/build.gradle.kts
@@ -23,7 +23,22 @@ plugins {
   id("kotlin-kapt")
 }
 
-android { namespace = "${BuildConfig.packageName}.templates.impl" }
+
+android {
+  namespace = "${BuildConfig.packageName}.templates.impl"
+
+  sourceSets {
+    getByName("main") {
+      java {
+        // Temporary: exclude partially ported Android Studio templates that still depend
+        // on legacy utilities/wizard APIs not available in templates-api.
+        exclude("com/itsaky/androidide/templates/impl/androidstudio/**")
+        exclude("com/itsaky/androidide/templates/impl/lithoClassic/**")
+      }
+    }
+  }
+}
+
 
 dependencies {
   kapt(libs.google.auto.service)


### PR DESCRIPTION
### Motivation
- Prevent compilation failures caused by partially migrated Android Studio templates that still reference legacy `utilities/wizard` APIs by excluding those directories from the `templates-impl` module until the migration to `templates-api` is completed.

### Description
- Update `utilities/templates-impl/build.gradle.kts` to add an `android` block with `namespace = "${BuildConfig.packageName}.templates.impl"` and configure the `main` source set to `exclude("com/itsaky/androidide/templates/impl/androidstudio/**")` and `exclude("com/itsaky/androidide/templates/impl/lithoClassic/**")`, with a comment explaining the exclusions are temporary.

### Testing
- Ran `./gradlew :utilities:templates-impl:compileDebugKotlin`, which failed in this environment due to an external Android/SDK toolchain issue reported as `25.0.2` and not due to the source-set exclusion change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09baf1af288328abbd28237adc9d81)