### PR TITLE
Fix layout-editor compile error and switch Git auth dialog to global identity API

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitAuthConfig.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitAuthConfig.kt
@@ -10,8 +10,6 @@ import com.catpuppyapp.puppygit.utils.Libgit2Helper
 
 object GitAuthConfig {
   private const val PREFS = "git_auth_config"
-  private const val KEY_USERNAME = "username"
-  private const val KEY_EMAIL = "email"
   private const val KEY_TOKEN = "token"
 
   data class Config(val username: String, val email: String, val token: String) {
@@ -19,10 +17,11 @@ object GitAuthConfig {
   }
 
   fun read(context: Context): Config {
+    val (globalUsername, globalEmail) = Libgit2Helper.getGitUsernameAndEmailFromGlobalConfig()
     val sp = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
     return Config(
-        username = sp.getString(KEY_USERNAME, "").orEmpty(),
-        email = sp.getString(KEY_EMAIL, "").orEmpty(),
+        username = globalUsername,
+        email = globalEmail,
         token = sp.getString(KEY_TOKEN, "").orEmpty(),
     )
   }
@@ -74,13 +73,11 @@ object GitAuthConfig {
                   emailEt.text.toString().trim(),
                   tokenEt.text.toString().trim(),
               )
+          Libgit2Helper.saveGitUsernameAndEmailForGlobal({}, cfg.username, cfg.email)
           val sp = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
           sp.edit {
-            putString(KEY_USERNAME, cfg.username)
-            putString(KEY_EMAIL, cfg.email)
             putString(KEY_TOKEN, cfg.token)
           }
-          Libgit2Helper.saveGitUsernameAndEmailForGlobal({}, cfg.username, cfg.email)
           onConfigured(cfg)
         }
         .setNegativeButton(android.R.string.cancel, null)

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
   api(libs.androidx.appcompat)
   api(libs.androidx.collection)
   api(libs.androidx.preference)
+  api(libs.androidx.documentfile)
   api(libs.androidx.vectors)
   api(libs.androidx.animated.vectors)
   api(libs.androidx.nav.ui)

--- a/core/layout-editor/src/main/java/android/zero/studio/layouteditor/utils/Utils.java
+++ b/core/layout-editor/src/main/java/android/zero/studio/layouteditor/utils/Utils.java
@@ -20,9 +20,8 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
-import com.google.android.material.R;
 import com.google.android.material.color.MaterialColors;
-import android.zero.studio.layouteditor.R.string;
+import android.zero.studio.layouteditor.R;
 import android.zero.studio.layouteditor.vectormaster.VectorMasterDrawable;
 
 import java.io.File;
@@ -99,14 +98,14 @@ public class Utils {
         // Get the directory for the user's public pictures directory.
         File path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
         // Create a new directory for your app
-        File appDir = new File(path, context.getString(string.app_name));
+        File appDir = new File(path, context.getString(R.string.app_name));
         if (!appDir.exists()) {
             appDir.mkdir();
         }
 
         // Generate a unique file name for your image
         String fileName =
-            context.getString(string.app_name).concat(" ").concat(title).concat(" ")
+            context.getString(R.string.app_name).concat(" ").concat(title).concat(" ")
                 + new Date().getTime()
                 + ".jpg";
         fileName = fileName.replaceAll(" ", "_").toLowerCase(Locale.getDefault());
@@ -132,7 +131,7 @@ public class Utils {
             values.put(MediaStore.Images.Media.DISPLAY_NAME, fileName);
             values.put(
                 MediaStore.Images.Media.DESCRIPTION,
-                "Image saved from ".concat(context.getString(string.app_name)));
+                "Image saved from ".concat(context.getString(R.string.app_name)));
             values.put(MediaStore.Images.Media.DATE_ADDED, System.currentTimeMillis());
             values.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
             values.put(MediaStore.Images.Media.ORIENTATION, 0);


### PR DESCRIPTION
### Motivation
- Fix a compile-time error in `core/layout-editor` where theme attribute lookups used the wrong `R` import causing `cannot find symbol: colorPrimary` during `javac`.
- Ensure Git username/email are sourced and persisted globally so all Git UI pages in `com/itsaky/androidide/fragments/git` see the same identity instead of relying on local duplicate storage.

### Description
- In `core/layout-editor/src/main/java/android/zero/studio/layouteditor/utils/Utils.java` removed the `com.google.android.material.R` import and imported the module `R`, and updated resource references to use `R.string` so theme attrs and `app_name` lookups resolve against the correct `R` class.
- In `core/app/src/main/java/com/itsaky/androidide/fragments/git/GitAuthConfig.kt` changed `read()` to fetch username/email from `Libgit2Helper.getGitUsernameAndEmailFromGlobalConfig()` and updated the save flow to call `Libgit2Helper.saveGitUsernameAndEmailForGlobal(...)`, removing the previous local `SharedPreferences` storage of username/email while keeping token storage local.
- Cleaned up an unused import and adjusted the dialog save order so global identity is persisted when the user saves the Git identity dialog.

### Testing
- Attempted `./gradlew :core:layout-editor:compileDebugJavaWithJavac -q`, but the build could not complete due to external dependency resolution failure for `com.mooltiverse.oss.nyx:gradle:2.5.2` (HTTP 403 from Maven Central), so compile validation is blocked in this environment.
- No additional automated tests were run in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b54c20db4832f920901ce35475a88)