### PR TITLE
docs: add protocol-migration plan (lsp4j-rpc → AIDL/gRPC/REAPI) and week1 task breakdown

### DIFF
--- a/docs/gradle-tooling-api-9.5.1-upgrade-plan.md
+++ b/docs/gradle-tooling-api-9.5.1-upgrade-plan.md
@@ -278,3 +278,49 @@
 ## 10. 结论
 
 你当前仓库已经具备升级到 9.5.1 的基础条件（依赖与模块结构都在），但离“全方面功能支持”还差一层**体系化补齐**。建议按“协议 -> 执行 -> 事件 -> 模型 -> 消费 -> 验证”顺序推进，避免先堆模型导致维护成本失控。
+
+
+## 10. 构建服务通信协议重构（强制）：移除 lsp4j-rpc，切换 AIDL + gRPC + REAPI + Proto
+
+> 目标：彻底移除客户端与服务端构建通信中的 lsp4j-rpc 依赖与调用链，构建“设备内 IPC + 远端执行/缓存 + 高效序列化”的双通道架构。
+
+### 10.1 目标架构（分层）
+1. **进程内/同机跨进程控制面**：AIDL（Binder）
+   - 用于 App(UI 进程) <-> 本机构建服务进程的控制命令、状态订阅、生命周期管理。
+2. **数据面/远程执行面**：gRPC + Proto
+   - 用于大体量构建事件、模型快照分片、日志流与远程执行请求。
+3. **远程构建与缓存协议面**：REAPI
+   - 对接 CAS/Action Cache/Execution，支持大项目缓存复用与并发执行。
+
+### 10.2 模块落点（与当前仓库对应）
+- `tooling/api`：
+  - 新增 AIDL 对应 DTO（轻量控制命令）。
+  - 新增 proto DTO 映射层（大对象流式传输，不经 Binder 直接搬运）。
+- `tooling/impl`：
+  - 新增 `TransportFacade`：`AidlControlChannel` + `GrpcDataChannel`。
+  - 新增 `ReapiExecutionBridge`：封装 Action/CAS/Execution 调用与重试。
+- `tooling/events`：
+  - 事件模型新增 chunk/sequence 字段，支持流式分片和断点续传。
+- `tooling/model`：
+  - 模型快照支持 `snapshotId/chunkCount/chunkHash` 元信息。
+- `core/app`：
+  - UI 仅通过 AIDL 控制通道发起请求；大数据流改为 gRPC 订阅。
+- `core/projects`：
+  - 同步流程改为 capability 驱动：优先 REAPI，失败自动 fallback 本地 Gradle。
+
+### 10.3 分阶段迁移（避免一次性切换风险）
+- **阶段A（并行接入）**：保留 lsp4j-rpc，新增 AIDL/gRPC 双栈，默认仍走旧链路。
+- **阶段B（灰度切流）**：按项目大小/开关切 5% -> 25% -> 50% 流量到新协议。
+- **阶段C（全面替换）**：删除 lsp4j-rpc server/client adapter 与序列化模型。
+- **阶段D（清理收口）**：删除遗留配置、文档、依赖与兼容分支。
+
+### 10.4 性能与稳定性验收门槛（必须量化）
+- P95 UI 主线程阻塞时间下降 >= 40%。
+- 构建服务进程峰值内存下降 >= 30%。
+- 超大型项目（`./build` 缓存 5GB~100GB+）连续构建 20 次无 OOM。
+- 同项目构建时长与 Termux 直跑 Gradle 的差距缩小到 <= 1.5x。
+
+### 10.5 与 9.5.1 升级的耦合关系
+- 9.5.1 Tooling API 升级优先解决“能力覆盖”；
+- 协议重构优先解决“传输与性能瓶颈”；
+- 两条线并行，但以 capability 协商统一收敛，确保客户端按能力选择本地/远程执行路径。

--- a/docs/iteration1-week1-status.md
+++ b/docs/iteration1-week1-status.md
@@ -108,3 +108,25 @@
     - `supportsModelSnapshot`
     - `supportsQueryService`
 - 当前阶段定位：**完成了“能力扩展字段设计/API 草案”这一步，但尚未完成服务端协商逻辑与兼容测试实跑。**  
