### PR TITLE
feat(tooling): scaffold hybrid AIDL + gRPC build protocol module

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -192,6 +192,7 @@ include(
     ":testing:lspTest",
     ":testing:unitTest",
     ":tooling:api",
+    ":tooling:build-grpc",
     ":tooling:builder-model-impl",
     ":tooling:events",
     ":tooling:impl",

--- a/tooling/build-grpc/build.gradle.kts
+++ b/tooling/build-grpc/build.gradle.kts
@@ -1,0 +1,63 @@
+@Suppress("JavaPluginLanguageLevel")
+plugins {
+  id("java-library")
+  id("org.jetbrains.kotlin.jvm")
+  alias(libs.plugins.protobuf)
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17))
+  }
+}
+
+kotlin {
+  jvmToolchain(17)
+}
+
+sourceSets {
+  main {
+    proto {
+      srcDir("src/main/proto")
+    }
+  }
+}
+
+dependencies {
+  api(libs.google.protobuf.java)
+  api(libs.google.protobuf.kotlin)
+  api(libs.grpc.protobuf)
+  api(libs.grpc.stub)
+  api(libs.grpc.kotlin.stub)
+
+  implementation(libs.common.jkotlin)
+  implementation(projects.tooling.reapiProto)
+
+  compileOnly("javax.annotation:javax.annotation-api:1.3.2")
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:${libs.versions.protobufVersion.get()}"
+  }
+  plugins {
+    create("grpc") {
+      artifact = "io.grpc:protoc-gen-grpc-java:${libs.versions.ioGrpcVersion.get()}"
+    }
+    create("grpckt") {
+      artifact = "io.grpc:protoc-gen-grpc-kotlin:${libs.versions.ioGrpcStubVersion.get()}:jdk8@jar"
+    }
+  }
+
+  generateProtoTasks {
+    all().forEach { task ->
+      task.plugins {
+        create("grpc")
+        create("grpckt")
+      }
+      task.builtins {
+        create("kotlin")
+      }
+    }
+  }
+}

--- a/tooling/build-grpc/src/main/aidl/com/itsaky/androidide/tooling/buildgrpc/IBuildEventListener.aidl
+++ b/tooling/build-grpc/src/main/aidl/com/itsaky/androidide/tooling/buildgrpc/IBuildEventListener.aidl
@@ -1,0 +1,6 @@
+package com.itsaky.androidide.tooling.buildgrpc;
+
+interface IBuildEventListener {
+  void onBuildEvent(String buildEventJson);
+  void onBuildStreamClosed(String requestId, boolean successful);
+}

--- a/tooling/build-grpc/src/main/aidl/com/itsaky/androidide/tooling/buildgrpc/IBuildServiceBridge.aidl
+++ b/tooling/build-grpc/src/main/aidl/com/itsaky/androidide/tooling/buildgrpc/IBuildServiceBridge.aidl
@@ -1,0 +1,8 @@
+package com.itsaky.androidide.tooling.buildgrpc;
+
+interface IBuildServiceBridge {
+  String initialize(String initializeBuildRequestJson);
+  String queryTargets(String queryBuildTargetsRequestJson);
+  String executeBuild(String executeBuildRequestJson);
+  String getBuildResult(String executeBuildRequestJson);
+}

--- a/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/api/BuildProtocolContract.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/api/BuildProtocolContract.kt
@@ -1,0 +1,14 @@
+package com.itsaky.androidide.tooling.buildgrpc.api
+
+/**
+ * Contract for a JVM-local build service protocol inspired by BSP + Build Event Protocol + REAPI.
+ *
+ * - gRPC: typed request/response and event stream.
+ * - AIDL: IPC-friendly bridge for Android process boundaries.
+ */
+interface BuildProtocolContract {
+  val protocolVersion: String
+  val serverName: String
+
+  fun supportedFeatures(): Set<String>
+}

--- a/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/bridge/AidlGrpcBridge.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/bridge/AidlGrpcBridge.kt
@@ -1,0 +1,22 @@
+package com.itsaky.androidide.tooling.buildgrpc.bridge
+
+import com.itsaky.androidide.tooling.buildgrpc.api.BuildProtocolContract
+
+/**
+ * Keeps protocol concerns separated:
+ * 1) Kotlin/gRPC service implementation.
+ * 2) AIDL JSON bridge for low-overhead IPC handoff.
+ */
+class AidlGrpcBridge(
+  private val contract: BuildProtocolContract,
+) {
+  fun describe(): String {
+    return buildString {
+      append(contract.serverName)
+      append('@')
+      append(contract.protocolVersion)
+      append(':')
+      append(contract.supportedFeatures().sorted().joinToString(","))
+    }
+  }
+}

--- a/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/model/BuildBridgeModels.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/model/BuildBridgeModels.kt
@@ -1,0 +1,15 @@
+package com.itsaky.androidide.tooling.buildgrpc.model
+
+data class BuildBridgeRequest(
+  val requestId: String,
+  val workspaceRoot: String,
+  val targetIds: List<String> = emptyList(),
+  val arguments: List<String> = emptyList(),
+)
+
+data class BuildBridgeEvent(
+  val requestId: String,
+  val eventId: String,
+  val category: String,
+  val payloadJson: String,
+)

