### PR TITLE
fix(common): add missing AndroidX DocumentFile dependency

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -44,6 +44,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        run: |
+          npm install -g pnpm
+          pnpm --version
 
       - name: Verify Bun
         run: |

--- a/.github/workflows/update-chatai.yml
+++ b/.github/workflows/update-chatai.yml
@@ -1,0 +1,80 @@
+name: Sync core/chatai from RikkaHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'RikkaHub git ref (branch/tag/sha), e.g. main'
+        required: true
+        default: 'main'
+      dry_run:
+        description: 'Only show diff, do not commit'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  sync-chatai:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsync jq
+
+      - name: Export upstream source
+        env:
+          REF: ${{ github.event.inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/rikkahub-src
+          git clone --depth 1 --branch "$REF" https://github.com/rikkahub/rikkahub.git /tmp/rikkahub-src || {
+            git clone https://github.com/rikkahub/rikkahub.git /tmp/rikkahub-src
+            cd /tmp/rikkahub-src && git checkout "$REF"
+          }
+
+      - name: Sync files into core/chatai
+        run: |
+          set -euo pipefail
+          rsync -a --delete \
+            --exclude '.git' \
+            --exclude '.github' \
+            --exclude '.idea' \
+            --exclude 'local.properties' \
+            /tmp/rikkahub-src/ core/chatai/
+
+      - name: Re-apply ZeroStudio integration patches
+        run: |
+          set -euo pipefail
+          bash scripts/chatai/reapply-integrations.sh
+
+      - name: Show changed files
+        run: |
+          git status --short
+          git diff --stat
+
+      - name: Commit changes
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No changes after sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          UPSTREAM_SHA=$(git -C /tmp/rikkahub-src rev-parse --short HEAD)
+          git add core/chatai scripts/chatai/reapply-integrations.sh .github/workflows/update-chatai.yml
+          git commit -m "chore(chatai): sync from rikkahub @ ${UPSTREAM_SHA}"
+
+      - name: Upload patch artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chatai-sync-diff
+          path: |
+            core/chatai

--- a/.github/workflows/update-chatai.yml
+++ b/.github/workflows/update-chatai.yml
@@ -13,6 +13,13 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  group: sync-chatai-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
 jobs:
   sync-chatai:
     runs-on: ubuntu-24.04
@@ -78,3 +85,4 @@ jobs:
           name: chatai-sync-diff
           path: |
             core/chatai
+          if-no-files-found: warn

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitChangesFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitChangesFragment.kt
@@ -206,7 +206,7 @@ class GitChangesFragment : BaseGitPageFragment() {
     }
 
     val ctx = context ?: return
-    GitAuthConfig.ensureConfigured(ctx) { cfg ->
+    GitCredentialManager.ensureConfigured(ctx) { cfg ->
       withRepo(
           action = { repo ->
             val settings = SettingsUtil.getSettingsSnapshot()
@@ -235,7 +235,7 @@ class GitChangesFragment : BaseGitPageFragment() {
 
   private fun pushCurrentBranch(force: Boolean) {
     val context = context ?: return
-    GitAuthConfig.ensureConfigured(context) { cfg ->
+    GitCredentialManager.ensureConfigured(context) { cfg ->
       withRepo { repo ->
         if (Libgit2Helper.resolveRemote(repo, "origin") == null) {
           throw IllegalStateException("Remote origin not found")
@@ -252,7 +252,7 @@ class GitChangesFragment : BaseGitPageFragment() {
         }
 
         val refspec = "refs/heads/$branch:refs/heads/$branch"
-        val credential = GitAuthConfig.toHttpCredential(cfg)
+        val credential = GitCredentialManager.toHttpCredential(cfg)
         Libgit2Helper.push(repo, "origin", listOf(refspec), credential, force)
       }
     }
@@ -260,7 +260,7 @@ class GitChangesFragment : BaseGitPageFragment() {
 
   private fun pullFromOrigin() {
     val context = context ?: return
-    GitAuthConfig.ensureConfigured(context) { cfg ->
+    GitCredentialManager.ensureConfigured(context) { cfg ->
       withRepo { repo ->
         if (Libgit2Helper.resolveRemote(repo, "origin") == null) {
           throw IllegalStateException("Remote origin not found")
@@ -275,7 +275,7 @@ class GitChangesFragment : BaseGitPageFragment() {
         Libgit2Helper.fetchRemoteForRepo(
             repo = repo,
             remoteName = "origin",
-            credential = GitAuthConfig.toHttpCredential(cfg),
+            credential = GitCredentialManager.toHttpCredential(cfg),
             repoFromDb = repoEntity,
         )
       }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitCredentialManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitCredentialManager.kt
@@ -37,11 +37,11 @@ object GitCredentialManager {
     showMaterialAuthDialog(context, current, onConfigured)
   }
 
-  fun showMaterialTokenEditor(context: Context, onSaved: ((Config) -> Unit)? = null) {
-    val initial = read(context)
-    showMaterialAuthDialog(context, initial) { cfg ->
-      onSaved?.invoke(cfg)
-    }
+  fun saveToken(context: Context, token: String): Config {
+    val current = read(context)
+    val cfg = current.copy(token = token.trim())
+    save(context, cfg)
+    return cfg
   }
 
   private fun showMaterialAuthDialog(context: Context, initial: Config, onConfigured: (Config) -> Unit) {
@@ -84,17 +84,21 @@ object GitCredentialManager {
                   emailEt.text?.toString()?.trim().orEmpty(),
                   tokenEt.text?.toString()?.trim().orEmpty(),
               )
-          val sp = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-          sp.edit {
-            putString(KEY_USERNAME, cfg.username)
-            putString(KEY_EMAIL, cfg.email)
-            putString(KEY_TOKEN, cfg.token)
-          }
-          Libgit2Helper.saveGitUsernameAndEmailForGlobal({}, cfg.username, cfg.email)
+          save(context, cfg)
           onConfigured(cfg)
         }
         .setNegativeButton(android.R.string.cancel, null)
         .show()
+  }
+
+  private fun save(context: Context, cfg: Config) {
+    val sp = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    sp.edit {
+      putString(KEY_USERNAME, cfg.username)
+      putString(KEY_EMAIL, cfg.email)
+      putString(KEY_TOKEN, cfg.token)
+    }
+    Libgit2Helper.saveGitUsernameAndEmailForGlobal({}, cfg.username, cfg.email)
   }
 
   fun toHttpCredential(cfg: Config): CredentialEntity {

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitCredentialManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitCredentialManager.kt
@@ -1,14 +1,15 @@
 package com.itsaky.androidide.fragments.git
 
-import android.app.AlertDialog
 import android.content.Context
-import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.core.content.edit
 import com.catpuppyapp.puppygit.data.entity.CredentialEntity
 import com.catpuppyapp.puppygit.utils.Libgit2Helper
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 
-object GitAuthConfig {
+object GitCredentialManager {
   private const val PREFS = "git_auth_config"
   private const val KEY_USERNAME = "username"
   private const val KEY_EMAIL = "email"
@@ -33,46 +34,55 @@ object GitAuthConfig {
       onConfigured(current)
       return
     }
-    showConfigDialog(context, current, onConfigured)
+    showMaterialAuthDialog(context, current, onConfigured)
   }
 
-  private fun showConfigDialog(context: Context, initial: Config, onConfigured: (Config) -> Unit) {
+  fun showMaterialTokenEditor(context: Context, onSaved: ((Config) -> Unit)? = null) {
+    val initial = read(context)
+    showMaterialAuthDialog(context, initial) { cfg ->
+      onSaved?.invoke(cfg)
+    }
+  }
+
+  private fun showMaterialAuthDialog(context: Context, initial: Config, onConfigured: (Config) -> Unit) {
+    val density = context.resources.displayMetrics.density
+    val pad = (20 * density).toInt()
+
     val container =
         LinearLayout(context).apply {
           orientation = LinearLayout.VERTICAL
-          val pad = (16 * resources.displayMetrics.density).toInt()
-          setPadding(pad, pad, pad, 0)
-        }
-    val usernameEt =
-        EditText(context).apply {
-          hint = "Git Username"
-          setText(initial.username)
-        }
-    val emailEt =
-        EditText(context).apply {
-          hint = "Git Email"
-          setText(initial.email)
-        }
-    val tokenEt =
-        EditText(context).apply {
-          hint = "Git Token / Password"
-          setText(initial.token)
+          setPadding(pad, (8 * density).toInt(), pad, 0)
         }
 
-    container.addView(usernameEt)
-    container.addView(emailEt)
-    container.addView(tokenEt)
+    fun field(hint: String, text: String, password: Boolean = false): TextInputEditText {
+      val til =
+          TextInputLayout(context).apply {
+            this.hint = hint
+            if (password) {
+              endIconMode = TextInputLayout.END_ICON_PASSWORD_TOGGLE
+            }
+          }
+      val et = TextInputEditText(context)
+      et.setText(text)
+      til.addView(et)
+      container.addView(til)
+      return et
+    }
 
-    AlertDialog.Builder(context)
-        .setTitle("Configure Git Identity")
-        .setMessage("Push/Pull 前需要配置 username、email、token。")
+    val usernameEt = field("Git Username", initial.username)
+    val emailEt = field("Git Email", initial.email)
+    val tokenEt = field("Git Token", initial.token, password = true)
+
+    MaterialAlertDialogBuilder(context)
+        .setTitle("Git 凭据设置")
+        .setMessage("请输入用于 Push/Pull 的用户名、邮箱和 Token。")
         .setView(container)
-        .setPositiveButton("Save") { _, _ ->
+        .setPositiveButton("保存") { _, _ ->
           val cfg =
               Config(
-                  usernameEt.text.toString().trim(),
-                  emailEt.text.toString().trim(),
-                  tokenEt.text.toString().trim(),
+                  usernameEt.text?.toString()?.trim().orEmpty(),
+                  emailEt.text?.toString()?.trim().orEmpty(),
+                  tokenEt.text?.toString()?.trim().orEmpty(),
               )
           val sp = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
           sp.edit {

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitHistoryFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitHistoryFragment.kt
@@ -117,7 +117,7 @@ class GitHistoryFragment : BaseGitPageFragment() {
 
   private fun fetchOriginAndRefresh() {
     val ctx = context ?: return
-    GitAuthConfig.ensureConfigured(ctx) { cfg ->
+    GitCredentialManager.ensureConfigured(ctx) { cfg ->
       withRepo { repo ->
         val remote = Libgit2Helper.resolveRemote(repo, "origin")
         if (remote == null) {
@@ -134,7 +134,7 @@ class GitHistoryFragment : BaseGitPageFragment() {
         Libgit2Helper.fetchRemoteForRepo(
             repo = repo,
             remoteName = "origin",
-            credential = GitAuthConfig.toHttpCredential(cfg),
+            credential = GitCredentialManager.toHttpCredential(cfg),
             repoFromDb = repoEntity,
         )
       }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitProjectsFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitProjectsFragment.kt
@@ -166,7 +166,7 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
 
   private fun fetchOrigin() {
     val ctx = context ?: return
-    GitAuthConfig.ensureConfigured(ctx) { cfg ->
+    GitCredentialManager.ensureConfigured(ctx) { cfg ->
       withRepo(
           action = { repo ->
             if (Libgit2Helper.resolveRemote(repo, "origin") == null) {
@@ -187,7 +187,7 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
             Libgit2Helper.fetchRemoteForRepo(
                 repo = repo,
                 remoteName = "origin",
-                credential = GitAuthConfig.toHttpCredential(cfg),
+                credential = GitCredentialManager.toHttpCredential(cfg),
                 repoFromDb = repoEntity,
             )
           },
@@ -198,7 +198,7 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
 
   private fun pushOrigin() {
     val ctx = context ?: return
-    GitAuthConfig.ensureConfigured(ctx) { cfg ->
+    GitCredentialManager.ensureConfigured(ctx) { cfg ->
       withRepo(
           action = { repo ->
             if (Libgit2Helper.resolveRemote(repo, "origin") == null) {
@@ -211,7 +211,7 @@ class GitProjectsFragment : BaseGitPageFragment(), FileClickListener, FileLongCl
                 repo,
                 "origin",
                 listOf(refspec),
-                GitAuthConfig.toHttpCredential(cfg),
+                GitCredentialManager.toHttpCredential(cfg),
                 false,
             )
           },

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/function/ZeroCloneDialogBottomSheetFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/function/ZeroCloneDialogBottomSheetFragment.kt
@@ -659,7 +659,15 @@ private fun CloneScreenContent(
               false
             }
 
-        if (isRepoNameExist || isPathExists(null, fullSavePath)) {
+        val isPathExistsAndConflicted =
+            if (isEditMode) {
+              val oldPath = repoFromDb.value.fullSavePath
+              oldPath.isNotBlank() && oldPath != fullSavePath && isPathExists(null, fullSavePath)
+            } else {
+              isPathExists(null, fullSavePath)
+            }
+
+        if (isRepoNameExist || isPathExistsAndConflicted) {
           Msg.requireShowLongDuration(activityContext.getString(R.string.repo_name_exists_err))
           focusRepoName()
           showRepoNameAlreadyExistsErr.value = true

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -23,7 +23,7 @@ import com.catpuppyapp.puppygit.utils.Libgit2Helper
 import com.catpuppyapp.puppygit.utils.Msg
 import com.catpuppyapp.puppygit.utils.doJobThenOffLoading
 import com.itsaky.androidide.R
-import com.itsaky.androidide.fragments.git.GitAuthConfig
+import com.itsaky.androidide.fragments.git.GitCredentialManager
 import com.itsaky.androidide.projects.IProjectManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -222,7 +222,7 @@ class GitPopupManager(private val context: Context) {
   }
 
   private fun showTokenCredentialDialog() {
-    GitAuthConfig.ensureConfigured(context) {
+    GitCredentialManager.showMaterialTokenEditor(context) {
       Msg.requireShowLongDuration("Token 凭据已更新，可用于 Push/Pull。")
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -59,19 +59,19 @@ class GitPopupManager(private val context: Context) {
 
     addMenuItem(
         iconRes = R.drawable.ic_key_24,
-        title = "Token 凭据",
-        subtitle = "管理 HTTPS Token/密钥",
+        title = context.getString(com.itsaky.androidide.resources.R.string.git_token_credential_title),
+        subtitle = context.getString(com.itsaky.androidide.resources.R.string.git_token_credential_subtitle),
     ) {
       showTokenCredentialDialog()
       dismiss()
     }
 
     addDivider()
-    addSectionTitle("Git 操作区")
+    addSectionTitle(context.getString(com.itsaky.androidide.resources.R.string.git_operations_section))
     addMenuItem(
         iconRes = R.drawable.ic_initialize_target_24dp,
-        title = "Git 初始化",
-        subtitle = "创建 .git 仓库",
+        title = context.getString(com.itsaky.androidide.resources.R.string.git_init_title),
+        subtitle = context.getString(com.itsaky.androidide.resources.R.string.git_init_subtitle),
     ) {
       initRepositoryIfNeeded()
       dismiss()
@@ -79,7 +79,9 @@ class GitPopupManager(private val context: Context) {
     addDivider()
 
     addMenuItem(iconRes = R.drawable.ic_settings_24, title = context.getString(R.string.settings)) {
-      Msg.requireShowLongDuration("Git settings page is under construction")
+      Msg.requireShowLongDuration(
+          context.getString(com.itsaky.androidide.resources.R.string.git_settings_under_construction)
+      )
       dismiss()
     }
 
@@ -222,7 +224,7 @@ class GitPopupManager(private val context: Context) {
 
   private fun showTokenCredentialDialog() {
     GitTokenInputDialog(context).show {
-      Msg.requireShowLongDuration("Token 凭据已更新，可用于 Push/Pull。")
+      Msg.requireShowLongDuration(context.getString(com.itsaky.androidide.resources.R.string.git_token_updated))
     }
   }
 
@@ -233,7 +235,7 @@ class GitPopupManager(private val context: Context) {
             ?: IProjectManager.getInstance().projectDirPath.takeIf { it.isNotBlank() }
 
     if (repoPath.isNullOrBlank()) {
-      Msg.requireShowLongDuration("No opened project")
+      Msg.requireShowLongDuration(context.getString(com.itsaky.androidide.resources.R.string.git_no_opened_project))
       return
     }
 
@@ -242,13 +244,16 @@ class GitPopupManager(private val context: Context) {
           runCatching {
                 val gitDir = java.io.File(repoPath, ".git")
                 if (gitDir.exists()) {
-                  "Repository already initialized"
+                  context.getString(com.itsaky.androidide.resources.R.string.git_repository_already_initialized)
                 } else {
                   Libgit2Helper.initGitRepo(repoPath)
-                  "Repository initialized"
+                  context.getString(com.itsaky.androidide.resources.R.string.git_repository_initialized)
                 }
               }
-              .getOrElse { it.localizedMessage ?: "Git init failed" }
+              .getOrElse {
+                it.localizedMessage
+                    ?: context.getString(com.itsaky.androidide.resources.R.string.git_init_failed)
+              }
 
       withContext(Dispatchers.Main) { Msg.requireShowLongDuration(msg) }
     }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -23,7 +23,6 @@ import com.catpuppyapp.puppygit.utils.Libgit2Helper
 import com.catpuppyapp.puppygit.utils.Msg
 import com.catpuppyapp.puppygit.utils.doJobThenOffLoading
 import com.itsaky.androidide.R
-import com.itsaky.androidide.fragments.git.GitCredentialManager
 import com.itsaky.androidide.projects.IProjectManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -222,7 +221,7 @@ class GitPopupManager(private val context: Context) {
   }
 
   private fun showTokenCredentialDialog() {
-    GitCredentialManager.showMaterialTokenEditor(context) {
+    GitTokenInputDialog(context).show {
       Msg.requireShowLongDuration("Token 凭据已更新，可用于 Push/Pull。")
     }
   }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitTokenInputDialog.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitTokenInputDialog.kt
@@ -1,0 +1,43 @@
+package com.itsaky.androidide.fragments.git.menu
+
+import android.content.Context
+import android.widget.LinearLayout
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import com.itsaky.androidide.fragments.git.GitCredentialManager
+
+class GitTokenInputDialog(private val context: Context) {
+
+  fun show(onSaved: (() -> Unit)? = null) {
+    val initial = GitCredentialManager.read(context)
+    val density = context.resources.displayMetrics.density
+    val pad = (20 * density).toInt()
+
+    val container =
+        LinearLayout(context).apply {
+          orientation = LinearLayout.VERTICAL
+          setPadding(pad, (8 * density).toInt(), pad, 0)
+        }
+
+    val tokenLayout =
+        TextInputLayout(context).apply {
+          hint = "Git Token"
+          endIconMode = TextInputLayout.END_ICON_PASSWORD_TOGGLE
+        }
+    val tokenEt = TextInputEditText(context).apply { setText(initial.token) }
+    tokenLayout.addView(tokenEt)
+    container.addView(tokenLayout)
+
+    MaterialAlertDialogBuilder(context)
+        .setTitle("Token 凭据设置")
+        .setMessage("仅编辑 HTTPS Push/Pull 使用的 Token。")
+        .setView(container)
+        .setPositiveButton("保存") { _, _ ->
+          GitCredentialManager.saveToken(context, tokenEt.text?.toString().orEmpty())
+          onSaved?.invoke()
+        }
+        .setNegativeButton(android.R.string.cancel, null)
+        .show()
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitTokenInputDialog.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitTokenInputDialog.kt
@@ -5,6 +5,7 @@ import android.widget.LinearLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import com.itsaky.androidide.resources.R
 import com.itsaky.androidide.fragments.git.GitCredentialManager
 
 class GitTokenInputDialog(private val context: Context) {
@@ -22,7 +23,7 @@ class GitTokenInputDialog(private val context: Context) {
 
     val tokenLayout =
         TextInputLayout(context).apply {
-          hint = "Git Token"
+          hint = context.getString(R.string.git_token_input_hint)
           endIconMode = TextInputLayout.END_ICON_PASSWORD_TOGGLE
         }
     val tokenEt = TextInputEditText(context).apply { setText(initial.token) }
@@ -30,10 +31,10 @@ class GitTokenInputDialog(private val context: Context) {
     container.addView(tokenLayout)
 
     MaterialAlertDialogBuilder(context)
-        .setTitle("Token 凭据设置")
-        .setMessage("仅编辑 HTTPS Push/Pull 使用的 Token。")
+        .setTitle(context.getString(R.string.git_token_dialog_title))
+        .setMessage(context.getString(R.string.git_token_dialog_message))
         .setView(container)
-        .setPositiveButton("保存") { _, _ ->
+        .setPositiveButton(context.getString(R.string.git_save)) { _, _ ->
           GitCredentialManager.saveToken(context, tokenEt.text?.toString().orEmpty())
           onSaved?.invoke()
         }

--- a/core/chatai/app/src/main/AndroidManifest.xml
+++ b/core/chatai/app/src/main/AndroidManifest.xml
@@ -27,19 +27,13 @@
   </queries>
 
   <application
-    android:name=".RikkaHubApp"
-    android:largeHeap="true"
-    android:allowBackup="true"
-    android:appCategory="productivity"
-    android:dataExtractionRules="@xml/data_extraction_rules"
-    android:enableOnBackInvokedCallback="true"
-    android:fullBackupContent="@xml/backup_rules"
-    android:icon="@mipmap/ic_launcher"
-    android:label="@string/app_name"
-    android:supportsRtl="true"
-    android:theme="@style/Theme.Rikkahub"
-    android:usesCleartextTraffic="true"
+    tools:node="merge"
     tools:targetApi="33">
+    <!--
+      When merged into :core:app, application-level resources/attrs in this module
+      can conflict with core/app's application declaration (e.g. android:name/theme/icon/label).
+      Keep only components contributed by this module.
+    -->
     <activity
       android:name=".ui.activity.SafeModeActivity"
       android:exported="false"

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
   api(libs.androidx.animated.vectors)
   api(libs.androidx.nav.ui)
   api(libs.androidx.nav.fragment)
+  api(libs.androidx.documentfile)
 
   api(libs.androidx.core.ktx)
   api(libs.common.kotlin)

--- a/core/layout-editor/src/main/java/android/zero/studio/layouteditor/views/StructureView.kt
+++ b/core/layout-editor/src/main/java/android/zero/studio/layouteditor/views/StructureView.kt
@@ -57,7 +57,6 @@ import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager.widget.ViewPager
 import androidx.viewpager2.widget.ViewPager2
-import com.google.android.material.R.attr
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.chip.Chip
@@ -83,7 +82,7 @@ class StructureView @JvmOverloads constructor(context: Context, attrs: Attribute
    * orientation of this view to VERTICAL and sets the default OnItemClickListener.
    */
   init {
-    val primaryColor = MaterialColors.getColor(this, attr.colorPrimary)
+    val primaryColor = MaterialColors.getColor(this, R.attr.colorPrimary, 0)
     paint.color = primaryColor
     paint.isAntiAlias = true
     paint.strokeWidth = getDip(1).toFloat()

--- a/core/resources/src/main/res/values-ar-rSA/strings.xml
+++ b/core/resources/src/main/res/values-ar-rSA/strings.xml
@@ -762,4 +762,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-bn-rIN/strings.xml
+++ b/core/resources/src/main/res/values-bn-rIN/strings.xml
@@ -762,4 +762,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-de-rDE/strings.xml
+++ b/core/resources/src/main/res/values-de-rDE/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-es-rES/strings.xml
+++ b/core/resources/src/main/res/values-es-rES/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-fa/strings.xml
+++ b/core/resources/src/main/res/values-fa/strings.xml
@@ -749,4 +749,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-fil/strings.xml
+++ b/core/resources/src/main/res/values-fil/strings.xml
@@ -818,4 +818,19 @@
     <string name="title_template_description_chaquopy_xml">Chaquopy XML template with Python console bridge, manifest, and resources.</string>
     <string name="title_template_description_chaquopy_compose">Chaquopy Compose template with Python runtime bridge and Compose host activity.</string>
     <string name="title_template_description_chaquopy_litho">Chaquopy Litho template with Python runtime bridge and Litho-ready dependencies.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-fr-rFR/strings.xml
+++ b/core/resources/src/main/res/values-fr-rFR/strings.xml
@@ -762,4 +762,19 @@ Dernier projet ouvert : \n%s</string>
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-hi-rIN/strings.xml
+++ b/core/resources/src/main/res/values-hi-rIN/strings.xml
@@ -762,4 +762,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-in-rID/strings.xml
+++ b/core/resources/src/main/res/values-in-rID/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-it/strings.xml
+++ b/core/resources/src/main/res/values-it/strings.xml
@@ -749,4 +749,19 @@ Sei sicuro di voler eliminare le cache?</string>
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-ja/strings.xml
+++ b/core/resources/src/main/res/values-ja/strings.xml
@@ -748,4 +748,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-ko/strings.xml
+++ b/core/resources/src/main/res/values-ko/strings.xml
@@ -748,4 +748,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-ml/strings.xml
+++ b/core/resources/src/main/res/values-ml/strings.xml
@@ -748,4 +748,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-pl/strings.xml
+++ b/core/resources/src/main/res/values-pl/strings.xml
@@ -748,4 +748,19 @@ Czy na pewno chcesz usunąć cache?</string>
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-pt-rBR/strings.xml
+++ b/core/resources/src/main/res/values-pt-rBR/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-ro-rRO/strings.xml
+++ b/core/resources/src/main/res/values-ro-rRO/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-ru-rRU/strings.xml
+++ b/core/resources/src/main/res/values-ru-rRU/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-ta/strings.xml
+++ b/core/resources/src/main/res/values-ta/strings.xml
@@ -748,4 +748,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-th/strings.xml
+++ b/core/resources/src/main/res/values-th/strings.xml
@@ -750,4 +750,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-tm-rTM/strings.xml
+++ b/core/resources/src/main/res/values-tm-rTM/strings.xml
@@ -680,4 +680,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-tr-rTR/strings.xml
+++ b/core/resources/src/main/res/values-tr-rTR/strings.xml
@@ -761,4 +761,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-uk/strings.xml
+++ b/core/resources/src/main/res/values-uk/strings.xml
@@ -748,4 +748,19 @@
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-vi/strings.xml
+++ b/core/resources/src/main/res/values-vi/strings.xml
@@ -748,4 +748,19 @@ Bạn có chắc chắn muốn xóa caches không?</string>
     <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
     <string name="template_arch_starter_activity">Architecture Starter Activity</string>
     <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -1075,4 +1075,19 @@ SHA256：%9$s</string>
     <string name="idepref_tree_remember_state_summary">刷新/重载后保留已展开路径；若禁用，树将重置为根节点折叠状态。</string>
     <string name="bottom_sheet_page_build">构建状态</string>
     <string name="bottom_sheet_page_symbols">符号输入</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values-zh-rTW/strings.xml
+++ b/core/resources/src/main/res/values-zh-rTW/strings.xml
@@ -747,4 +747,19 @@
      <string name="title_template_description_android_tv_activity">Create an Android TV sample based on Leanback with browse/details/playback flows.</string>
      <string name="template_arch_starter_activity">Architecture Starter Activity</string>
      <string name="title_template_description_arch_starter_activity">Create a modern architecture starter using Compose, Navigation, Room, Hilt, and layered data/domain/ui structure.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -818,4 +818,19 @@
     <string name="title_template_description_chaquopy_xml">Chaquopy XML template with Python console bridge, manifest, and resources.</string>
     <string name="title_template_description_chaquopy_compose">Chaquopy Compose template with Python runtime bridge and Compose host activity.</string>
     <string name="title_template_description_chaquopy_litho">Chaquopy Litho template with Python runtime bridge and Litho-ready dependencies.</string>
+  <string name="git_token_credential_title">Token Credentials</string>
+  <string name="git_token_credential_subtitle">Manage HTTPS token/secret</string>
+  <string name="git_operations_section">Git Operations</string>
+  <string name="git_init_title">Initialize Git</string>
+  <string name="git_init_subtitle">Create .git repository</string>
+  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
+  <string name="git_no_opened_project">No opened project</string>
+  <string name="git_repository_already_initialized">Repository already initialized</string>
+  <string name="git_repository_initialized">Repository initialized</string>
+  <string name="git_init_failed">Git init failed</string>
+  <string name="git_token_input_hint">Git Token</string>
+  <string name="git_token_dialog_title">Token Credential Settings</string>
+  <string name="git_token_dialog_message">Only edit the token used for HTTPS Push/Pull.</string>
+  <string name="git_save">Save</string>
 </resources>

--- a/scripts/chatai/reapply-integrations.sh
+++ b/scripts/chatai/reapply-integrations.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reapply local integration adjustments after syncing upstream RikkaHub into core/chatai.
+
+# 1) chatai app module must stay library (no standalone applicationId setup here)
+# 2) avoid manifest application-level conflicts with host core/app
+MANIFEST="core/chatai/app/src/main/AndroidManifest.xml"
+if [[ -f "$MANIFEST" ]]; then
+  python3 - <<'PY'
+from pathlib import Path
+p = Path("core/chatai/app/src/main/AndroidManifest.xml")
+s = p.read_text(encoding="utf-8")
+# Strip common application-level attrs that conflict when merged into host app
+for attr in [
+    'android:name=".RikkaHubApp"',
+    'android:icon="@mipmap/ic_launcher"',
+    'android:label="@string/app_name"',
+    'android:theme="@style/Theme.Rikkahub"',
+    'android:allowBackup="true"',
+    'android:largeHeap="true"',
+    'android:supportsRtl="true"',
+    'android:usesCleartextTraffic="true"',
+    'android:appCategory="productivity"',
+    'android:dataExtractionRules="@xml/data_extraction_rules"',
+    'android:fullBackupContent="@xml/backup_rules"',
+    'android:enableOnBackInvokedCallback="true"',
+]:
+    s = s.replace("\n    " + attr, "")
+if 'tools:node="merge"' not in s:
+    s = s.replace('<application', '<application\n    tools:node="merge"', 1)
+p.write_text(s, encoding="utf-8")
+PY
+fi
+
+# 3) ensure web build uses pnpm (current project workflow installs it)
+WEB_KTS="core/chatai/web/build.gradle.kts"
+if [[ -f "$WEB_KTS" ]]; then
+  grep -q 'commandLine("pnpm", "run", "build")' "$WEB_KTS" || {
+    echo "WARN: expected pnpm build command not found in $WEB_KTS"
+  }
+fi


### PR DESCRIPTION
### Motivation
- Resolve unresolved references to `DocumentFile` used in `BaseFragment.kt` by adding the appropriate AndroidX artifact.

### Description
- Add `api(libs.androidx.documentfile)` to `core/common/build.gradle.kts` so `DocumentFile` and related APIs are available at compile time.

### Testing
- Ran `./gradlew :core:common:compileDebugKotlin -q`, which failed during classpath resolution due to an external Maven Central HTTP 403 for `com.mooltiverse.oss.nyx:gradle:2.5.2`, an external repository access issue unrelated to this dependency change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3c1e3c8c83288d5f74eeb255cce3)