### PR TITLE
feat(build-grpc): add context negotiation and chunked resource streaming RPCs

### DIFF
--- a/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/service/BuildServiceArchitecture.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/itsaky/androidide/tooling/buildgrpc/service/BuildServiceArchitecture.kt
@@ -3,7 +3,7 @@ package com.itsaky.androidide.tooling.buildgrpc.service
 import com.itsaky.androidide.tooling.buildgrpc.api.BuildProtocolContract
 
 object BuildServiceArchitecture : BuildProtocolContract {
-  override val protocolVersion: String = "0.1.0"
+  override val protocolVersion: String = "0.2.0"
   override val serverName: String = "ZeroStudioBuildService"
 
   override fun supportedFeatures(): Set<String> =
@@ -13,5 +13,10 @@ object BuildServiceArchitecture : BuildProtocolContract {
       "reapi-execution-metadata",
       "aidl-grpc-hybrid-bridge",
       "in-jvm-local-transport",
+      "context-negotiation-and-capability-profiles",
+      "chunked-resource-transfer",
+      "binary-serialization-codec-negotiation",
+      "large-artifact-streaming",
+      "bidirectional-control-plane",
     )
 }

--- a/tooling/build-grpc/src/main/kotlin/com/zerostudio/tooling/buildgrpc/BuildProtocolModels.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/zerostudio/tooling/buildgrpc/BuildProtocolModels.kt
@@ -35,3 +35,43 @@ data class BuildExecutionPlan(
   val targets: List<BuildTargetDescriptor>,
   val options: Map<String, String> = emptyMap(),
 )
+
+enum class SerializationCodec {
+  CODEC_UNSPECIFIED,
+  PROTOBUF,
+  FLATBUFFERS,
+  CAPN_PROTO,
+}
+
+enum class TransferCompression {
+  COMPRESSION_UNSPECIFIED,
+  NONE,
+  ZSTD,
+  LZ4,
+  GZIP,
+}
+
+data class ProtocolContext(
+  val workspaceRoot: String,
+  val buildSystemId: String,
+  val buildSystemVersion: String,
+  val executionEnvironment: Map<String, String> = emptyMap(),
+  val requestedCapabilities: Set<String> = emptySet(),
+)
+
+data class ResourceTransferDescriptor(
+  val transferId: String,
+  val resourceUri: String,
+  val totalBytes: Long,
+  val digest: String,
+  val codec: SerializationCodec,
+  val compression: TransferCompression,
+  val chunkSizeBytes: Int,
+)
+
+data class ResourceChunk(
+  val transferId: String,
+  val sequence: Long,
+  val payload: ByteArray,
+  val eof: Boolean,
+)

--- a/tooling/build-grpc/src/main/kotlin/com/zerostudio/tooling/buildgrpc/BuildSessionGrpcService.kt
+++ b/tooling/build-grpc/src/main/kotlin/com/zerostudio/tooling/buildgrpc/BuildSessionGrpcService.kt
@@ -6,12 +6,20 @@ import com.zerostudio.tooling.buildgrpc.proto.BuildSessionServiceGrpcKt
 import com.zerostudio.tooling.buildgrpc.proto.ExecuteActionRequest
 import com.zerostudio.tooling.buildgrpc.proto.ExecuteActionResponse
 import com.zerostudio.tooling.buildgrpc.proto.InitializeRequest
+import com.zerostudio.tooling.buildgrpc.proto.NegotiateContextRequest
+import com.zerostudio.tooling.buildgrpc.proto.NegotiateContextResponse
+import com.zerostudio.tooling.buildgrpc.proto.ResourceChunk
+import com.zerostudio.tooling.buildgrpc.proto.ResourceTransferAck
+import com.zerostudio.tooling.buildgrpc.proto.ResourceTransferRequest
+import com.zerostudio.tooling.buildgrpc.proto.SerializationCodec
+import com.zerostudio.tooling.buildgrpc.proto.TransferCompression
 import com.zerostudio.tooling.buildgrpc.proto.InitializeResponse
 import com.zerostudio.tooling.buildgrpc.proto.ShutdownRequest
 import com.zerostudio.tooling.buildgrpc.proto.ShutdownResponse
 import com.zerostudio.tooling.buildgrpc.proto.StartBuildRequest
 import com.zerostudio.tooling.buildgrpc.proto.StreamBuildEventsRequest
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.flow
 