+
+
+## 8) 第1周剩余任务拆分（可直接执行）
+
+### 8.1 D1-D2（收口 P0）
+1. 完成兼容矩阵 smoke：`new-server+old-client` / `old-server+new-client`。
+2. 事件闭合校验脚本：至少覆盖 TASK、PROJECT_CONFIGURATION。
+3. Capability 协商字段在 client UI 侧显示（只读 debug 面板）。
+
+### 8.2 D3（协议改造预备）
+1. 建立 `lsp4j-rpc` 使用点清单（client/server/serialization）。
+2. 新建 AIDL 控制面接口草案（connect/execute/cancel/subscribe/unsubscribe）。
+3. 新建 proto 服务草案（EventStream、ModelChunkStream、ExecutionSummary）。
+
+### 8.3 D4-D5（风险前置验证）
+1. 在大型项目样本上运行 2 组对照：旧协议 vs 新协议（若新协议未全量完成，先跑 mock stream）。
+2. 记录：峰值 RSS、GC 次数、UI 掉帧、构建总时长。
+3. 输出迭代1周报补充页：性能基线与差异结论。
+
+### 8.4 本周 Definition of Done（更新）
+- 不仅完成 execute 主链路；
+- 还需具备：兼容矩阵实跑结果 + 事件闭合验收 + 协议替换预备文档三件套。

--- a/docs/tooling-951-gap-register.md
+++ b/docs/tooling-951-gap-register.md
@@ -72,3 +72,40 @@
 2. 并行推进 **GAP-P0-02** capability 扩展字段设计。  
 3. 下周初收敛 **GAP-P1-01** requestId 全链路。  
 
+
+
+## P0（协议替换专项：lsp4j-rpc -> AIDL/gRPC/REAPI）
+
+### GAP-P0-04：lsp4j-rpc 依赖与调用链未移除
+- **能力名**：构建服务通信协议迁移。
+- **当前状态**：仍存在 lsp4j-rpc 主链路。
+- **影响范围**：`core/app`、`tooling/api`、`tooling/impl`、`tooling/events`。
+- **风险**：序列化/反序列化高开销导致高内存、高延迟、UI 卡顿与 OOM。
+- **最小实现方案**：
+  1. 盘点并冻结新增 lsp4j-rpc 接口；
+  2. 设计 AIDL 控制面 + gRPC 数据面；
+  3. 加入双栈灰度开关与回退策略；
+  4. 完成旧链路删除计划。
+- **验收标准**：
+  - 构建主流程默认不再经过 lsp4j-rpc；
+  - 保留可控回退开关（发布前可临时启用）。
+
+### GAP-P0-05：缺少 REAPI 远程执行/缓存接入层
+- **能力名**：远程执行与缓存标准化。
+- **当前状态**：未形成 REAPI bridge。
+- **影响范围**：`tooling/impl`、`tooling/model`、`core/projects`。
+- **风险**：大型项目缓存复用不足，构建耗时无法显著下降。
+- **最小实现方案**：
+  1. 新增 `ReapiExecutionBridge` 抽象；
+  2. 打通 Action Cache / CAS 查询与上传下载；
+  3. 增加 capability 协商：是否支持 remote execution。
+- **验收标准**：
+  - 远程缓存命中率可观测；
+  - 失败可自动 fallback 到本地执行。
+
+### GAP-P1-03：大模型/大事件缺少分片传输协议
+- **能力名**：流式传输与分片重组。
+- **当前状态**：协议默认单包模型，不利于超大结果。
+- **影响范围**：`tooling/events`、`tooling/model`、`core/app`。
+- **最小实现方案**：事件与模型新增 `chunkId/sequence/total/hash` 字段，并提供重组校验器。
+- **验收标准**：100MB 级事件/模型流可稳定传输且可校验一致性。


### PR DESCRIPTION
### Motivation
- Capture and formalize a mandatory protocol migration path to remove `lsp4j-rpc` and adopt `AIDL + gRPC + REAPI + Proto` to address high-memory and IPC performance issues for very large builds. 
- Make the current 9.5.1 Tooling API upgrade work actionable by adding concrete next-step tasks, DoD updates, and explicit gap items for protocol replacement and remote execution support. 

### Description
- Extended `docs/gradle-tooling-api-9.5.1-upgrade-plan.md` with a new section `10. 构建服务通信协议重构` that defines the layered architecture, module landing spots, phased migration, and quantitative performance acceptance criteria. 
- Added a concrete D1–D5 task breakdown and updated the Definition of Done in `docs/iteration1-week1-status.md` to include compatibility smoke tests, event-closure verification, and protocol-prep artifacts. 
- Expanded `docs/tooling-951-gap-register.md` with protocol-replacement gaps (`GAP-P0-04`, `GAP-P0-05`) and a chunked-transport gap (`GAP-P1-03`) describing minimal implementation plans and acceptance criteria. 
- This PR is documentation-only and touches the three files: `docs/gradle-tooling-api-9.5.1-upgrade-plan.md`, `docs/iteration1-week1-status.md`, and `docs/tooling-951-gap-register.md`. 

### Testing
- Wrote the updated files to disk and validated the appended sections by printing and inspecting file segments with `sed`/`nl` to confirm the new headings and paragraphs were present. 
- Verified the new `10.` protocol-rewrite section and the `8)` remaining-tasks block appear in the respective files and contain the expected task lists and acceptance criteria. 
- No runtime or unit tests apply because this is a documentation change only, and the content validation checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10005c18748323a1a640ccbcbf0de2)