### PR TITLE
Fix templates-impl API symbol mismatches for Android Studio templates

### DIFF
--- a/utilities/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/TemplateProviderImpl.kt
+++ b/utilities/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/TemplateProviderImpl.kt
@@ -23,8 +23,8 @@ import com.itsaky.androidide.templates.Template
 import com.itsaky.androidide.templates.TemplateCategory
 import com.itsaky.androidide.templates.impl.basicActivity.basicActivityProject
 import com.itsaky.androidide.templates.impl.androidstudio.activity.aiGlassesActivity.aiGlassesActivityProject
-import com.itsaky.androidide.templates.impl.androidstudio.activity.aiStarter.aiStarterActivityProject
-import com.itsaky.androidide.templates.impl.androidstudio.activity.androidTVActivity.androidTVActivityProject
+import com.itsaky.androidide.templates.impl.androidstudio.activity.aiStarter.aiStarterTemplate
+import com.itsaky.androidide.templates.impl.androidstudio.activity.androidTVActivity.androidTVActivityTemplate
 import com.itsaky.androidide.templates.impl.androidstudio.activity.archStarterActivity.archStarterActivityProject
 import com.itsaky.androidide.templates.impl.androidstudio.activity.basicActivity.basicActivityProjectAndroidStudio
 import com.itsaky.androidide.templates.impl.basicCpp.basicCppProject
@@ -133,12 +133,12 @@ class TemplateProviderImpl : ITemplateProvider {
     registerSubCategoryTemplate(
         TemplateCategory.Mobile,
         AndroidStudioSubCategories.MobileAI,
-        aiStarterActivityProject(),
+        aiStarterTemplate,
     )
     // Android Studio template：XR 👓
     registerTemplate(TemplateCategory.XR, aiGlassesActivityProject())
     // Android Studio template：television 📺
-    registerTemplate(TemplateCategory.Tv, androidTVActivityProject())
+    registerTemplate(TemplateCategory.Tv, androidTVActivityTemplate)
     
     //Hybrid dev language Frameworks
     registerTemplate(TemplateCategory.HybridFrameworks, chaquopyXmlDemoProject())

--- a/utilities/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/androidstudio/activity/aiGlassesActivity/aiGlassesActivityRecipe.kt
+++ b/utilities/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/androidstudio/activity/aiGlassesActivity/aiGlassesActivityRecipe.kt
@@ -18,11 +18,11 @@ import com.itsaky.androidide.templates.impl.base.createRecipe
 internal fun AndroidModuleTemplateBuilder.aiGlassesActivityRecipe() = createRecipe {
   executor.apply {
     addDependency(Dependency.AndroidX.Core_Ktx)
-    addDependency(Dependency.AndroidX.Activity)
-    addDependency(Dependency.AndroidX.Activity_Compose)
-    addDependency(Dependency.AndroidX.Lifecycle_Runtime_Ktx)
-    addDependency(Dependency.AndroidX.Lifecycle_Runtime_Compose)
-    addDependency(Dependency.AndroidX.Lifecycle_ViewModel_Compose)
+    addDependency(parseDependency("androidx.activity:activity:1.11.0", tomlAlias = "androidx-activity"))
+    addDependency(Dependency.AndroidX.Compose.Activity)
+    addDependency(Dependency.AndroidX.Compose.LifeCycle_Runtime_Ktx)
+    addDependency(parseDependency("androidx.lifecycle:lifecycle-runtime-compose:2.9.2", tomlAlias = "androidx-lifecycle-runtime-compose"))
+    addDependency(parseDependency("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.2", tomlAlias = "androidx-lifecycle-viewmodel-compose"))
     addDependency(Dependency.AndroidX.Compose.Material3)
     addDependency(parseDependency("androidx.xr.glimmer:glimmer:1.0.0-alpha02", tomlAlias = "androidx-xr-glimmer"))
     addDependency(parseDependency("androidx.xr.projected:projected:1.0.0-alpha03", tomlAlias = "androidx-xr-projected"))
@@ -40,10 +40,11 @@ internal fun AndroidModuleTemplateBuilder.aiGlassesActivityRecipe() = createReci
         ManifestActivity(
             name = "GlassesMainActivity",
             isExported = true,
-            theme = "@style/${manifest.themeRes}",
             isLauncher = true,
-            attributes = mapOf("android:requiredDisplayCategory" to "@string/display_category_xr_projected"),
-            action = "android.intent.action.MAIN",
+            configureAttrs = {
+              attribute("android:theme", "@style/${manifest.themeRes}")
+              attribute("android:requiredDisplayCategory", "@string/display_category_xr_projected")
+            },
         ))
   }
 }


### PR DESCRIPTION
### Motivation
- Several Android Studio templates were migrated from `utilities/wizard` to the `utilities/templates-api` style but imports/identifier usage were not updated, causing many unresolved references and compile failures during Kotlin compilation.

### Description
- Updated `TemplateProviderImpl` to import and register the existing template symbols `aiStarterTemplate` and `androidTVActivityTemplate` instead of non-existent `aiStarterActivityProject()` and `androidTVActivityProject()` so provider registration compiles. (`utilities/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/TemplateProviderImpl.kt`)
- Fixed `aiGlassesActivityRecipe` to match the current `templates-api` model by replacing unavailable `Dependency.AndroidX.*` constants with `parseDependency(...)` or `Dependency.AndroidX.Compose.*` where appropriate and adding the missing `androidx.activity:activity` entry. (`utilities/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/androidstudio/activity/aiGlassesActivity/aiGlassesActivityRecipe.kt`)
- Replaced unsupported `ManifestActivity` constructor usage (`theme`, `attributes`, `action`) with the supported `configureAttrs` attribute builder to align with the manifest DSL.

### Testing
- Attempted to run `./gradlew :utilities:templates-impl:compileDebugKotlin`, but the build failed before Kotlin compilation due to external dependency resolution error for `com.mooltiverse.oss.nyx:gradle:2.5.2` (Maven Central returned HTTP 403), so compile could not be validated in this environment.
- No other automated tests were executed; `git` operations (add/commit) succeeded for the applied changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9d0f2b708331bd9d4fb3c174c2e9)