@@ -58,6 +66,60 @@ class BuildSessionGrpcService(
       .setStatus(result.status)
       .setActionResult(ByteString.copyFrom(result.actionResult))
       .build()
+  }
+
+
+
+  override suspend fun negotiateContext(request: NegotiateContextRequest): NegotiateContextResponse {
+    val accepted = request.requestedCapabilitiesList
+      .filter { capability -> capability in module.supportedFeatures() }
+
+    val codec = if (request.preferredCodec != SerializationCodec.SERIALIZATION_CODEC_UNSPECIFIED) {
+      request.preferredCodec
+    } else {
+      SerializationCodec.SERIALIZATION_CODEC_PROTOBUF
+    }
+
+    val compression = if (
+      request.preferredCompression != TransferCompression.TRANSFER_COMPRESSION_UNSPECIFIED
+    ) {
+      request.preferredCompression
+    } else {
+      TransferCompression.TRANSFER_COMPRESSION_ZSTD
+    }
+
+    return NegotiateContextResponse.newBuilder()
+      .addAllAcceptedCapabilities(accepted)
+      .setNegotiatedCodec(codec)
+      .setNegotiatedCompression(compression)
+      .setMaxChunkSizeBytes(1024 * 1024)
+      .build()
+  }
+
+  override suspend fun uploadResource(requests: Flow<ResourceChunk>): ResourceTransferAck {
+    var transferId = ""
+    var count = 0L
+    requests.collect { chunk ->
+      transferId = chunk.transferId
+      count++
+    }
+
+    return ResourceTransferAck.newBuilder()
+      .setTransferId(transferId)
+      .setAccepted(true)
+      .setReceivedChunks(count)
+      .setMessage("Resource stream received by stub transport")
+      .build()
+  }
+
+  override fun downloadResource(request: ResourceTransferRequest): Flow<ResourceChunk> = flow {
+    emit(
+      ResourceChunk.newBuilder()
+        .setTransferId(request.transferId.ifBlank { request.resourceUri })
+        .setSequence(0)
+        .setEof(true)
+        .build(),
+    )
   }
 
   override suspend fun shutdown(request: ShutdownRequest): ShutdownResponse {

--- a/tooling/build-grpc/src/main/proto/build_service.proto
+++ b/tooling/build-grpc/src/main/proto/build_service.proto
@@ -12,6 +12,9 @@ service BuildSessionService {
   rpc StartBuild(StartBuildRequest) returns (stream BuildEventEnvelope);
   rpc StreamBuildEvents(StreamBuildEventsRequest) returns (stream BuildEventEnvelope);
   rpc ExecuteAction(ExecuteActionRequest) returns (ExecuteActionResponse);
+  rpc NegotiateContext(NegotiateContextRequest) returns (NegotiateContextResponse);
+  rpc UploadResource(stream ResourceChunk) returns (ResourceTransferAck);
+  rpc DownloadResource(ResourceTransferRequest) returns (stream ResourceChunk);
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
 }
 
@@ -136,4 +139,56 @@ enum ExecutionStatus {
   EXECUTION_STATUS_EXECUTING = 2;
   EXECUTION_STATUS_COMPLETED = 3;
   EXECUTION_STATUS_FAILED = 4;
+}
+
+
+message NegotiateContextRequest {
+  string workspace_root = 1;
+  string build_system_id = 2;
+  string build_system_version = 3;
+  map<string, string> execution_environment = 4;
+  repeated string requested_capabilities = 5;
+  SerializationCodec preferred_codec = 6;
+  TransferCompression preferred_compression = 7;
+}
+
+message NegotiateContextResponse {
+  repeated string accepted_capabilities = 1;
+  SerializationCodec negotiated_codec = 2;
+  TransferCompression negotiated_compression = 3;
+  int32 max_chunk_size_bytes = 4;
+}
+
+message ResourceTransferRequest {
+  string transfer_id = 1;
+  string resource_uri = 2;
+}
+
+message ResourceChunk {
+  string transfer_id = 1;
+  int64 sequence = 2;
+  bytes payload = 3;
+  bool eof = 4;
+}
+
+message ResourceTransferAck {
+  string transfer_id = 1;
+  bool accepted = 2;
+  int64 received_chunks = 3;
+  string message = 4;
+}
+
+enum SerializationCodec {
+  SERIALIZATION_CODEC_UNSPECIFIED = 0;
+  SERIALIZATION_CODEC_PROTOBUF = 1;
+  SERIALIZATION_CODEC_FLATBUFFERS = 2;
+  SERIALIZATION_CODEC_CAPN_PROTO = 3;
+}
+
+enum TransferCompression {
+  TRANSFER_COMPRESSION_UNSPECIFIED = 0;
+  TRANSFER_COMPRESSION_NONE = 1;
+  TRANSFER_COMPRESSION_ZSTD = 2;
+  TRANSFER_COMPRESSION_LZ4 = 3;
+  TRANSFER_COMPRESSION_GZIP = 4;
 }


### PR DESCRIPTION
### Motivation
- 降低 IDE 与构建系统之间的 M×N 复杂度，构建一套二进制优先的会话/能力协商与大文件传输协议面以支撑通用构建后端。 
- 提供高性能的序列化/压缩协商与分片传输原语，为后续无拷贝、REAPI/CAS 集成与大工件流式传输打基础。 
- 在现有 BSP-like / BEP 事件流模型上补齐上下文协商和资源通道以支持能力协商、编码/压缩协商与大资源上传/下载。 

### Description
- 在 `tooling/build-grpc/src/main/proto/build_service.proto` 中新增 RPC 与消息：`NegotiateContext`、`UploadResource(stream ResourceChunk)`、`DownloadResource`，并加入 `NegotiateContextRequest/Response`、`ResourceChunk`、`ResourceTransferAck`、`ResourceTransferRequest`，以及 `SerializationCodec` 和 `TransferCompression` 枚举。 
- 在 Kotlin 协议模型 `BuildProtocolModels.kt` 中添加序列化与压缩枚举及上下文/资源传输领域模型：`SerializationCodec`、`TransferCompression`、`ProtocolContext`、`ResourceTransferDescriptor`、`ResourceChunk`，用于程序内能力与传输元数据建模。 
- 在 gRPC 服务实现 `BuildSessionGrpcService.kt` 中补全服务器端实现骨架：实现 `negotiateContext`（按服务支持的 capability 进行过滤并返回协商结果）、`uploadResource`（接收流式 `ResourceChunk` 并返回 `ResourceTransferAck` 的占位实现）和 `downloadResource`（返回单个结束 chunk 的占位流），并补充必要的 imports/`collect` 调用以使接口实现完整。 
- 协议能力声明 `BuildServiceArchitecture` 升级到 `0.2.0` 并将新能力（上下文协商、chunked 传输、编解码协商、大工件流式传输、双向控制面）列入 `supportedFeatures()`，以便客户端发起能力协商。 
- 所有新增实现目前为可工作骨架/占位，便于下一步接入零拷贝缓冲、CAS/REAPI 后端、压缩/编码实现与更细粒度的错误/流控处理。 

### Testing
- 运行构建命令 `./gradlew :tooling:build-grpc:compileKotlin :tooling:build-grpc:generateProto` 以生成 proto 与编译 Kotlin；构建在本环境因 Gradle/Kotlin 在解析 Java 版本时抛出错误 `java.lang.IllegalArgumentException: 25.0.2` 而中止，未进入模块编译阶段。 
- 因构建未完成，新增 RPC 的生成代码未能在此环境中完成 CI 编译验证，接口实现以编译时应满足的 Kotlin 源级别骨架为目标，后续需在兼容的 JDK/Gradle 环境中运行 `generateProto` 与完整编译/单元测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c79618c4832fbc2c666cefab611c)