### PR TITLE
fix(chatai): use Kotlin Compose compiler plugin alias

### DIFF
--- a/core/chatai/app/build.gradle.kts
+++ b/core/chatai/app/build.gradle.kts
@@ -6,7 +6,7 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.org.jetbrains.kotlin.compose)
+    alias(libs.plugins.org.jetbrains.kotlin.plugin.compose)
     alias(libs.plugins.org.jetbrains.kotlin.plugin.serialization)
     alias(libs.plugins.com.google.devtools.ksp)
 }


### PR DESCRIPTION
### Motivation
- The `composeCompiler { ... }` DSL in `core/chatai/app/build.gradle.kts` failed to compile due to unresolved references (`composeCompiler` and `stabilityConfigurationFiles`), so the module needs the proper Kotlin Compose compiler plugin applied.

### Description
- Replace the applied plugin alias `org.jetbrains.compose` with the Kotlin compiler plugin alias `org.jetbrains.kotlin.plugin.compose` in `core/chatai/app/build.gradle.kts` so the `composeCompiler { ... }` block is recognized.

### Testing
- Ran `./gradlew :core:chatai:app:help --warning-mode all`, which now proceeds past the Gradle Kotlin DSL compile error but fails during dependency resolution for `com.mooltiverse.oss.nyx:gradle:2.5.2` (HTTP 403) in this environment, so the plugin fix itself validated but the build could not complete due to external repository access errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b17275eb0832899e58344a4c2c649)