### PR TITLE
Iteration2: 网关化 observer 边界并引入 endpoint 工厂切换开关

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -41,13 +41,10 @@ import com.itsaky.androidide.services.ToolingServerNotStartedException
 import com.itsaky.androidide.services.builder.ToolingServerRunner.OnServerStartListener
 import com.itsaky.androidide.tasks.ifCancelledOrInterrupted
 import com.itsaky.androidide.tasks.runOnUiThread
-import com.itsaky.androidide.tooling.api.ForwardingToolingApiClient
 import com.itsaky.androidide.tooling.api.IProject
-import com.itsaky.androidide.tooling.api.IToolingApiClient
 import com.itsaky.androidide.tooling.api.LogSenderConfig.PROPERTY_LOGSENDER_ENABLED
 import com.itsaky.androidide.tooling.api.messages.ExecutionRequest
 import com.itsaky.androidide.tooling.api.messages.InitializeProjectParams
-import com.itsaky.androidide.tooling.api.messages.LogMessageParams
 import com.itsaky.androidide.tooling.api.messages.result.BuildCancellationRequestResult
 import com.itsaky.androidide.tooling.api.messages.result.BuildInfo
 import com.itsaky.androidide.tooling.api.messages.result.BuildResult
@@ -56,6 +53,7 @@ import com.itsaky.androidide.tooling.api.messages.result.ExecutionResult
 import com.itsaky.androidide.tooling.api.messages.result.InitializeResult
 import com.itsaky.androidide.tooling.api.messages.result.TaskExecutionResult
 import com.itsaky.androidide.tooling.api.models.ToolingServerMetadata
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportClientObserver
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
 import com.itsaky.androidide.tooling.events.ProgressEvent
 import com.itsaky.androidide.utils.Environment
@@ -84,17 +82,7 @@ import org.slf4j.LoggerFactory
  * @author Akash Yadav
  */
 class GradleBuildService :
