### PR TITLE
Fix SLF4J provider conflict causing IDE log crash

### DIFF
--- a/core/chatai/app/build.gradle.kts
+++ b/core/chatai/app/build.gradle.kts
@@ -271,9 +271,11 @@ dependencies {
     // jmDNS (mDNS/Bonjour for .local hostname)
     implementation(libs.jmdns)
 
-    // SLF4J Android binding — routes Ktor/SLF4J logs to logcat
+    // Use only the SLF4J API here. The host app provides the single runtime SLF4J
+    // provider (logback-classic via :logging:logger). Adding another provider such as
+    // uk.uuid.slf4j:slf4j-android makes SLF4J choose that factory at runtime and
+    // breaks IDELogFragment, which attaches a Logback appender to the root logger.
     implementation(libs.tooling.slf4j)
-    implementation(libs.slf4j.android.uuid)
 
     // sqlite-android (requery SQLite for Android)
     implementation(libs.sqlite.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -523,7 +523,6 @@ haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
 haze-materials = { module = "dev.chrisbanes.haze:haze-materials", version.ref = "haze" }
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 slf4j-android = { module = "org.slf4j:slf4j-android", version.ref = "slf4j-android" }
-slf4j-android-uuid = { module = "uk.uuid.slf4j:slf4j-android", version = "2.0.17-0" }
 sqlite-android = { module = "com.github.rikkahub:sqlite-android", version.ref = "sqlite-android" }
 sqlite-vector = { module = "ai.sqlite:vector", version.ref = "sqlite-vector" }
 floatingx = { module = "io.github.petterpx:floatingx", version.ref = "floatingx" }


### PR DESCRIPTION
### Motivation

- The IDE crashed with a `ClassCastException` because `LoggerFactory.getILoggerFactory()` could return the `uk.uuid.slf4j` runtime binding instead of Logback's `LoggerContext`, breaking code that casts to `ch.qos.logback.classic.LoggerContext` in `IDELogFragment`.

### Description

- Remove the runtime SLF4J provider `uk.uuid.slf4j:slf4j-android` from `core/chatai/app/build.gradle.kts` and add a comment explaining the provider conflict and why ChatAI should only depend on the SLF4J API.
- Delete the now-unused `slf4j-android-uuid` entry from `gradle/libs.versions.toml` so the version catalog no longer exposes that provider alias.
- Preserve the SLF4J API dependency (`implementation(libs.tooling.slf4j)`) so ChatAI code still compiles while allowing the host app to supply the single Logback runtime.

### Testing

- Ran `git diff --check` to validate workspace diffs and it reported no issues.
- Searched the tree with `rg` for uses of the removed provider and the version-catalog alias and found no remaining references.
- Attempted `ZEROSTUDIO_SKIP_NYX=true ./gradlew :core:app:dependencyInsight --configuration debugRuntimeClasspath --dependency uk.uuid.slf4j:slf4j-android` to verify the runtime classpath, but Gradle plugin resolution failed in this environment (unrelated `org.jetbrains.kotlin.jvm` resolution error), so full dependency-graph verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bac5e99d08331b64debf67c9cbdec)