--- a/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/service/BuildServiceArchitecture.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/service/BuildServiceArchitecture.kt
@@ -1,0 +1,17 @@
+package com.itsaky.androidide.tooling.buildgrpc.service
+
+import com.itsaky.androidide.tooling.buildgrpc.api.BuildProtocolContract
+
+object BuildServiceArchitecture : BuildProtocolContract {
+  override val protocolVersion: String = "0.1.0"
+  override val serverName: String = "ZeroStudioBuildService"
+
+  override fun supportedFeatures(): Set<String> =
+    linkedSetOf(
+      "bsp-like-session-lifecycle",
+      "build-event-protocol-stream",
+      "reapi-execution-metadata",
+      "aidl-grpc-hybrid-bridge",
+      "in-jvm-local-transport",
+    )
+}

--- a/tooling/build-grpc/src/main/proto/build_service.proto
+++ b/tooling/build-grpc/src/main/proto/build_service.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package tooling.buildgrpc.v1;
+
+option java_multiple_files = true;
+option java_package = "com.itsaky.androidide.tooling.buildgrpc.proto";
+option java_outer_classname = "BuildServiceProto";
+
+message BuildClientCapabilities {
+  bool supports_build_event_stream = 1;
+  bool supports_remote_execution = 2;
+  bool supports_incremental_tasks = 3;
+}
+
+message InitializeBuildRequest {
+  string protocol_version = 1;
+  string workspace_root = 2;
+  BuildClientCapabilities client_capabilities = 3;
+}
+
+message BuildServerCapabilities {
+  bool provides_build_event_stream = 1;
+  bool provides_remote_execution = 2;
+  bool provides_task_graph = 3;
+  bool supports_aidl_bridge = 4;
+}
+
+message InitializeBuildResponse {
+  string server_name = 1;
+  string server_version = 2;
+  BuildServerCapabilities capabilities = 3;
+}
+
+message BuildTarget {
+  string id = 1;
+  string display_name = 2;
+  repeated string tags = 3;
+}
+
+message QueryBuildTargetsRequest {}
+
+message QueryBuildTargetsResponse {
+  repeated BuildTarget targets = 1;
+}
+
+message ExecuteBuildRequest {
+  string request_id = 1;
+  repeated string target_ids = 2;
+  repeated string arguments = 3;
+  bool run_tests = 4;
+}
+
+message BuildEvent {
+  string request_id = 1;
+  string event_id = 2;
+  int64 event_time_epoch_ms = 3;
+  string category = 4;
+  string payload_json = 5;
+}
+
+message ExecuteBuildResponse {
+  string request_id = 1;
+  bool accepted = 2;
+}
+
+message BuildResult {
+  string request_id = 1;
+  bool success = 2;
+  int64 duration_ms = 3;
+  string summary = 4;
+}
+
+service BuildService {
+  rpc Initialize(InitializeBuildRequest) returns (InitializeBuildResponse);
+  rpc QueryTargets(QueryBuildTargetsRequest) returns (QueryBuildTargetsResponse);
+  rpc ExecuteBuild(ExecuteBuildRequest) returns (ExecuteBuildResponse);
+  rpc StreamBuildEvents(ExecuteBuildRequest) returns (stream BuildEvent);
+  rpc GetBuildResult(ExecuteBuildRequest) returns (BuildResult);
+}


### PR DESCRIPTION
### Motivation
- Provide a JVM-local, BSP-like build service protocol that combines gRPC (typed RPC + streaming), proto/Kotlin models, and AIDL for low-overhead IPC to support REAPI/BEP-style interactions.
- Create a project-local in-JVM transport suitable for Termux/JVM-hosted build service usage without network traffic and with better serialization/IPC characteristics than raw Kotlin serialization.

### Description
- Add a new `:tooling:build-grpc` Gradle module and register it in `settings.gradle.kts` as `:tooling:build-grpc`.
- Add `tooling/build-grpc/build.gradle.kts` with Kotlin/JVM, Protobuf and gRPC codegen configuration and dependency on `:tooling:reapi-proto`.
- Introduce a BSP/BEP/REAPI-inspired protobuf API in `src/main/proto/build_service.proto` defining initialization, target query, execute, event stream, and result RPCs.
- Add AIDL bridge contracts `IBuildServiceBridge.aidl` and `IBuildEventListener.aidl` for JSON-based IPC handoff and Kotlin scaffolding (`BuildProtocolContract`, `AidlGrpcBridge`, `BuildBridgeModels`, `BuildServiceArchitecture`) to describe the hybrid design.

### Testing
- Attempted `./gradlew :tooling:build-grpc:compileKotlin -q`, which failed due to an existing environment/setup issue reporting `25.0.2` before module compilation could complete.
- Verified changed files via `git status --short` and committed the scaffold with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143bd01ae0832cb166750d31eeeb5a)