-    Service(), BuildService, IToolingApiClient, ToolingServerRunner.Observer {
-
-  companion object {
-    private const val PROP_USE_TOOLING_EXECUTE = "androidide.use.tooling.execute"
-    private const val PROP_TOOLING_EXECUTE_JVM_ARGS = "androidide.tooling.execute.jvmArgs"
-  }
-
-  companion object {
-    private const val PROP_USE_TOOLING_EXECUTE = "androidide.use.tooling.execute"
-    private const val PROP_TOOLING_EXECUTE_JVM_ARGS = "androidide.tooling.execute.jvmArgs"
-  }
+    Service(), BuildService, ToolingServerRunner.Observer {
 
   companion object {
     private const val PROP_USE_TOOLING_EXECUTE = "androidide.use.tooling.execute"
@@ -106,13 +94,6 @@ class GradleBuildService :
   override var isBuildInProgress = false
     private set
 
-  /**
-   * We do not provide direct access to GradleBuildService instance to the Tooling API launcher as
-   * it may cause memory leaks. Instead, we create another client object which forwards all calls to
-   * us. So, when the service is destroyed, we release the reference to the service from this
-   * client.
-   */
-  private var _toolingApiClient: ForwardingToolingApiClient? = null
   private var toolingServerRunner: ToolingServerRunner? = null
   private var outputReaderJob: Job? = null
   private var notificationManager: NotificationManager? = null
@@ -241,8 +222,6 @@ class GradleBuildService :
     toolingServerRunner?.release()
     toolingServerRunner = null
 
-    _toolingApiClient?.client = null
-    _toolingApiClient = null
 
     log.debug("Cancelling tooling server output reader job...")
     outputReaderJob?.cancel()
@@ -361,27 +340,26 @@ class GradleBuildService :
     isToolingServerStarted = true
   }
 
+
+  override fun onServerStarted(projectProxy: IProject, errorStream: InputStream) {
+    startServerOutputReader(errorStream)
+    Lookup.getDefault().update(BuildService.KEY_PROJECT_PROXY, projectProxy)
+    isToolingServerStarted = true
+  }
+
   override fun onServerExited(exitCode: Int) {
     log.warn("Tooling API process terminated with exit code: {}", exitCode)
     stopForeground(STOP_FOREGROUND_REMOVE)
   }
 
-  override fun getClient(): IToolingApiClient {
-    if (_toolingApiClient == null) {
-      _toolingApiClient = ForwardingToolingApiClient(this)
-    }
-    return _toolingApiClient!!
-  }
-
-  override fun logMessage(params: LogMessageParams) {
-    val logger = LoggerFactory.getLogger(params.tag)
-    when (params.level) {
-      'D' -> logger.debug(params.message)
-      'W' -> logger.warn(params.message)
-      'E' -> logger.error(params.message)
-      'I' -> logger.info(params.message)
-
-      else -> logger.trace(params.message)
+  override fun onLogMessage(tag: String, level: Char, message: String) {
+    val logger = LoggerFactory.getLogger(tag)
+    when (level) {
+      'D' -> logger.debug(message)
+      'W' -> logger.warn(message)
+      'E' -> logger.error(message)
+      'I' -> logger.info(message)
+      else -> logger.trace(message)
     }
   }
 
@@ -389,7 +367,7 @@ class GradleBuildService :
     eventListener?.onOutput(line)
   }
 
-  override fun prepareBuild(buildInfo: BuildInfo) {
+  override fun onBuildPrepared(buildInfo: BuildInfo) {
     updateNotification(getString(R.string.build_status_in_progress), true)
     eventListener?.prepareBuild(buildInfo)
   }
@@ -414,7 +392,7 @@ class GradleBuildService :
     eventListener?.onProgressEvent(event)
   }
 
-  override fun getBuildArguments(): CompletableFuture<List<String>> {
+  override fun buildArguments(): CompletableFuture<List<String>> {
     val extraArgs = ArrayList<String>()
 
     if (DevOpsPreferences.logsenderEnabled) {
@@ -589,7 +567,7 @@ class GradleBuildService :
     }
 
     if (useToolingExecute()) {
-      val buildArgs = getBuildArguments().get().filter { it.isNotBlank() }
+      val buildArgs = buildArguments().get().filter { it.isNotBlank() }
       val jvmArgs = resolveToolingExecuteJvmArgs()
       val request =
           ExecutionRequest(
@@ -610,7 +588,7 @@ class GradleBuildService :
     val useToolingExecute =
         System.getProperty("androidide.use.tooling.execute", "false").toBoolean()
     if (useToolingExecute) {
-      val buildArgs = getBuildArguments().get().filter { it.isNotBlank() }
+      val buildArgs = buildArguments().get().filter { it.isNotBlank() }
       val jvmArgs =
           System.getProperty("androidide.tooling.execute.jvmArgs", "")
               .split(' ')
@@ -633,7 +611,7 @@ class GradleBuildService :
     }
 
     if (useToolingExecute()) {
-      val buildArgs = getBuildArguments().get().filter { it.isNotBlank() }
+      val buildArgs = buildArguments().get().filter { it.isNotBlank() }
       val jvmArgs = resolveToolingExecuteJvmArgs()
       val request =
           ExecutionRequest(
@@ -681,7 +659,7 @@ class GradleBuildService :
             val command = mutableListOf("sh", gradlewPath)
             command.addAll(tasks)
 
-            val buildArgs = getBuildArguments().get()
+            val buildArgs = buildArguments().get()
             command.addAll(buildArgs)
 
             log.info("Executing command: ${command.joinToString(" ")}")
@@ -900,7 +878,7 @@ class GradleBuildService :
   }
 
   private fun createToolingExecutionRequest(tasks: List<String>): ExecutionRequest {
-    val buildArgs = getBuildArguments().get().filter { it.isNotBlank() }
+    val buildArgs = buildArguments().get().filter { it.isNotBlank() }
     val jvmArgs = resolveToolingExecuteJvmArgs()
     return ExecutionRequest(
         tasks = tasks,
@@ -1024,7 +1002,7 @@ class GradleBuildService :
       null
     } else
         object : EventListener {
-          override fun prepareBuild(buildInfo: BuildInfo) {
+          override fun onBuildPrepared(buildInfo: BuildInfo) {
             runOnUiThread { listener.prepareBuild(buildInfo) }
           }
 

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -53,7 +53,9 @@ import com.itsaky.androidide.tooling.api.messages.result.ExecutionResult
 import com.itsaky.androidide.tooling.api.messages.result.InitializeResult
 import com.itsaky.androidide.tooling.api.messages.result.TaskExecutionResult
 import com.itsaky.androidide.tooling.api.models.ToolingServerMetadata
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportMode
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
+import com.itsaky.androidide.tooling.impl.transport.ToolingServerEndpointFactories
 import com.itsaky.androidide.tooling.events.ProgressEvent
 import com.itsaky.androidide.utils.Environment
 import com.termux.shared.termux.shell.command.environment.TermuxShellEnvironment
@@ -969,6 +971,12 @@ class GradleBuildService :
     }
 
     if (toolingServerRunner?.isRunningOrStarting != true) {
+      val transportValue = resolveConfiguredTransportValue()
+      System.setProperty(ToolingServerEndpointFactories.TRANSPORT_SWITCH_PROPERTY, transportValue)
+      log.info(
+          "Starting tooling server with transport switch='{}'",
+          transportValue,
+      )
       val envs = TermuxShellEnvironment().getEnvironment(this, false)
       toolingServerRunner = ToolingServerRunner(listener, this).also { it.startAsync(envs) }
       return
@@ -988,6 +996,25 @@ class GradleBuildService :
     }
     this.eventListener = wrap(eventListener)
     return this
+  }
+
+  private fun resolveConfiguredTransportValue(): String {
+    val raw =
+        System.getProperty(
+            ToolingServerEndpointFactories.TRANSPORT_SWITCH_PROPERTY,
+            ToolingServerEndpointFactories.LEGACY,
+        )
+    val mode = ToolingTransportMode.fromWireValue(raw)
+    if (mode == null) {
+      log.warn(
+          "Unknown transport switch '{}' for -D{}. Fallback to '{}'.",
+          raw,
+          ToolingServerEndpointFactories.TRANSPORT_SWITCH_PROPERTY,
+          ToolingServerEndpointFactories.LEGACY,
+      )
+      return ToolingServerEndpointFactories.LEGACY
+    }
+    return mode.wireValue
   }
 
   private fun wrap(listener: EventListener?): EventListener? {

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -53,7 +53,6 @@ import com.itsaky.androidide.tooling.api.messages.result.ExecutionResult
 import com.itsaky.androidide.tooling.api.messages.result.InitializeResult
 import com.itsaky.androidide.tooling.api.messages.result.TaskExecutionResult
 import com.itsaky.androidide.tooling.api.models.ToolingServerMetadata
-import com.itsaky.androidide.tooling.api.transport.ToolingTransportClientObserver
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
 import com.itsaky.androidide.tooling.events.ProgressEvent
 import com.itsaky.androidide.utils.Environment
@@ -329,7 +328,7 @@ class GradleBuildService :
     System.setProperty("ide.logger.init.script", initScript.absolutePath)
   }
 
-  override fun onListenerStarted(
+  override fun onServerStarted(
       serverEndpoint: ToolingTransportServerEndpoint,
       projectProxy: IProject,
       errorStream: InputStream,
@@ -340,12 +339,6 @@ class GradleBuildService :
     isToolingServerStarted = true
   }
 
-
-  override fun onServerStarted(projectProxy: IProject, errorStream: InputStream) {
-    startServerOutputReader(errorStream)
-    Lookup.getDefault().update(BuildService.KEY_PROJECT_PROXY, projectProxy)
-    isToolingServerStarted = true
-  }
 
   override fun onServerExited(exitCode: Int) {
     log.warn("Tooling API process terminated with exit code: {}", exitCode)

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -44,7 +44,6 @@ import com.itsaky.androidide.tasks.runOnUiThread
 import com.itsaky.androidide.tooling.api.ForwardingToolingApiClient
 import com.itsaky.androidide.tooling.api.IProject
 import com.itsaky.androidide.tooling.api.IToolingApiClient
-import com.itsaky.androidide.tooling.api.IToolingApiServer
 import com.itsaky.androidide.tooling.api.LogSenderConfig.PROPERTY_LOGSENDER_ENABLED
 import com.itsaky.androidide.tooling.api.messages.ExecutionRequest
 import com.itsaky.androidide.tooling.api.messages.InitializeProjectParams
@@ -58,7 +57,6 @@ import com.itsaky.androidide.tooling.api.messages.result.InitializeResult
 import com.itsaky.androidide.tooling.api.messages.result.TaskExecutionResult
 import com.itsaky.androidide.tooling.api.models.ToolingServerMetadata
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
-import com.itsaky.androidide.tooling.impl.transport.LegacyToolingServerEndpoint
 import com.itsaky.androidide.tooling.events.ProgressEvent
 import com.itsaky.androidide.utils.Environment
 import com.termux.shared.termux.shell.command.environment.TermuxShellEnvironment
@@ -353,12 +351,12 @@ class GradleBuildService :
   }
 
   override fun onListenerStarted(
-      server: IToolingApiServer,
+      serverEndpoint: ToolingTransportServerEndpoint,
       projectProxy: IProject,
       errorStream: InputStream,
   ) {
     startServerOutputReader(errorStream)
-    this.serverEndpoint = LegacyToolingServerEndpoint(server)
+    this.serverEndpoint = serverEndpoint
     Lookup.getDefault().update(BuildService.KEY_PROJECT_PROXY, projectProxy)
     isToolingServerStarted = true
   }

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -23,7 +23,6 @@ import com.itsaky.androidide.tasks.cancelIfActive
 import com.itsaky.androidide.tooling.api.IProject
 import com.itsaky.androidide.tooling.api.IToolingApiServer
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportClientObserver
-import com.itsaky.androidide.tooling.api.transport.ToolingTransportMode
 import com.itsaky.androidide.tooling.impl.transport.ToolingServerEndpointFactories
 import com.itsaky.androidide.tooling.impl.transport.LegacyToolingClientAdapter
 import com.itsaky.androidide.tooling.api.util.ToolingApiLauncher
@@ -148,17 +147,18 @@ internal class ToolingServerRunner(
                       ToolingServerEndpointFactories.TRANSPORT_SWITCH_PROPERTY,
                       ToolingServerEndpointFactories.LEGACY,
                   )
-              val parsedMode = ToolingTransportMode.fromWireValue(configuredTransport)
+              val selection = ToolingServerEndpointFactories.resolveSelection(configuredTransport)
               log.info(
-                  "Tooling transport switch configured as '{}', parsed mode={}",
-                  configuredTransport,
-                  parsedMode?.name ?: "UNKNOWN",
+                  "Tooling transport configured='{}', parsed={}, effective={}, fallbackReason={}",
+                  selection.requestedValue,
+                  selection.parsedMode?.name ?: "UNKNOWN",
+                  selection.effectiveMode.name,
+                  selection.fallbackReason ?: "NONE",
               )
               observer?.onServerStarted(
                   serverEndpoint =
-                      ToolingServerEndpointFactories.fromTransportValue(configuredTransport).create(
-                          launcher.remoteProxy as IToolingApiServer,
-                      ),
+                      ToolingServerEndpointFactories.fromSelection(selection)
+                          .create(launcher.remoteProxy as IToolingApiServer),
                   projectProxy = launcher.remoteProxy as IProject,
                   errorStream = errorStream,
               )

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -23,6 +23,7 @@ import com.itsaky.androidide.tasks.cancelIfActive
 import com.itsaky.androidide.tooling.api.IProject
 import com.itsaky.androidide.tooling.api.IToolingApiServer
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportClientObserver
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportMode
 import com.itsaky.androidide.tooling.impl.transport.ToolingServerEndpointFactories
 import com.itsaky.androidide.tooling.impl.transport.LegacyToolingClientAdapter
 import com.itsaky.androidide.tooling.api.util.ToolingApiLauncher
@@ -147,7 +148,12 @@ internal class ToolingServerRunner(
                       ToolingServerEndpointFactories.TRANSPORT_SWITCH_PROPERTY,
                       ToolingServerEndpointFactories.LEGACY,
                   )
-              log.info("Tooling transport switch configured as '{}'", configuredTransport)
+              val parsedMode = ToolingTransportMode.fromWireValue(configuredTransport)
+              log.info(
+                  "Tooling transport switch configured as '{}', parsed mode={}",
+                  configuredTransport,
+                  parsedMode?.name ?: "UNKNOWN",
+              )
               observer?.onServerStarted(
                   serverEndpoint =
                       ToolingServerEndpointFactories.fromTransportValue(configuredTransport).create(

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -138,7 +138,7 @@ internal class ToolingServerRunner(
                   )
 
               val future = launcher.startListening()
-              observer?.onListenerStarted(
+              observer?.onServerStarted(
                   serverEndpoint =
                       ToolingServerEndpointFactories.fromSystemProperty().create(
                           launcher.remoteProxy as IToolingApiServer,
@@ -202,16 +202,7 @@ internal class ToolingServerRunner(
         .getOrNull()
   }
 
-  interface Observer : ToolingTransportClientObserver {
-
-    fun onListenerStarted(
-        serverEndpoint: com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint,
-        projectProxy: IProject,
-        errorStream: InputStream,
-    )
-
-    override fun onServerExited(exitCode: Int)
-  }
+  interface Observer : ToolingTransportClientObserver
 
   /** Callback to listen for Tooling API server start event. */
   fun interface OnServerStartListener {

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -21,9 +21,10 @@ import ch.qos.logback.core.CoreConstants
 import com.itsaky.androidide.shell.executeProcessAsync
 import com.itsaky.androidide.tasks.cancelIfActive
 import com.itsaky.androidide.tooling.api.IProject
-import com.itsaky.androidide.tooling.api.IToolingApiClient
 import com.itsaky.androidide.tooling.api.IToolingApiServer
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportClientObserver
 import com.itsaky.androidide.tooling.impl.transport.ToolingServerEndpointFactories
+import com.itsaky.androidide.tooling.impl.transport.LegacyToolingClientAdapter
 import com.itsaky.androidide.tooling.api.util.ToolingApiLauncher
 import com.itsaky.androidide.utils.Environment
 import com.termux.shared.reflection.ReflectionUtils
@@ -131,7 +132,7 @@ internal class ToolingServerRunner(
 
               val launcher =
                   ToolingApiLauncher.newClientLauncher(
-                      observer!!.getClient(),
+                      LegacyToolingClientAdapter(observer!!),
                       inputStream,
                       outputStream,
                   )
@@ -201,7 +202,7 @@ internal class ToolingServerRunner(
         .getOrNull()
   }
 
-  interface Observer {
+  interface Observer : ToolingTransportClientObserver {
 
     fun onListenerStarted(
         serverEndpoint: com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint,
@@ -209,9 +210,7 @@ internal class ToolingServerRunner(
         errorStream: InputStream,
     )
 
-    fun onServerExited(exitCode: Int)
-
-    fun getClient(): IToolingApiClient
+    override fun onServerExited(exitCode: Int)
   }
 
   /** Callback to listen for Tooling API server start event. */

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -23,6 +23,7 @@ import com.itsaky.androidide.tasks.cancelIfActive
 import com.itsaky.androidide.tooling.api.IProject
 import com.itsaky.androidide.tooling.api.IToolingApiClient
 import com.itsaky.androidide.tooling.api.IToolingApiServer
+import com.itsaky.androidide.tooling.impl.transport.ToolingServerEndpointFactories
 import com.itsaky.androidide.tooling.api.util.ToolingApiLauncher
 import com.itsaky.androidide.utils.Environment
 import com.termux.shared.reflection.ReflectionUtils
@@ -137,7 +138,10 @@ internal class ToolingServerRunner(
 
               val future = launcher.startListening()
               observer?.onListenerStarted(
-                  server = launcher.remoteProxy as IToolingApiServer,
+                  serverEndpoint =
+                      ToolingServerEndpointFactories.fromSystemProperty().create(
+                          launcher.remoteProxy as IToolingApiServer,
+                      ),
                   projectProxy = launcher.remoteProxy as IProject,
                   errorStream = errorStream,
               )
@@ -200,7 +204,7 @@ internal class ToolingServerRunner(
   interface Observer {
 
     fun onListenerStarted(
-        server: IToolingApiServer,
+        serverEndpoint: com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint,
         projectProxy: IProject,
         errorStream: InputStream,
     )

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/ToolingServerRunner.kt
@@ -132,15 +132,25 @@ internal class ToolingServerRunner(
 
               val launcher =
                   ToolingApiLauncher.newClientLauncher(
-                      LegacyToolingClientAdapter(observer!!),
+                      LegacyToolingClientAdapter(
+                          checkNotNull(observer) {
+                            "ToolingServerRunner observer was released before launcher init"
+                          },
+                      ),
                       inputStream,
                       outputStream,
                   )
 
               val future = launcher.startListening()
+              val configuredTransport =
+                  System.getProperty(
+                      ToolingServerEndpointFactories.TRANSPORT_SWITCH_PROPERTY,
+                      ToolingServerEndpointFactories.LEGACY,
+                  )
+              log.info("Tooling transport switch configured as '{}'", configuredTransport)
               observer?.onServerStarted(
                   serverEndpoint =
-                      ToolingServerEndpointFactories.fromSystemProperty().create(
+                      ToolingServerEndpointFactories.fromTransportValue(configuredTransport).create(
                           launcher.remoteProxy as IToolingApiServer,
                       ),
                   projectProxy = launcher.remoteProxy as IProject,

--- a/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/ToolingTransportMode.kt
+++ b/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/ToolingTransportMode.kt
@@ -1,17 +1,21 @@
 package com.itsaky.androidide.tooling.api.transport
 
-/** Transport switch values for tooling server endpoint selection. */
+/**
+ * Transport stack selection for tooling server endpoint wiring.
+ *
+ * Note: AIDL + gRPC(UDS) + REAPI are treated as one integrated stack, not three independent
+ * modes.
+ */
 enum class ToolingTransportMode(val wireValue: String) {
-  LEGACY("legacy"),
-  AIDL("aidl"),
-  GRPC_UDS("grpc-uds");
+  LEGACY_JSONRPC("legacy"),
+  INTEGRATED_AIDL_GRPC_REAPI("integrated");
 
   companion object {
     @JvmStatic
     fun fromWireValue(value: String?): ToolingTransportMode? {
       val normalized = value.orEmpty().trim().lowercase()
       if (normalized.isBlank()) {
-        return LEGACY
+        return LEGACY_JSONRPC
       }
       return entries.firstOrNull { it.wireValue == normalized }
     }

--- a/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/ToolingTransportMode.kt
+++ b/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/ToolingTransportMode.kt
@@ -1,0 +1,19 @@
+package com.itsaky.androidide.tooling.api.transport
+
+/** Transport switch values for tooling server endpoint selection. */
+enum class ToolingTransportMode(val wireValue: String) {
+  LEGACY("legacy"),
+  AIDL("aidl"),
+  GRPC_UDS("grpc-uds");
+
+  companion object {
+    @JvmStatic
+    fun fromWireValue(value: String?): ToolingTransportMode? {
+      val normalized = value.orEmpty().trim().lowercase()
+      if (normalized.isBlank()) {
+        return LEGACY
+      }
+      return entries.firstOrNull { it.wireValue == normalized }
+    }
+  }
+}

--- a/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/TransportContracts.kt
+++ b/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/TransportContracts.kt
@@ -41,7 +41,11 @@ interface ToolingTransportClientObserver {
 
   fun buildArguments(): CompletableFuture<List<String>>
 
-  fun onServerStarted(projectProxy: com.itsaky.androidide.tooling.api.IProject, errorStream: InputStream)
+  fun onServerStarted(
+      serverEndpoint: ToolingTransportServerEndpoint,
+      projectProxy: com.itsaky.androidide.tooling.api.IProject,
+      errorStream: InputStream,
+  )
 
   fun onServerExited(exitCode: Int)
 }

--- a/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/TransportContracts.kt
+++ b/tooling/api/src/main/java/com/itsaky/androidide/tooling/api/transport/TransportContracts.kt
@@ -8,6 +8,8 @@ import com.itsaky.androidide.tooling.api.messages.result.ExecutionResult
 import com.itsaky.androidide.tooling.api.messages.result.InitializeResult
 import com.itsaky.androidide.tooling.api.messages.result.TaskExecutionResult
 import com.itsaky.androidide.tooling.api.models.ToolingServerMetadata
+import com.itsaky.androidide.tooling.events.ProgressEvent
+import java.io.InputStream
 import java.util.concurrent.CompletableFuture
 
 /** Transport-neutral contract for build-service client->server calls. */
@@ -23,4 +25,23 @@ interface ToolingTransportServerEndpoint {
   fun cancelCurrentBuild(): CompletableFuture<BuildCancellationRequestResult>
 
   fun shutdown(): CompletableFuture<Void>
+}
+
+/** Transport-neutral observer for server lifecycle and callback events. */
+interface ToolingTransportClientObserver {
+  fun onLogMessage(tag: String, level: Char, message: String)
+
+  fun onBuildPrepared(buildInfo: com.itsaky.androidide.tooling.api.messages.result.BuildInfo)
+
+  fun onBuildSuccessful(result: com.itsaky.androidide.tooling.api.messages.result.BuildResult)
+
+  fun onBuildFailed(result: com.itsaky.androidide.tooling.api.messages.result.BuildResult)
+
+  fun onProgressEvent(event: ProgressEvent)
+
+  fun buildArguments(): CompletableFuture<List<String>>
+
+  fun onServerStarted(projectProxy: com.itsaky.androidide.tooling.api.IProject, errorStream: InputStream)
+
+  fun onServerExited(exitCode: Int)
 }

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/LegacyToolingClientAdapter.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/LegacyToolingClientAdapter.kt
@@ -1,0 +1,39 @@
+package com.itsaky.androidide.tooling.impl.transport
+
+import com.itsaky.androidide.tooling.api.IToolingApiClient
+import com.itsaky.androidide.tooling.api.messages.LogMessageParams
+import com.itsaky.androidide.tooling.api.messages.result.BuildInfo
+import com.itsaky.androidide.tooling.api.messages.result.BuildResult
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportClientObserver
+import com.itsaky.androidide.tooling.events.ProgressEvent
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Legacy JSON-RPC callback adapter that bridges [IToolingApiClient] into
+ * transport-neutral [ToolingTransportClientObserver].
+ */
+class LegacyToolingClientAdapter(private val observer: ToolingTransportClientObserver) :
+    IToolingApiClient {
+
+  override fun logMessage(params: LogMessageParams) {
+    observer.onLogMessage(params.tag, params.level, params.message)
+  }
+
+  override fun prepareBuild(buildInfo: BuildInfo) {
+    observer.onBuildPrepared(buildInfo)
+  }
+
+  override fun onBuildSuccessful(result: BuildResult) {
+    observer.onBuildSuccessful(result)
+  }
+
+  override fun onBuildFailed(result: BuildResult) {
+    observer.onBuildFailed(result)
+  }
+
+  override fun onProgressEvent(event: ProgressEvent) {
+    observer.onProgressEvent(event)
+  }
+
+  override fun getBuildArguments(): CompletableFuture<List<String>> = observer.buildArguments()
+}

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
@@ -8,8 +8,9 @@ import org.slf4j.LoggerFactory
 /**
  * Factory contract for creating a concrete tooling transport endpoint.
  *
- * Transport selection is controlled by `androidide.tooling.transport`:
+ * Transport stack selection is controlled by `androidide.tooling.transport`:
  * - `legacy` (default): JSON-RPC/LSP4J based server proxy.
+ * - `integrated`: AIDL + gRPC(UDS) + REAPI integrated stack (reserved, not implemented yet).
  */
 fun interface ToolingServerEndpointFactory {
   fun create(server: IToolingApiServer): ToolingTransportServerEndpoint
@@ -37,25 +38,24 @@ object ToolingServerEndpointFactories {
     val configured = value.orEmpty().ifBlank { LEGACY }.trim().lowercase()
     val mode = ToolingTransportMode.fromWireValue(configured)
     return when (mode) {
-      ToolingTransportMode.LEGACY ->
+      ToolingTransportMode.LEGACY_JSONRPC ->
           TransportSelectionResult(
               requestedValue = configured,
               parsedMode = mode,
-              effectiveMode = ToolingTransportMode.LEGACY,
+              effectiveMode = ToolingTransportMode.LEGACY_JSONRPC,
           )
-      ToolingTransportMode.AIDL,
-      ToolingTransportMode.GRPC_UDS ->
+      ToolingTransportMode.INTEGRATED_AIDL_GRPC_REAPI ->
           TransportSelectionResult(
               requestedValue = configured,
               parsedMode = mode,
-              effectiveMode = ToolingTransportMode.LEGACY,
-              fallbackReason = "Transport '$configured' is not implemented yet",
+              effectiveMode = ToolingTransportMode.LEGACY_JSONRPC,
+              fallbackReason = "Integrated transport stack '$configured' is not implemented yet",
           )
       null ->
           TransportSelectionResult(
               requestedValue = configured,
               parsedMode = null,
-              effectiveMode = ToolingTransportMode.LEGACY,
+              effectiveMode = ToolingTransportMode.LEGACY_JSONRPC,
               fallbackReason = "Unknown transport value '$configured'",
           )
     }
@@ -64,11 +64,10 @@ object ToolingServerEndpointFactories {
   @JvmStatic
   fun fromSelection(selection: TransportSelectionResult): ToolingServerEndpointFactory {
     when (selection.parsedMode) {
-      ToolingTransportMode.LEGACY -> Unit
-      ToolingTransportMode.AIDL,
-      ToolingTransportMode.GRPC_UDS -> {
+      ToolingTransportMode.LEGACY_JSONRPC -> Unit
+      ToolingTransportMode.INTEGRATED_AIDL_GRPC_REAPI -> {
         log.info(
-            "Transport '{}' is not implemented yet. Falling back to '{}' endpoint.",
+            "Integrated transport stack '{}' is not implemented yet. Falling back to '{}' endpoint.",
             selection.requestedValue,
             LEGACY,
         )

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
@@ -24,7 +24,13 @@ object ToolingServerEndpointFactories {
 
   @JvmStatic
   fun fromSystemProperty(): ToolingServerEndpointFactory {
-    val configured = System.getProperty(TRANSPORT_SWITCH_PROPERTY, LEGACY).trim().lowercase()
+    val configured = System.getProperty(TRANSPORT_SWITCH_PROPERTY, LEGACY)
+    return fromTransportValue(configured)
+  }
+
+  @JvmStatic
+  fun fromTransportValue(value: String?): ToolingServerEndpointFactory {
+    val configured = value.orEmpty().ifBlank { LEGACY }.trim().lowercase()
     return when (configured) {
       LEGACY -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
       AIDL,

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
@@ -1,0 +1,27 @@
+package com.itsaky.androidide.tooling.impl.transport
+
+import com.itsaky.androidide.tooling.api.IToolingApiServer
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
+
+/**
+ * Factory contract for creating a concrete tooling transport endpoint.
+ *
+ * Transport selection is controlled by `androidide.tooling.transport`:
+ * - `legacy` (default): JSON-RPC/LSP4J based server proxy.
+ */
+fun interface ToolingServerEndpointFactory {
+  fun create(server: IToolingApiServer): ToolingTransportServerEndpoint
+}
+
+object ToolingServerEndpointFactories {
+  const val TRANSPORT_SWITCH_PROPERTY: String = "androidide.tooling.transport"
+  const val LEGACY: String = "legacy"
+
+  @JvmStatic
+  fun fromSystemProperty(): ToolingServerEndpointFactory {
+    return when (System.getProperty(TRANSPORT_SWITCH_PROPERTY, LEGACY).trim().lowercase()) {
+      LEGACY -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+      else -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+    }
+  }
+}

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
@@ -2,6 +2,7 @@ package com.itsaky.androidide.tooling.impl.transport
 
 import com.itsaky.androidide.tooling.api.IToolingApiServer
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
+import org.slf4j.LoggerFactory
 
 /**
  * Factory contract for creating a concrete tooling transport endpoint.
@@ -14,14 +15,36 @@ fun interface ToolingServerEndpointFactory {
 }
 
 object ToolingServerEndpointFactories {
+  private val log = LoggerFactory.getLogger(ToolingServerEndpointFactories::class.java)
+
   const val TRANSPORT_SWITCH_PROPERTY: String = "androidide.tooling.transport"
   const val LEGACY: String = "legacy"
+  const val AIDL: String = "aidl"
+  const val GRPC_UDS: String = "grpc-uds"
 
   @JvmStatic
   fun fromSystemProperty(): ToolingServerEndpointFactory {
-    return when (System.getProperty(TRANSPORT_SWITCH_PROPERTY, LEGACY).trim().lowercase()) {
+    val configured = System.getProperty(TRANSPORT_SWITCH_PROPERTY, LEGACY).trim().lowercase()
+    return when (configured) {
       LEGACY -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
-      else -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+      AIDL,
+      GRPC_UDS -> {
+        log.info(
+            "Transport '{}' is not implemented yet. Falling back to '{}' endpoint.",
+            configured,
+            LEGACY,
+        )
+        ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+      }
+      else -> {
+        log.warn(
+            "Unknown transport switch '{}' from -D{}. Falling back to '{}'.",
+            configured,
+            TRANSPORT_SWITCH_PROPERTY,
+            LEGACY,
+        )
+        ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+      }
     }
   }
 }

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
@@ -1,6 +1,7 @@
 package com.itsaky.androidide.tooling.impl.transport
 
 import com.itsaky.androidide.tooling.api.IToolingApiServer
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportMode
 import com.itsaky.androidide.tooling.api.transport.ToolingTransportServerEndpoint
 import org.slf4j.LoggerFactory
 
@@ -19,8 +20,6 @@ object ToolingServerEndpointFactories {
 
   const val TRANSPORT_SWITCH_PROPERTY: String = "androidide.tooling.transport"
   const val LEGACY: String = "legacy"
-  const val AIDL: String = "aidl"
-  const val GRPC_UDS: String = "grpc-uds"
 
   @JvmStatic
   fun fromSystemProperty(): ToolingServerEndpointFactory {
@@ -31,10 +30,11 @@ object ToolingServerEndpointFactories {
   @JvmStatic
   fun fromTransportValue(value: String?): ToolingServerEndpointFactory {
     val configured = value.orEmpty().ifBlank { LEGACY }.trim().lowercase()
-    return when (configured) {
-      LEGACY -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
-      AIDL,
-      GRPC_UDS -> {
+    val mode = ToolingTransportMode.fromWireValue(configured)
+    return when (mode) {
+      ToolingTransportMode.LEGACY -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+      ToolingTransportMode.AIDL,
+      ToolingTransportMode.GRPC_UDS -> {
         log.info(
             "Transport '{}' is not implemented yet. Falling back to '{}' endpoint.",
             configured,
@@ -42,7 +42,7 @@ object ToolingServerEndpointFactories {
         )
         ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
       }
-      else -> {
+      null -> {
         log.warn(
             "Unknown transport switch '{}' from -D{}. Falling back to '{}'.",
             configured,

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/ToolingServerEndpointFactory.kt
@@ -24,33 +24,64 @@ object ToolingServerEndpointFactories {
   @JvmStatic
   fun fromSystemProperty(): ToolingServerEndpointFactory {
     val configured = System.getProperty(TRANSPORT_SWITCH_PROPERTY, LEGACY)
-    return fromTransportValue(configured)
+    return fromSelection(resolveSelection(configured))
   }
 
   @JvmStatic
   fun fromTransportValue(value: String?): ToolingServerEndpointFactory {
+    return fromSelection(resolveSelection(value))
+  }
+
+  @JvmStatic
+  fun resolveSelection(value: String?): TransportSelectionResult {
     val configured = value.orEmpty().ifBlank { LEGACY }.trim().lowercase()
     val mode = ToolingTransportMode.fromWireValue(configured)
     return when (mode) {
-      ToolingTransportMode.LEGACY -> ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
+      ToolingTransportMode.LEGACY ->
+          TransportSelectionResult(
+              requestedValue = configured,
+              parsedMode = mode,
+              effectiveMode = ToolingTransportMode.LEGACY,
+          )
+      ToolingTransportMode.AIDL,
+      ToolingTransportMode.GRPC_UDS ->
+          TransportSelectionResult(
+              requestedValue = configured,
+              parsedMode = mode,
+              effectiveMode = ToolingTransportMode.LEGACY,
+              fallbackReason = "Transport '$configured' is not implemented yet",
+          )
+      null ->
+          TransportSelectionResult(
+              requestedValue = configured,
+              parsedMode = null,
+              effectiveMode = ToolingTransportMode.LEGACY,
+              fallbackReason = "Unknown transport value '$configured'",
+          )
+    }
+  }
+
+  @JvmStatic
+  fun fromSelection(selection: TransportSelectionResult): ToolingServerEndpointFactory {
+    when (selection.parsedMode) {
+      ToolingTransportMode.LEGACY -> Unit
       ToolingTransportMode.AIDL,
       ToolingTransportMode.GRPC_UDS -> {
         log.info(
             "Transport '{}' is not implemented yet. Falling back to '{}' endpoint.",
-            configured,
+            selection.requestedValue,
             LEGACY,
         )
-        ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
       }
       null -> {
         log.warn(
             "Unknown transport switch '{}' from -D{}. Falling back to '{}'.",
-            configured,
+            selection.requestedValue,
             TRANSPORT_SWITCH_PROPERTY,
             LEGACY,
         )
-        ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
       }
     }
+    return ToolingServerEndpointFactory(::LegacyToolingServerEndpoint)
   }
 }

--- a/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/TransportSelectionResult.kt
+++ b/tooling/impl/src/main/java/com/itsaky/androidide/tooling/impl/transport/TransportSelectionResult.kt
@@ -1,0 +1,10 @@
+package com.itsaky.androidide.tooling.impl.transport
+
+import com.itsaky.androidide.tooling.api.transport.ToolingTransportMode
+
+data class TransportSelectionResult(
+    val requestedValue: String,
+    val parsedMode: ToolingTransportMode?,
+    val effectiveMode: ToolingTransportMode,
+    val fallbackReason: String? = null,
+)


### PR DESCRIPTION
### Motivation
- Reduce the coupling between client-side build service and the legacy Tooling API server instance so future `AIDL`/`gRPC(UDS)` endpoints can be plugged in behind a transport gateway. 
- Provide a transport-switching extension point so endpoint selection can be controlled centrally without sprinkling legacy construction logic across `core/app`. 
- Unify the observer/callback boundary to make server lifecycle, logs, progress and build lifecycle notifications transport-neutral.

### Description
- Added a transport-neutral observer contract `ToolingTransportClientObserver` in `tooling/api` to surface log messages, build lifecycle callbacks, progress events, build arguments and server lifecycle notifications. 
- Introduced `ToolingServerEndpointFactory` and `ToolingServerEndpointFactories` in `tooling/impl` to centralize creation of `ToolingTransportServerEndpoint` implementations and to route selection via the system property `androidide.tooling.transport` (default `legacy`). 
- Changed `ToolingServerRunner` to create a `ToolingTransportServerEndpoint` from the factory and pass that endpoint to the observer instead of exposing `IToolingApiServer` directly. 
- Updated `GradleBuildService` to accept the transport endpoint in `onListenerStarted` and removed local instantiation of `LegacyToolingServerEndpoint`, thereby shrinking the surface area that knows about legacy JSON-RPC/LSP4J details. 
- Kept the runtime behavior equivalent to before (the factory currently falls back to the legacy adapter) so this is a structural refactor that prepares for adding `aidl`/`grpc-uds` implementations later. 

### Testing
- Attempted a local compile with `./gradlew :tooling:api:compileKotlin :tooling:impl:compileKotlin` but the build failed with an environment/SDK error (`* What went wrong: 25.0.2`), so compile-time validation could not be completed. 
- No automated unit tests were run as part of this change due to the compile failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a108b2bccbc832aa039a561ec5a6f90)