### PR TITLE
docs: add gRPC + REAPI + AIDL architecture for replacing lsp4j build transport

### DIFF
--- a/docs/architecture/reapi-grpc-aidl-build-service-refactor.md
+++ b/docs/architecture/reapi-grpc-aidl-build-service-refactor.md
@@ -1,0 +1,283 @@
+# 使用 gRPC + Remote Execution API (REAPI) + AIDL 重构构建服务架构方案（替代 lsp4j）
+
+## 1. 目标与边界
+
+### 1.1 重构目标
+- 在 `./tooling/***`、`core/project`、`core/app` 中彻底移除当前基于 `lsp4j` 的构建服务协议与通信通道。
+- 建立统一的 **三层传输架构**：
+  1) 进程内/本机跨进程：AIDL（Android Binder）
+  2) 远程高性能 RPC：gRPC（HTTP/2 + Protobuf）
+  3) 远程执行与缓存协议：REAPI（CAS/AC/Execution）
+- 用“能力分层 + 协议分层”的方式，让 IDE UI、项目模型、构建执行彼此解耦。
+
+### 1.2 非目标（避免范围膨胀）
+- 不在第一阶段重写全部语言服务能力（仅聚焦构建、同步、任务执行、日志、状态流）。
+- 不在客户端一次性切换所有模块；采用可回滚灰度迁移。
+
+---
+
+## 2. 当前痛点（为何必须替换 lsp4j 路径）
+
+1. **协议语义错位**：LSP/lsp4j 本质是“编辑器语言服务协议”，用于构建服务时语义不自然，导致消息定义臃肿、扩展成本高。  
+2. **资源开销高**：JSON-RPC 序列化开销、对象分配与反序列化压力明显，移动端易出现内存抖动和 GC 频繁。  
+3. **链路不统一**：本地 IPC、远程执行、日志流、取消/超时语义分散，造成状态管理复杂。  
+4. **不可观测性弱**：调用链、重试、缓存命中与队列积压缺少统一指标模型，难做容量治理。
+
+---
+
+## 3. 目标架构（推荐终态）
+
+## 3.1 分层总览
+
+- **UI 层（core/app）**
+  - 只面向 `BuildOrchestratorFacade`（单入口）
+  - 不直接接触 gRPC stub / REAPI 细节
+
+- **项目编排层（core/project）**
+  - 负责项目状态机、任务图、并发调度、取消传播
+  - 输出标准化 `BuildPlan` / `ExecutionIntent`
+
+- **传输与执行层（tooling/***）**
+  - `AIDL Gateway`：App ↔ 本地构建守护进程
+  - `gRPC Control Plane`：构建控制、心跳、日志、事件流
+  - `REAPI Data/Exec Plane`：Action 缓存、CAS、远程执行
+
+## 3.2 关键组件
+
+1. **Build Orchestrator（客户端）**
+   - 接收“构建/同步/运行测试”意图
+   - 生成可缓存 Action（命令、输入树、环境）
+   - 调用 REAPI：先查 AC，未命中再执行
+
+2. **Session Manager（服务端）**
+   - 为每个项目会话分配隔离上下文（工作目录、凭据、资源配额）
+   - 统一管理生命周期：创建、续租、超时回收
+
+3. **Execution Broker**
+   - 将 Action 分派至本地执行器或远程集群
+   - 内置并发阈值、优先级、背压队列
+
+4. **Streaming Bus（gRPC streaming）**
+   - 双向流：状态、日志、进度、诊断事件
+   - 支持事件分级（UI 高优先、日志低优先）
+
+5. **Artifact Service（REAPI CAS）**
+   - 输入/输出工件统一内容寻址
+   - 减少重复传输，降低 I/O 与内存峰值
+
+---
+
+## 4. 协议设计（AIDL + gRPC + REAPI 协同）
+
+## 4.1 AIDL 角色定位（Android 本地入口）
+
+AIDL 仅承担：
+- 客户端进程与本机构建守护进程的连接管理
+- 会话建立、前台任务绑定、生命周期感知（前后台/低内存）
+- 快速失败与降级（例如网络不可用时自动本地执行）
+
+建议 AIDL 接口：
+- `IBuildGatewayService`
+  - `openSession(ProjectDescriptor): SessionToken`
+  - `startBuild(SessionToken, BuildRequest)`
+  - `cancelOperation(OperationId)`
+  - `subscribeEvents(SessionToken, IBuildEventCallback)`
+  - `closeSession(SessionToken)`
+
+> 设计原则：AIDL 只传“轻量控制消息 + Binder 句柄”，大量日志/诊断流经 gRPC 流，避免 Binder 大对象与主线程压力。
+
+## 4.2 gRPC 控制面（核心交互）
+
+使用 protobuf 定义强类型接口：
+- `BuildControlService`
+  - `StartOperation`
+  - `CancelOperation`
+  - `GetOperation`
+  - `StreamOperationEvents`（server streaming）
+  - `InteractiveChannel`（bidirectional streaming，可选）
+
+关键语义：
+- 每个操作强制携带 `operation_id`、`session_id`、`deadline`、`priority`
+- 所有可重试请求必须带 `idempotency_key`
+- 错误码映射统一（gRPC status ↔ 领域错误码）
+
+## 4.3 REAPI 数据与执行面
+
+严格按 REAPI 语义拆分：
+- **CAS**：上传输入树、下载产物
+- **Action Cache (AC)**：基于 Action Digest 查命中
+- **Execution**：未命中时执行，返回执行元数据与输出引用
+
+核心机制：
+1. Action 规范化（命令、env、platform properties）
+2. 输入根目录 Merkle 化，得到 digest
+3. 先查 AC；命中直接回包（秒级反馈）
+4. 未命中进入 Execution，结果回写 CAS+AC
+
+---
+
+## 5. 性能与稳定性极致优化策略
+
+## 5.1 内存与对象分配优化
+- 使用 protobuf（避免 JSON 解析热点）。
+- Event 对象池化（尤其日志/进度事件）。
+- 分块传输大日志（chunked streaming），禁止一次性聚合全量日志到内存。
+- 对 UI 仅保留“窗口化日志缓存”（如最近 N 行），历史落盘。
+
+## 5.2 减少 UI 卡顿
+- `core/app` 只消费“节流后的状态快照”，例如 100~200ms 合并推送一次。
+- 重日志流在后台线程消费，主线程只收 summary。
+- 进度事件去抖与 coalescing（相同阶段重复事件合并）。
+
+## 5.3 OOM 防护
+- 为每会话设置内存预算与软硬阈值：
+  - 软阈值：触发日志降采样、低优先级任务降速
+  - 硬阈值：拒绝新任务并提示用户
+- 大工件统一走文件流/零拷贝路径，不走 Binder 大 Parcel。
+- 构建守护进程采用“空闲回收 + 热启动池”平衡内存与冷启动。
+
+## 5.4 并发与背压
+- 统一队列模型：`interactive > foreground build > background sync`
+- 每类任务设置最大并发，防止资源争抢。
+- gRPC 流实现应用层背压信号（客户端可下发 `window_hint`）。
+
+## 5.5 网络与远程执行鲁棒性
+- 断网/高延迟时自动切换本地执行策略（Policy-based fallback）。
+- REAPI 下载采用并行小块 + 自适应并发。
+- 关键 RPC 指数退避重试，强制总 deadline，避免无限等待。
+
+---
+
+## 6. 模块重构蓝图（按目录落地）
+
+## 6.1 tooling/***
+建议新增子模块：
+- `tooling/transport-contract`：protobuf + AIDL 契约定义
+- `tooling/transport-grpc-client`：客户端 stub 与拦截器
+- `tooling/transport-grpc-server`：服务端实现
+- `tooling/reapi-client`：CAS/AC/Execution 封装
+- `tooling/build-orchestrator`：面向 core/project 的统一编排 API
+
+并将现有 lsp4j 依赖迁移策略：
+- 先引入新接口适配层（anti-corruption layer）
+- 再逐步替换调用点
+- 最后删除 lsp4j 与 JSON-RPC 相关代码路径
+
+## 6.2 core/project
+- 新建 `ProjectBuildDomainService`
+  - 负责 BuildPlan 生成、任务图、取消传播
+- 新建 `BuildStateStore`
+  - 采用不可变快照，便于 UI 差量渲染
+- 新建 `BuildPolicyEngine`
+  - 决策本地执行 / 远程执行 / 混合执行
+
+## 6.3 core/app
+- 引入 `BuildViewModelFacade`
+  - 只消费 `BuildUiState` 与 `BuildEventSummary`
+- UI 层不再处理底层协议对象（proto/aidl）
+- 前台生命周期变化通过 AIDL 网关通知会话优先级
+
+---
+
+## 7. 迁移路线图（分阶段、可回滚）
+
+### Phase 0：基线与观测先行
+- 建立现网基线：构建时长、峰值内存、ANR、OOM、UI 帧率。
+- 增加 tracing/metrics（会话、队列、缓存命中、流量）。
+
+### Phase 1：双栈期（lsp4j 与新架构并存）
+- 新建 transport-contract + orchestrator，接入少量命令（如 sync）。
+- 用 feature flag 控制灰度用户。
+
+### Phase 2：核心路径切换
+- build/test/run 迁移到 gRPC + REAPI。
+- AIDL 只保留入口与生命周期管理。
+
+### Phase 3：完全移除 lsp4j
+- 删除依赖、旧协议模型、桥接适配器。
+- 清理无用线程池与遗留状态机。
+
+### Phase 4：性能收敛
+- 根据指标调优并发、缓存策略、事件节流参数。
+- 固化 SLO 与自动回归基准。
+
+---
+
+## 8. 可观测性与运维治理
+
+必须落地四类指标：
+1. **延迟**：P50/P95/P99（启动、队列、执行、产物下载）
+2. **资源**：RSS、堆峰值、GC 次数、线程数
+3. **质量**：失败率、重试率、取消成功率
+4. **缓存**：AC 命中率、CAS 命中率、字节节省量
+
+日志与追踪要求：
+- 全链路 `trace_id/session_id/operation_id` 贯穿
+- 错误分层（用户错误、环境错误、系统错误）
+- 关键事件结构化输出，便于回放与根因分析
+
+---
+
+## 9. 安全与隔离
+
+- gRPC 使用 mTLS（设备证书或短期令牌）
+- REAPI 凭据最小权限与短时有效期
+- 多项目会话隔离（目录、缓存命名空间、配额）
+- 工件下载校验 digest，避免污染与篡改
+
+---
+
+## 10. 风险清单与对策
+
+1. **协议迁移期复杂度上升**  
+   对策：双栈仅保留最短窗口；每阶段可回滚。
+
+2. **远程执行不稳定影响体验**  
+   对策：本地执行兜底 + 快速超时 + 自愈重试。
+
+3. **事件风暴导致 UI 抖动**  
+   对策：事件分级、节流、合并、窗口化缓存。
+
+4. **缓存一致性问题**  
+   对策：Action 规范化与环境指纹严格一致。
+
+---
+
+## 11. 最小可行接口草案（示例）
+
+- `BuildOrchestratorFacade`
+  - `submit(request): OperationHandle`
+  - `cancel(operationId)`
+  - `observe(sessionId): Flow<BuildEventSummary>`
+
+- `BuildPolicyEngine`
+  - `selectRoute(request, deviceState, networkState): ExecutionRoute`
+
+- `ReapiExecutionClient`
+  - `computeActionDigest(plan)`
+  - `lookupActionCache(digest)`
+  - `execute(action)`
+  - `fetchOutputs(resultRefs)`
+
+---
+
+## 12. 预期收益（落地后）
+
+- 构建链路语义统一，减少协议适配层复杂度。
+- Protobuf + 流式传输显著降低序列化与内存抖动。
+- REAPI 缓存命中可显著缩短重复构建耗时。
+- AIDL 与 gRPC 分工明确，降低 Binder 压力与 UI 卡顿概率。
+- 可观测性完善后，可持续优化 OOM/ANR/性能瓶颈。
+
+---
+
+## 13. 建议的验收标准（必须量化）
+
+- 相比现网基线：
+  - 构建中位时长下降 ≥ 20%
+  - 峰值内存下降 ≥ 25%
+  - OOM 率下降 ≥ 40%
+  - UI 卡顿（慢帧）下降 ≥ 30%
+  - 重复构建缓存命中场景时长下降 ≥ 50%
+
+若以上指标不达标，不进入全面切流。

--- a/docs/architecture/reapi-grpc-aidl-build-service-refactor.md
+++ b/docs/architecture/reapi-grpc-aidl-build-service-refactor.md
@@ -1,115 +1,70 @@
-# 构建服务重构方案（深度源码评估版）
+# 构建服务重构方案（彻底替换版）
 
-> 目标：基于对 `tooling/***`、`core/projects`、`core/app` 现有源码的全链路分析，给出可落地的 **lsp4j 全量移除** 与 **gRPC + REAPI + AIDL** 重构方案。
-
----
-
-## 1. 现状全景：现有构建链路如何工作
-
-## 1.1 当前端到端链路（代码事实）
-
-1. `core/app` 的 `GradleBuildService` 作为 Android 前台 Service，同时实现 `BuildService` + `IToolingApiClient`，负责启动/持有 tooling 进程与转发事件。  
-2. tooling 侧通过 `ToolingApiLauncher`（lsp4j JSON-RPC）建立 `IToolingApiServer`/`IToolingApiClient` 双向代理。  
-3. `tooling/impl/Main.kt` 通过 `System.in/System.out` 启动 JSON-RPC listener；`ToolingApiServerImpl` 调用 Gradle Tooling API 完成 initialize / executeTasks / cancel / shutdown。  
-4. `core/projects/ProjectManagerImpl` 依赖 `BuildService` 进行源码生成任务（如 `process...Resources`、`dataBinding...`），并在完成后触发重新索引。  
+> 目标：基于对 `tooling/***`、`core/projects`、`core/app` 的源码评估，执行**一次性彻底替换**：完整移除旧 lsp4j/JSON-RPC 架构，不保留旧协议运行路径，统一升级为 **AIDL + gRPC + REAPI**。
 
 ---
 
-## 2. 现有问题评估（结合源码）
+## 1. 现有链路与根问题（源码事实）
 
-## 2.1 协议层与序列化层问题（lsp4j / Gson / JSON-RPC）
+### 1.1 当前链路
+1. `core/app` 的 `GradleBuildService` 同时承担前台服务、构建状态、tooling 进程、协议客户端等职责。  
+2. `tooling/api` 通过 `ToolingApiLauncher` + lsp4j JSON-RPC 连接 `IToolingApiServer/IToolingApiClient`。  
+3. `tooling/impl/Main.kt` 用 `System.in/System.out` 挂载通信；`ToolingApiServerImpl` 对接 Gradle Tooling API。  
+4. `core/projects/ProjectManagerImpl` 直接调用 `BuildService.executeTasks()` 触发生成/构建。  
 
-### 问题 A：构建域模型多态过重，JSON 反序列化成本高
-- `ToolingApiLauncher.configureGson()` 注册了大量 runtimeTypeAdapter（`ProgressEvent`、`OperationResult`、`ProjectMetadata` 等多层级多态）。
-- 每次事件往返都依赖字符串字段（`gsonType`）与反射/分发路径，移动端容易产生对象风暴与 GC 压力。
-
-### 问题 B：通信与业务模型强绑定到 lsp4j 注解
-- `IToolingApiServer` / `IToolingApiClient` 直接使用 `@JsonRequest/@JsonNotification/@JsonSegment`。
-- 这导致上层 API 合同被协议实现“反向污染”，协议升级代价高。
-
-### 问题 C：IO 通道是 `stdin/stdout` 文本流，结构化背压能力弱
-- `Main.kt` 使用 `ToolingApiLauncher.newServerLauncher(..., System.in, System.out)`。
-- 日志与协议通道在进程边界上容易竞争，缺乏原生流控与 QoS 优先级。
-
-## 2.2 线程与并发问题
-
-### 问题 D：`newCachedThreadPool()` 无上限扩容风险
-- `ToolingApiLauncher.newIoLauncher()` 使用 `Executors.newCachedThreadPool()`。
-- 在高频事件或阻塞场景可能扩容过快，引发线程数与内存峰值放大。
-
-### 问题 E：服务端构建互斥状态管理较脆弱
-- `ToolingApiServerImpl` 通过 `isBuildInProgress` 布尔位控制并发，runBuild 抛异常阻止并行。
-- 无队列/优先级/公平调度模型，无法支持“前台交互 > 后台同步”的真实场景。
-
-## 2.3 生命周期与资源治理问题
-
-### 问题 F：服务层承担过多职责
-- `GradleBuildService` 同时负责：前台通知、tooling 进程生命周期、事件消费、日志处理、构建状态管理、资源清理。
-- 单体服务复杂度高，不利于替换协议与分层治理。
-
-### 问题 G：构建进程清理依赖 best-effort
-- `onDestroy()` 中存在 `killGradlewProcesses()`、`destroy()`、超时 shutdown 等兜底，说明“优雅关闭路径”不稳定。
-- 缺乏 session lease + server heartbeat + 操作级 deadline 的协议化治理。
-
-## 2.4 架构耦合问题
-
-### 问题 H：core/projects 与构建执行细节耦合偏深
-- `ProjectManagerImpl.generateSources()` 直接拼接任务名并调用 `BuildService.executeTasks()`。
-- 项目域逻辑、执行策略、传输协议之间界限不清，难以引入远程执行策略。
-
-### 问题 I：应用层保留 lsp4j 依赖
-- `core/app/build.gradle.kts` 仍引入 `org.eclipse.lsp4j`，且 proguard 有 lsp4j keep 规则。
-- 表明协议依赖已渗透到 app 层，迁移必须“分层剥离”。
+### 1.2 性能与稳定性根因
+1. **JSON 多态序列化热路径过重**：`ToolingApiLauncher.configureGson()` 注册大量 runtimeTypeAdapter，事件频繁时 GC/分配压力大。  
+2. **协议绑定侵入业务合同**：`IToolingApiServer/Client` 使用 lsp4j 注解，导致协议与领域接口耦合。  
+3. **并发控制粗粒度**：`newCachedThreadPool()` + `isBuildInProgress` 布尔位，缺少上限、优先级与背压。  
+4. **服务职责过载**：`GradleBuildService` 单体化，生命周期/通知/构建/通信/清理耦合，演进困难。  
+5. **旧链路的文本流通信上限低**：`stdin/stdout` 缺少现代流控、事件分级与 QoS。  
 
 ---
 
-## 3. 性能压力根因结论
+## 2. 重构硬约束（这次必须满足）
 
-从源码看，当前性能压力主要来自：
-1. **JSON 多态反序列化热路径**（事件频繁时最明显）。
-2. **线程池与异步模型缺乏明确上限和背压机制**。
-3. **服务职责过载导致 UI/构建生命周期互相干扰**。
-4. **协议语义与构建语义不对齐**，造成额外适配和数据复制。
-
----
-
-## 4. 新架构目标（强约束）
-
-1. 彻底移除 `tooling/***`、`core/projects`、`core/app` 中的 lsp4j 协议依赖。
-2. 采用三平面架构：
-   - **AIDL（本地控制平面）**：Android 进程间控制/生命周期。
-   - **gRPC（控制与事件平面）**：强类型 RPC + 双向流。
-   - **REAPI（执行与工件平面）**：CAS/AC/Execution。
-3. 将“项目域编排”和“协议实现”完全解耦。
+1. **不保留旧协议运行路径**：
+   - 删除 lsp4j JSON-RPC 运行链路；
+   - 删除 `ToolingApiLauncher` 作为生产传输入口；
+   - 删除 app 层 lsp4j 依赖与 keep 规则。  
+2. **统一新传输栈**：
+   - 本地控制：AIDL
+   - 远程控制与事件：gRPC
+   - 执行与缓存：REAPI（CAS/AC/Execution）
+3. **统一编排语义**：`core/projects` 只输出领域 Intent/Plan，不再直连旧协议细节。
 
 ---
 
-## 5. 新架构设计（最佳机制版）
+## 3. 新架构（最终态，非双栈）
 
-## 5.1 逻辑分层
+## 3.1 `core/app`（客户端生命周期层）
+- 保留 Android Service 形态，但重构为 `BuildGatewayAndroidService`：
+  - 仅负责 AIDL 入口、会话生命周期、前后台优先级。
+  - 不再持有旧 lsp4j client/server proxy。
+- 新增 `BuildEventReducer`：
+  - 将 gRPC 流式事件折叠为 UI 快照；
+  - 100~200ms 节流推送，避免主线程抖动。
 
-### A. `core/app`（UI 与 Android 生命周期）
-- 新增 `BuildClientFacade`（仅暴露 UI 语义接口）。
-- 仅通过 `IBuildGatewayService.aidl` 访问本地构建网关。
-- UI 只接收节流后的 `BuildUiSnapshot`（非原始底层事件）。
-
-### B. `core/projects`（项目域与编排域）
+## 3.2 `core/projects`（领域编排层）
 - 新增 `ProjectBuildDomainService`：
-  - 输入：`BuildIntent`（sync/build/test/generateSources）
-  - 输出：`ExecutionPlan`（可本地可远程）
-- 新增 `BuildPolicyEngine`：根据网络、设备状态、缓存命中预测选择 Local/Remote/Hybrid。
-- `ProjectManagerImpl.generateSources()` 改为提交领域 intent，不再直接拼接执行细节。
+  - 输入：`BuildIntent(sync/build/test/generateSources/run)`
+  - 输出：`ExecutionPlan`
+- 新增 `BuildPolicyEngine`：
+  - 决策 Local/Remote/Hybrid（**均基于新栈，不回退旧栈**）。
+- `ProjectManagerImpl.generateSources()` 改为提交 intent，不直接拼 task 命令到旧接口。
 
-### C. `tooling/***`（传输与执行域）
-- `tooling/transport-contract`：proto + aidl 合同。
-- `tooling/transport-grpc-client`：channel、interceptor、retry、deadline、tracing。
-- `tooling/transport-grpc-server`：session/operation 管理、流式事件总线。
-- `tooling/reapi-client`：CAS/AC/Execution。
-- `tooling/build-orchestrator`：操作状态机、取消传播、背压。
+## 3.3 `tooling/***`（传输与执行层）
+- `tooling/transport-contract`：AIDL + Proto 合同。
+- `tooling/transport-grpc-client`：deadline/retry/interceptor/tracing。
+- `tooling/transport-grpc-server`：session/operation/event stream/backpressure。
+- `tooling/reapi-client`：CAS/AC/Execution 统一封装。
+- `tooling/build-orchestrator`：状态机、取消链、预算治理。
 
-## 5.2 协议设计
+---
 
-### AIDL（本地轻控制）
+## 4. 协议与机制设计
+
+## 4.1 AIDL（仅本地轻控制）
 ```aidl
 interface IBuildGatewayService {
   SessionToken openSession(in ProjectDescriptor project);
@@ -119,126 +74,107 @@ interface IBuildGatewayService {
   void closeSession(in SessionToken session);
 }
 ```
-
 约束：
-- AIDL 不传大日志正文/大工件。
-- 回调只传 operation 状态摘要与必要错误。
+- AIDL 不传大日志/大产物；
+- 仅传控制命令与状态摘要。
 
-### gRPC（强类型控制面）
-- `BuildControlService`：`StartOperation`、`CancelOperation`、`GetOperation`、`StreamEvents`。
-- 所有请求强制字段：`session_id`、`operation_id`、`deadline_ms`、`idempotency_key`。
-- 引入 client hint：`ui_priority`、`max_event_rate`、`preferred_result_detail`。
+## 4.2 gRPC（控制与事件主通道）
+- `BuildControlService`: `StartOperation` / `CancelOperation` / `GetOperation` / `StreamEvents`。
+- 强制字段：`session_id`、`operation_id`、`deadline_ms`、`idempotency_key`。
+- 事件双通道：
+  - `status stream`（高优先）
+  - `log stream`（可降采样）
 
-### REAPI（执行面）
-- 先 AC lookup，再 execution。
-- 输入树 Merkle 化，输出统一 CAS 引用。
-- 输出日志也可选择 CAS chunk 化（避免内存聚合）。
-
-## 5.3 关键机制（性能/稳定性）
-
-1. **事件分级总线**：
-   - P0：状态变更（开始/阶段/结束/失败）
-   - P1：诊断摘要
-   - P2：详细日志（可降采样）
-2. **双背压机制**：
-   - gRPC HTTP/2 流控 + 应用层 `window_hint`。
-3. **操作预算系统**：
-   - 每 operation 配置 CPU/内存/日志预算。
-   - 预算触发后自动降级事件粒度。
-4. **可恢复会话**：
-   - session lease + heartbeat，服务重启后可恢复 operation 状态。
-5. **确定性取消链**：
-   - UI cancel -> AIDL cancel -> gRPC cancel -> Gradle/REAPI cancel token 级联。
+## 4.3 REAPI（执行与缓存通道）
+- Action Digest 标准化（命令、env、platform）；
+- 先查 AC，未命中再 Execution；
+- 输入输出都走 CAS 引用，减少重复传输和内存峰值。
 
 ---
 
-## 6. 针对当前模块的升级改造清单
+## 5. 极致性能机制（核心）
+
+1. **彻底移除 JSON 热路径**：统一 protobuf 编码，消灭 `gsonType` 多态反序列化。
+2. **有界并发模型**：固定线程池 + 分级队列（interactive > build > sync）。
+3. **端到端背压**：HTTP/2 流控 + 应用层 `window_hint`。
+4. **事件分级与窗口化缓存**：UI 只保留近 N 行，历史落盘。
+5. **预算驱动降级**：超预算自动降低日志粒度、合并进度事件。
+6. **确定性取消**：AIDL cancel → gRPC cancel → REAPI/Gradle token，2 秒内生效为目标。
+
+---
+
+## 6. 模块级“删旧换新”清单
 
 ## 6.1 tooling/***
+### 删除
+- lsp4j jsonrpc 依赖与注解接口。
+- `ToolingApiLauncher` 生产路径。
+- 旧 stdout/stderr 文本协议通信入口。
 
-### 需要移除
-- `tooling/api` 中 lsp4j jsonrpc 依赖与注解接口。
-- `ToolingApiLauncher` 的 Gson runtimeTypeAdapter 方案。
-
-### 需要新增
-- proto 合同：`build_control.proto`、`build_events.proto`、`build_domain.proto`。
-- REAPI adapter：action digest 计算、AC lookup、execution submit、CAS 上传下载。
+### 新增
+- proto: `build_control.proto` / `build_events.proto` / `build_domain.proto`。
 - `OperationStateMachine`（Queued/Running/Cancelling/Completed/Failed）。
+- REAPI Adapter（Digest/AC/CAS/Execution）。
 
 ## 6.2 core/projects
+### 删除/替换
+- 旧 `BuildService` 协议导向接口（替换为领域导向 API）。
+- 直接任务字符串拼装执行路径。
 
-### 需要调整
-- `BuildService` 由“具体协议调用接口”升级为“领域语义接口”。
-- `ProjectManagerImpl` 的 `generateSources()` 改为提交 `GenerateSourcesIntent`。
-
-### 新增能力
-- 构建意图去重（同会话同参数短时间内合并）。
-- 任务图与变体映射缓存（减少重复组装）。
+### 新增
+- `ProjectBuildDomainService`
+- `BuildPolicyEngine`
+- `ExecutionPlanCache`
 
 ## 6.3 core/app
+### 删除
+- lsp4j 依赖与相关 Proguard keep。
+- 旧 `GradleBuildService` 的协议耦合实现。
 
-### 需要移除
-- app 层对 lsp4j/proguard keep 规则依赖。
-- `GradleBuildService` 里协议/进程/日志/通知重耦合实现。
-
-### 需要新增
-- `BuildGatewayAndroidService`（仅 AIDL 网关 + lifecycle）。
-- `BuildEventReducer`（流事件 -> UI 快照，100~200ms 节流）。
-- 输出窗口化缓存（UI只保留最近 N 行）。
-
----
-
-## 7. 迁移路径（可回滚）
-
-### Phase 0：基线测量
-- 增加 trace_id/session_id/operation_id。
-- 记录当前：构建耗时、峰值内存、GC、慢帧、OOM。
-
-### Phase 1：合同先行
-- 引入 AIDL + proto 合同，不切流。
-- 建立桥接层：旧 `BuildService` -> 新 `BuildClientFacade`。
-
-### Phase 2：双栈运行
-- sync / generateSources 先迁移至 gRPC。
-- build/test 保持旧栈，便于回滚。
-
-### Phase 3：执行面切换
-- build/test/run 全量走 gRPC + REAPI。
-- 开启 AC/CAS 命中监控。
-
-### Phase 4：lsp4j 删除
-- 删除 `tooling/api` 的 jsonrpc 注解与 launcher。
-- 删除 `core/app` lsp4j 依赖与 proguard keep。
-
-### Phase 5：性能收敛
-- 根据指标调优：事件速率、并发窗口、缓存策略。
+### 新增
+- `BuildGatewayAndroidService`
+- `BuildClientFacade`
+- `BuildEventReducer`
 
 ---
 
-## 8. 量化验收指标（必须同时满足）
+## 7. 实施策略（不是双栈共存，而是“并行开发 + 一次切换”）
 
-1. P50 构建耗时下降 ≥ 20%，P95 下降 ≥ 15%。
-2. 构建期间 app 进程峰值内存下降 ≥ 25%。
-3. 构建相关慢帧下降 ≥ 30%。
+### Stage A：新架构并行开发（不接入线上运行）
+- 在隔离模块内完成 AIDL/gRPC/REAPI 全链路。
+- 引入压测与回归基线，验证吞吐、内存、慢帧。
+
+### Stage B：预发全量验证
+- 在测试渠道启用**仅新架构**。
+- 旧架构不参与请求分流（避免混栈干扰数据）。
+
+### Stage C：生产一次切换
+- 发布版本时直接切换到新架构；
+- 同版本中不再保留旧架构执行入口；
+- 若失败，回滚到上一个稳定版本（版本级回滚，而非运行时双栈）。
+
+### Stage D：源码清理封版
+- 删除全部旧协议代码、依赖、配置与文档。
+- 固化新的 SLO 与性能阈值守卫。
+
+---
+
+## 8. 验收标准（必须达标）
+
+1. P50 构建耗时下降 ≥ 25%，P95 下降 ≥ 20%。
+2. 构建阶段 app 进程峰值内存下降 ≥ 30%。
+3. 构建相关慢帧下降 ≥ 35%。
 4. OOM 率下降 ≥ 40%。
-5. 重复构建（命中 AC）耗时下降 ≥ 50%。
+5. 重复构建命中 AC 时长下降 ≥ 55%。
 6. 取消请求 2 秒内生效率 ≥ 95%。
 
 ---
 
-## 9. 风险与防线
+## 9. 结论
 
-1. **双栈复杂度上升** -> 限期双栈，阶段完成后强制清理旧路径。  
-2. **远程执行不稳定** -> 本地 fallback + 短 deadline + 幂等重试。  
-3. **事件洪峰影响 UI** -> 事件分级 + 降采样 + 快照节流。  
-4. **缓存一致性** -> Action 输入规范化 + 环境指纹强校验。  
+本方案强调“**彻底替换**”而非“新旧混用”：
+- 不保留旧 lsp4j 协议运行路径；
+- 不保留旧 JSON-RPC 文本通道；
+- 通过 AIDL + gRPC + REAPI 全面升级 `tooling/***`、`core/projects`、`core/app` 构建服务架构。
 
----
-
-## 10. 结论
-
-本次方案不是“只换通信协议”，而是将当前构建服务从“lsp4j + 进程文本流 + 单体服务”升级为“领域编排清晰、协议分层明确、执行可观测可治理”的体系化架构。其核心收益在于：
-- 消除 JSON-RPC 多态序列化热路径；
-- 降低线程/内存抖动与 UI 卡顿风险；
-- 引入 REAPI 缓存与远程执行能力；
-- 让 `tooling/***`、`core/projects`、`core/app` 在职责上可长期演进。
+这样才能在构建速度、内存占用、UI 流畅度、取消响应与可观测性上获得最大化收益，实现你要求的“全方面升级改造”。

--- a/docs/architecture/reapi-grpc-aidl-build-service-refactor.md
+++ b/docs/architecture/reapi-grpc-aidl-build-service-refactor.md
@@ -1,283 +1,244 @@
-# 使用 gRPC + Remote Execution API (REAPI) + AIDL 重构构建服务架构方案（替代 lsp4j）
+# 构建服务重构方案（深度源码评估版）
 
-## 1. 目标与边界
-
-### 1.1 重构目标
-- 在 `./tooling/***`、`core/project`、`core/app` 中彻底移除当前基于 `lsp4j` 的构建服务协议与通信通道。
-- 建立统一的 **三层传输架构**：
-  1) 进程内/本机跨进程：AIDL（Android Binder）
-  2) 远程高性能 RPC：gRPC（HTTP/2 + Protobuf）
-  3) 远程执行与缓存协议：REAPI（CAS/AC/Execution）
-- 用“能力分层 + 协议分层”的方式，让 IDE UI、项目模型、构建执行彼此解耦。
-
-### 1.2 非目标（避免范围膨胀）
-- 不在第一阶段重写全部语言服务能力（仅聚焦构建、同步、任务执行、日志、状态流）。
-- 不在客户端一次性切换所有模块；采用可回滚灰度迁移。
+> 目标：基于对 `tooling/***`、`core/projects`、`core/app` 现有源码的全链路分析，给出可落地的 **lsp4j 全量移除** 与 **gRPC + REAPI + AIDL** 重构方案。
 
 ---
 
-## 2. 当前痛点（为何必须替换 lsp4j 路径）
+## 1. 现状全景：现有构建链路如何工作
 
-1. **协议语义错位**：LSP/lsp4j 本质是“编辑器语言服务协议”，用于构建服务时语义不自然，导致消息定义臃肿、扩展成本高。  
-2. **资源开销高**：JSON-RPC 序列化开销、对象分配与反序列化压力明显，移动端易出现内存抖动和 GC 频繁。  
-3. **链路不统一**：本地 IPC、远程执行、日志流、取消/超时语义分散，造成状态管理复杂。  
-4. **不可观测性弱**：调用链、重试、缓存命中与队列积压缺少统一指标模型，难做容量治理。
+## 1.1 当前端到端链路（代码事实）
 
----
-
-## 3. 目标架构（推荐终态）
-
-## 3.1 分层总览
-
-- **UI 层（core/app）**
-  - 只面向 `BuildOrchestratorFacade`（单入口）
-  - 不直接接触 gRPC stub / REAPI 细节
-
-- **项目编排层（core/project）**
-  - 负责项目状态机、任务图、并发调度、取消传播
-  - 输出标准化 `BuildPlan` / `ExecutionIntent`
-
-- **传输与执行层（tooling/***）**
-  - `AIDL Gateway`：App ↔ 本地构建守护进程
-  - `gRPC Control Plane`：构建控制、心跳、日志、事件流
-  - `REAPI Data/Exec Plane`：Action 缓存、CAS、远程执行
-
-## 3.2 关键组件
-
-1. **Build Orchestrator（客户端）**
-   - 接收“构建/同步/运行测试”意图
-   - 生成可缓存 Action（命令、输入树、环境）
-   - 调用 REAPI：先查 AC，未命中再执行
-
-2. **Session Manager（服务端）**
-   - 为每个项目会话分配隔离上下文（工作目录、凭据、资源配额）
-   - 统一管理生命周期：创建、续租、超时回收
-
-3. **Execution Broker**
-   - 将 Action 分派至本地执行器或远程集群
-   - 内置并发阈值、优先级、背压队列
-
-4. **Streaming Bus（gRPC streaming）**
-   - 双向流：状态、日志、进度、诊断事件
-   - 支持事件分级（UI 高优先、日志低优先）
-
-5. **Artifact Service（REAPI CAS）**
-   - 输入/输出工件统一内容寻址
-   - 减少重复传输，降低 I/O 与内存峰值
+1. `core/app` 的 `GradleBuildService` 作为 Android 前台 Service，同时实现 `BuildService` + `IToolingApiClient`，负责启动/持有 tooling 进程与转发事件。  
+2. tooling 侧通过 `ToolingApiLauncher`（lsp4j JSON-RPC）建立 `IToolingApiServer`/`IToolingApiClient` 双向代理。  
+3. `tooling/impl/Main.kt` 通过 `System.in/System.out` 启动 JSON-RPC listener；`ToolingApiServerImpl` 调用 Gradle Tooling API 完成 initialize / executeTasks / cancel / shutdown。  
+4. `core/projects/ProjectManagerImpl` 依赖 `BuildService` 进行源码生成任务（如 `process...Resources`、`dataBinding...`），并在完成后触发重新索引。  
 
 ---
 
-## 4. 协议设计（AIDL + gRPC + REAPI 协同）
+## 2. 现有问题评估（结合源码）
 
-## 4.1 AIDL 角色定位（Android 本地入口）
+## 2.1 协议层与序列化层问题（lsp4j / Gson / JSON-RPC）
 
-AIDL 仅承担：
-- 客户端进程与本机构建守护进程的连接管理
-- 会话建立、前台任务绑定、生命周期感知（前后台/低内存）
-- 快速失败与降级（例如网络不可用时自动本地执行）
+### 问题 A：构建域模型多态过重，JSON 反序列化成本高
+- `ToolingApiLauncher.configureGson()` 注册了大量 runtimeTypeAdapter（`ProgressEvent`、`OperationResult`、`ProjectMetadata` 等多层级多态）。
+- 每次事件往返都依赖字符串字段（`gsonType`）与反射/分发路径，移动端容易产生对象风暴与 GC 压力。
 
-建议 AIDL 接口：
-- `IBuildGatewayService`
-  - `openSession(ProjectDescriptor): SessionToken`
-  - `startBuild(SessionToken, BuildRequest)`
-  - `cancelOperation(OperationId)`
-  - `subscribeEvents(SessionToken, IBuildEventCallback)`
-  - `closeSession(SessionToken)`
+### 问题 B：通信与业务模型强绑定到 lsp4j 注解
+- `IToolingApiServer` / `IToolingApiClient` 直接使用 `@JsonRequest/@JsonNotification/@JsonSegment`。
+- 这导致上层 API 合同被协议实现“反向污染”，协议升级代价高。
 
-> 设计原则：AIDL 只传“轻量控制消息 + Binder 句柄”，大量日志/诊断流经 gRPC 流，避免 Binder 大对象与主线程压力。
+### 问题 C：IO 通道是 `stdin/stdout` 文本流，结构化背压能力弱
+- `Main.kt` 使用 `ToolingApiLauncher.newServerLauncher(..., System.in, System.out)`。
+- 日志与协议通道在进程边界上容易竞争，缺乏原生流控与 QoS 优先级。
 
-## 4.2 gRPC 控制面（核心交互）
+## 2.2 线程与并发问题
 
-使用 protobuf 定义强类型接口：
-- `BuildControlService`
-  - `StartOperation`
-  - `CancelOperation`
-  - `GetOperation`
-  - `StreamOperationEvents`（server streaming）
-  - `InteractiveChannel`（bidirectional streaming，可选）
+### 问题 D：`newCachedThreadPool()` 无上限扩容风险
+- `ToolingApiLauncher.newIoLauncher()` 使用 `Executors.newCachedThreadPool()`。
+- 在高频事件或阻塞场景可能扩容过快，引发线程数与内存峰值放大。
 
-关键语义：
-- 每个操作强制携带 `operation_id`、`session_id`、`deadline`、`priority`
-- 所有可重试请求必须带 `idempotency_key`
-- 错误码映射统一（gRPC status ↔ 领域错误码）
+### 问题 E：服务端构建互斥状态管理较脆弱
+- `ToolingApiServerImpl` 通过 `isBuildInProgress` 布尔位控制并发，runBuild 抛异常阻止并行。
+- 无队列/优先级/公平调度模型，无法支持“前台交互 > 后台同步”的真实场景。
 
-## 4.3 REAPI 数据与执行面
+## 2.3 生命周期与资源治理问题
 
-严格按 REAPI 语义拆分：
-- **CAS**：上传输入树、下载产物
-- **Action Cache (AC)**：基于 Action Digest 查命中
-- **Execution**：未命中时执行，返回执行元数据与输出引用
+### 问题 F：服务层承担过多职责
+- `GradleBuildService` 同时负责：前台通知、tooling 进程生命周期、事件消费、日志处理、构建状态管理、资源清理。
+- 单体服务复杂度高，不利于替换协议与分层治理。
 
-核心机制：
-1. Action 规范化（命令、env、platform properties）
-2. 输入根目录 Merkle 化，得到 digest
-3. 先查 AC；命中直接回包（秒级反馈）
-4. 未命中进入 Execution，结果回写 CAS+AC
+### 问题 G：构建进程清理依赖 best-effort
+- `onDestroy()` 中存在 `killGradlewProcesses()`、`destroy()`、超时 shutdown 等兜底，说明“优雅关闭路径”不稳定。
+- 缺乏 session lease + server heartbeat + 操作级 deadline 的协议化治理。
 
----
+## 2.4 架构耦合问题
 
-## 5. 性能与稳定性极致优化策略
+### 问题 H：core/projects 与构建执行细节耦合偏深
+- `ProjectManagerImpl.generateSources()` 直接拼接任务名并调用 `BuildService.executeTasks()`。
+- 项目域逻辑、执行策略、传输协议之间界限不清，难以引入远程执行策略。
 
-## 5.1 内存与对象分配优化
-- 使用 protobuf（避免 JSON 解析热点）。
-- Event 对象池化（尤其日志/进度事件）。
-- 分块传输大日志（chunked streaming），禁止一次性聚合全量日志到内存。
-- 对 UI 仅保留“窗口化日志缓存”（如最近 N 行），历史落盘。
-
-## 5.2 减少 UI 卡顿
-- `core/app` 只消费“节流后的状态快照”，例如 100~200ms 合并推送一次。
-- 重日志流在后台线程消费，主线程只收 summary。
-- 进度事件去抖与 coalescing（相同阶段重复事件合并）。
-
-## 5.3 OOM 防护
-- 为每会话设置内存预算与软硬阈值：
-  - 软阈值：触发日志降采样、低优先级任务降速
-  - 硬阈值：拒绝新任务并提示用户
-- 大工件统一走文件流/零拷贝路径，不走 Binder 大 Parcel。
-- 构建守护进程采用“空闲回收 + 热启动池”平衡内存与冷启动。
-
-## 5.4 并发与背压
-- 统一队列模型：`interactive > foreground build > background sync`
-- 每类任务设置最大并发，防止资源争抢。
-- gRPC 流实现应用层背压信号（客户端可下发 `window_hint`）。
-
-## 5.5 网络与远程执行鲁棒性
-- 断网/高延迟时自动切换本地执行策略（Policy-based fallback）。
-- REAPI 下载采用并行小块 + 自适应并发。
-- 关键 RPC 指数退避重试，强制总 deadline，避免无限等待。
+### 问题 I：应用层保留 lsp4j 依赖
+- `core/app/build.gradle.kts` 仍引入 `org.eclipse.lsp4j`，且 proguard 有 lsp4j keep 规则。
+- 表明协议依赖已渗透到 app 层，迁移必须“分层剥离”。
 
 ---
 
-## 6. 模块重构蓝图（按目录落地）
+## 3. 性能压力根因结论
+
+从源码看，当前性能压力主要来自：
+1. **JSON 多态反序列化热路径**（事件频繁时最明显）。
+2. **线程池与异步模型缺乏明确上限和背压机制**。
+3. **服务职责过载导致 UI/构建生命周期互相干扰**。
+4. **协议语义与构建语义不对齐**，造成额外适配和数据复制。
+
+---
+
+## 4. 新架构目标（强约束）
+
+1. 彻底移除 `tooling/***`、`core/projects`、`core/app` 中的 lsp4j 协议依赖。
+2. 采用三平面架构：
+   - **AIDL（本地控制平面）**：Android 进程间控制/生命周期。
+   - **gRPC（控制与事件平面）**：强类型 RPC + 双向流。
+   - **REAPI（执行与工件平面）**：CAS/AC/Execution。
+3. 将“项目域编排”和“协议实现”完全解耦。
+
+---
+
+## 5. 新架构设计（最佳机制版）
+
+## 5.1 逻辑分层
+
+### A. `core/app`（UI 与 Android 生命周期）
+- 新增 `BuildClientFacade`（仅暴露 UI 语义接口）。
+- 仅通过 `IBuildGatewayService.aidl` 访问本地构建网关。
+- UI 只接收节流后的 `BuildUiSnapshot`（非原始底层事件）。
+
+### B. `core/projects`（项目域与编排域）
+- 新增 `ProjectBuildDomainService`：
+  - 输入：`BuildIntent`（sync/build/test/generateSources）
+  - 输出：`ExecutionPlan`（可本地可远程）
+- 新增 `BuildPolicyEngine`：根据网络、设备状态、缓存命中预测选择 Local/Remote/Hybrid。
+- `ProjectManagerImpl.generateSources()` 改为提交领域 intent，不再直接拼接执行细节。
+
+### C. `tooling/***`（传输与执行域）
+- `tooling/transport-contract`：proto + aidl 合同。
+- `tooling/transport-grpc-client`：channel、interceptor、retry、deadline、tracing。
+- `tooling/transport-grpc-server`：session/operation 管理、流式事件总线。
+- `tooling/reapi-client`：CAS/AC/Execution。
+- `tooling/build-orchestrator`：操作状态机、取消传播、背压。
+
+## 5.2 协议设计
+
+### AIDL（本地轻控制）
+```aidl
+interface IBuildGatewayService {
+  SessionToken openSession(in ProjectDescriptor project);
+  void submit(in SessionToken session, in BuildIntentParcel intent, in IBuildCallback callback);
+  void cancel(in SessionToken session, String operationId);
+  void setForegroundState(in SessionToken session, boolean isForeground);
+  void closeSession(in SessionToken session);
+}
+```
+
+约束：
+- AIDL 不传大日志正文/大工件。
+- 回调只传 operation 状态摘要与必要错误。
+
+### gRPC（强类型控制面）
+- `BuildControlService`：`StartOperation`、`CancelOperation`、`GetOperation`、`StreamEvents`。
+- 所有请求强制字段：`session_id`、`operation_id`、`deadline_ms`、`idempotency_key`。
+- 引入 client hint：`ui_priority`、`max_event_rate`、`preferred_result_detail`。
+
+### REAPI（执行面）
+- 先 AC lookup，再 execution。
+- 输入树 Merkle 化，输出统一 CAS 引用。
+- 输出日志也可选择 CAS chunk 化（避免内存聚合）。
+
+## 5.3 关键机制（性能/稳定性）
+
+1. **事件分级总线**：
+   - P0：状态变更（开始/阶段/结束/失败）
+   - P1：诊断摘要
+   - P2：详细日志（可降采样）
+2. **双背压机制**：
+   - gRPC HTTP/2 流控 + 应用层 `window_hint`。
+3. **操作预算系统**：
+   - 每 operation 配置 CPU/内存/日志预算。
+   - 预算触发后自动降级事件粒度。
+4. **可恢复会话**：
+   - session lease + heartbeat，服务重启后可恢复 operation 状态。
+5. **确定性取消链**：
+   - UI cancel -> AIDL cancel -> gRPC cancel -> Gradle/REAPI cancel token 级联。
+
+---
+
+## 6. 针对当前模块的升级改造清单
 
 ## 6.1 tooling/***
-建议新增子模块：
-- `tooling/transport-contract`：protobuf + AIDL 契约定义
-- `tooling/transport-grpc-client`：客户端 stub 与拦截器
-- `tooling/transport-grpc-server`：服务端实现
-- `tooling/reapi-client`：CAS/AC/Execution 封装
-- `tooling/build-orchestrator`：面向 core/project 的统一编排 API
 
-并将现有 lsp4j 依赖迁移策略：
-- 先引入新接口适配层（anti-corruption layer）
-- 再逐步替换调用点
-- 最后删除 lsp4j 与 JSON-RPC 相关代码路径
+### 需要移除
+- `tooling/api` 中 lsp4j jsonrpc 依赖与注解接口。
+- `ToolingApiLauncher` 的 Gson runtimeTypeAdapter 方案。
 
-## 6.2 core/project
-- 新建 `ProjectBuildDomainService`
-  - 负责 BuildPlan 生成、任务图、取消传播
-- 新建 `BuildStateStore`
-  - 采用不可变快照，便于 UI 差量渲染
-- 新建 `BuildPolicyEngine`
-  - 决策本地执行 / 远程执行 / 混合执行
+### 需要新增
+- proto 合同：`build_control.proto`、`build_events.proto`、`build_domain.proto`。
+- REAPI adapter：action digest 计算、AC lookup、execution submit、CAS 上传下载。
+- `OperationStateMachine`（Queued/Running/Cancelling/Completed/Failed）。
+
+## 6.2 core/projects
+
+### 需要调整
+- `BuildService` 由“具体协议调用接口”升级为“领域语义接口”。
+- `ProjectManagerImpl` 的 `generateSources()` 改为提交 `GenerateSourcesIntent`。
+
+### 新增能力
+- 构建意图去重（同会话同参数短时间内合并）。
+- 任务图与变体映射缓存（减少重复组装）。
 
 ## 6.3 core/app
-- 引入 `BuildViewModelFacade`
-  - 只消费 `BuildUiState` 与 `BuildEventSummary`
-- UI 层不再处理底层协议对象（proto/aidl）
-- 前台生命周期变化通过 AIDL 网关通知会话优先级
+
+### 需要移除
+- app 层对 lsp4j/proguard keep 规则依赖。
+- `GradleBuildService` 里协议/进程/日志/通知重耦合实现。
+
+### 需要新增
+- `BuildGatewayAndroidService`（仅 AIDL 网关 + lifecycle）。
+- `BuildEventReducer`（流事件 -> UI 快照，100~200ms 节流）。
+- 输出窗口化缓存（UI只保留最近 N 行）。
 
 ---
 
-## 7. 迁移路线图（分阶段、可回滚）
+## 7. 迁移路径（可回滚）
 
-### Phase 0：基线与观测先行
-- 建立现网基线：构建时长、峰值内存、ANR、OOM、UI 帧率。
-- 增加 tracing/metrics（会话、队列、缓存命中、流量）。
+### Phase 0：基线测量
+- 增加 trace_id/session_id/operation_id。
+- 记录当前：构建耗时、峰值内存、GC、慢帧、OOM。
 
-### Phase 1：双栈期（lsp4j 与新架构并存）
-- 新建 transport-contract + orchestrator，接入少量命令（如 sync）。
-- 用 feature flag 控制灰度用户。
+### Phase 1：合同先行
+- 引入 AIDL + proto 合同，不切流。
+- 建立桥接层：旧 `BuildService` -> 新 `BuildClientFacade`。
 
-### Phase 2：核心路径切换
-- build/test/run 迁移到 gRPC + REAPI。
-- AIDL 只保留入口与生命周期管理。
+### Phase 2：双栈运行
+- sync / generateSources 先迁移至 gRPC。
+- build/test 保持旧栈，便于回滚。
 
-### Phase 3：完全移除 lsp4j
-- 删除依赖、旧协议模型、桥接适配器。
-- 清理无用线程池与遗留状态机。
+### Phase 3：执行面切换
+- build/test/run 全量走 gRPC + REAPI。
+- 开启 AC/CAS 命中监控。
 
-### Phase 4：性能收敛
-- 根据指标调优并发、缓存策略、事件节流参数。
-- 固化 SLO 与自动回归基准。
+### Phase 4：lsp4j 删除
+- 删除 `tooling/api` 的 jsonrpc 注解与 launcher。
+- 删除 `core/app` lsp4j 依赖与 proguard keep。
 
----
-
-## 8. 可观测性与运维治理
-
-必须落地四类指标：
-1. **延迟**：P50/P95/P99（启动、队列、执行、产物下载）
-2. **资源**：RSS、堆峰值、GC 次数、线程数
-3. **质量**：失败率、重试率、取消成功率
-4. **缓存**：AC 命中率、CAS 命中率、字节节省量
-
-日志与追踪要求：
-- 全链路 `trace_id/session_id/operation_id` 贯穿
-- 错误分层（用户错误、环境错误、系统错误）
-- 关键事件结构化输出，便于回放与根因分析
+### Phase 5：性能收敛
+- 根据指标调优：事件速率、并发窗口、缓存策略。
 
 ---
 
-## 9. 安全与隔离
+## 8. 量化验收指标（必须同时满足）
 
-- gRPC 使用 mTLS（设备证书或短期令牌）
-- REAPI 凭据最小权限与短时有效期
-- 多项目会话隔离（目录、缓存命名空间、配额）
-- 工件下载校验 digest，避免污染与篡改
-
----
-
-## 10. 风险清单与对策
-
-1. **协议迁移期复杂度上升**  
-   对策：双栈仅保留最短窗口；每阶段可回滚。
-
-2. **远程执行不稳定影响体验**  
-   对策：本地执行兜底 + 快速超时 + 自愈重试。
-
-3. **事件风暴导致 UI 抖动**  
-   对策：事件分级、节流、合并、窗口化缓存。
-
-4. **缓存一致性问题**  
-   对策：Action 规范化与环境指纹严格一致。
+1. P50 构建耗时下降 ≥ 20%，P95 下降 ≥ 15%。
+2. 构建期间 app 进程峰值内存下降 ≥ 25%。
+3. 构建相关慢帧下降 ≥ 30%。
+4. OOM 率下降 ≥ 40%。
+5. 重复构建（命中 AC）耗时下降 ≥ 50%。
+6. 取消请求 2 秒内生效率 ≥ 95%。
 
 ---
 
-## 11. 最小可行接口草案（示例）
+## 9. 风险与防线
 
-- `BuildOrchestratorFacade`
-  - `submit(request): OperationHandle`
-  - `cancel(operationId)`
-  - `observe(sessionId): Flow<BuildEventSummary>`
-
-- `BuildPolicyEngine`
-  - `selectRoute(request, deviceState, networkState): ExecutionRoute`
-
-- `ReapiExecutionClient`
-  - `computeActionDigest(plan)`
-  - `lookupActionCache(digest)`
-  - `execute(action)`
-  - `fetchOutputs(resultRefs)`
+1. **双栈复杂度上升** -> 限期双栈，阶段完成后强制清理旧路径。  
+2. **远程执行不稳定** -> 本地 fallback + 短 deadline + 幂等重试。  
+3. **事件洪峰影响 UI** -> 事件分级 + 降采样 + 快照节流。  
+4. **缓存一致性** -> Action 输入规范化 + 环境指纹强校验。  
 
 ---
 
-## 12. 预期收益（落地后）
+## 10. 结论
 
-- 构建链路语义统一，减少协议适配层复杂度。
-- Protobuf + 流式传输显著降低序列化与内存抖动。
-- REAPI 缓存命中可显著缩短重复构建耗时。
-- AIDL 与 gRPC 分工明确，降低 Binder 压力与 UI 卡顿概率。
-- 可观测性完善后，可持续优化 OOM/ANR/性能瓶颈。
-
----
-
-## 13. 建议的验收标准（必须量化）
-
-- 相比现网基线：
-  - 构建中位时长下降 ≥ 20%
-  - 峰值内存下降 ≥ 25%
-  - OOM 率下降 ≥ 40%
-  - UI 卡顿（慢帧）下降 ≥ 30%
-  - 重复构建缓存命中场景时长下降 ≥ 50%
-
-若以上指标不达标，不进入全面切流。
+本次方案不是“只换通信协议”，而是将当前构建服务从“lsp4j + 进程文本流 + 单体服务”升级为“领域编排清晰、协议分层明确、执行可观测可治理”的体系化架构。其核心收益在于：
+- 消除 JSON-RPC 多态序列化热路径；
+- 降低线程/内存抖动与 UI 卡顿风险；
+- 引入 REAPI 缓存与远程执行能力；
+- 让 `tooling/***`、`core/projects`、`core/app` 在职责上可长期演进。


### PR DESCRIPTION
### Motivation

- Replace the current `lsp4j`-based build-transport in `tooling/***`, `core/project`, and `core/app` with a purpose-built stack using AIDL (local IPC), gRPC (control plane), and REAPI (data/exec plane) to align protocol semantics with build orchestration needs.
- Reduce runtime overhead and mobile-client pain points (JSON-RPC serialization, excessive object allocation, GC spikes, OOM, and UI jank) by switching to Protobuf/gRPC streaming, REAPI CAS/AC, and carefully scoped AIDL bindings.
- Provide a clear, phaseable migration path that enables dual-stack rollout, observability-first validation, and safe rollback without a full-system rip-and-replace.

### Description

- Add a detailed architecture/design document at `docs/architecture/reapi-grpc-aidl-build-service-refactor.md` that specifies a three-layer transport architecture (AIDL / gRPC / REAPI), component responsibilities, and interface drafts such as `IBuildGatewayService` and `BuildControlService`.
- Propose concrete new modules under `tooling` (`transport-contract`, `transport-grpc-client`, `transport-grpc-server`, `reapi-client`, `build-orchestrator`) and domain services in `core/project` and `core/app` (e.g., `ProjectBuildDomainService`, `BuildStateStore`, `BuildViewModelFacade`) to decouple UI, orchestration, and execution.
- Document REAPI usage patterns (Merkle input trees, Action Digest, AC/CAS hit-first semantics), gRPC semantics (operation_id, session_id, idempotency_key, streaming event bus), and AIDL guidelines (lightweight control messages, avoid large Parcels) to minimize Binder/IPC pressure.
- Provide extensive operational guidance including memory/object pooling, chunked log streaming, UI throttling/coalescing, session memory budgets, backpressure and priority queues, failover/local-exec fallback, observability metrics, security (mTLS and short-lived credentials), migration phases, risk mitigations, and quantifiable acceptance criteria.

### Testing

- No automated tests were run because this is a documentation-only change and does not modify runtime code or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ced3bda48328bbf2829c946481fa)