### PR TITLE
Fix Kotlin LSP warn logging call

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -28,10 +28,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git zip unzip protobuf-compiler python3 python3-pip wget curl
 
-      - name: Configure JDK 21 (Temurin)
+      - name: Configure JDK 21 (Zulu 21.0.9)
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '21'
           cache: 'gradle'
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -28,10 +28,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git zip unzip protobuf-compiler python3 python3-pip wget curl
 
-      - name: Configure JDK 21 (Zulu 21.0.9)
+      - name: Configure JDK 21 (Temurin)
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
 

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -85,11 +85,6 @@ import org.slf4j.LoggerFactory
 class GradleBuildService :
     Service(), BuildService, ToolingServerRunner.Observer {
 
-  companion object {
-    private const val PROP_USE_TOOLING_EXECUTE = "androidide.use.tooling.execute"
-    private const val PROP_TOOLING_EXECUTE_JVM_ARGS = "androidide.tooling.execute.jvmArgs"
-  }
-
   private var mBinder: GradleServiceBinder? = null
   private var isToolingServerStarted = false
   override var isBuildInProgress = false
@@ -133,6 +128,8 @@ class GradleBuildService :
 
   companion object {
 
+    private const val PROP_USE_TOOLING_EXECUTE = "androidide.use.tooling.execute"
+    private const val PROP_TOOLING_EXECUTE_JVM_ARGS = "androidide.tooling.execute.jvmArgs"
     private val log = LoggerFactory.getLogger(GradleBuildService::class.java)
     private val NOTIFICATION_ID = R.string.app_name
     private val SERVER_System_err = LoggerFactory.getLogger("ToolingApiErrorStream")

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -28,7 +28,6 @@ import androidx.core.app.NotificationManagerCompat
 import com.blankj.utilcode.util.ResourceUtils
 import com.blankj.utilcode.util.ZipUtils
 import com.itsaky.androidide.BuildConfig
-import com.itsaky.androidide.R.*
 import com.itsaky.androidide.app.BaseApplication
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.managers.ToolsManager
@@ -162,7 +161,7 @@ class GradleBuildService :
     val buildNotificationChannel =
         NotificationChannel(
             BaseApplication.NOTIFICATION_GRADLE_BUILD_SERVICE,
-            getString(string.title_gradle_service_notification_channel),
+            getString(R.string.title_gradle_service_notification_channel),
             NotificationManager.IMPORTANCE_LOW,
         )
     NotificationManagerCompat.from(this).createNotificationChannel(buildNotificationChannel)

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt
@@ -643,7 +643,7 @@ class KotlinLanguageServerImpl(
             throw IllegalStateException("Kotlin LSP is not initialized. Cannot execute command '$commandName'.")
         }
         if (!canExecuteCommand(commandName)) {
-            log.warn("Executing Kotlin LSP command '{}' even though it was not advertised by the server.", commandName)
+            log.warn("Executing Kotlin LSP command '$commandName' even though it was not advertised by the server.")
         }
 
         val params = LspExecuteCommandParams(commandName, toLspArguments(arguments))


### PR DESCRIPTION
### Motivation
- Fix a Kotlin compile error caused by calling `log.warn` with formatting arguments while the project `Logger.warn` only accepts a single `message: String` parameter.

### Description
- Replace the multi-argument logging call with a single interpolated string in `lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/KotlinLanguageServerImpl.kt`, changing `log.warn("Executing Kotlin LSP command '{}' even though it was not advertised by the server.", commandName)` to `log.warn("Executing Kotlin LSP command '$commandName' even though it was not advertised by the server.")`.

### Testing
- Ran `git diff --check` (clean); attempted `./gradlew :lsp:kotlin:compileDebugKotlin` which failed due to the environment using OpenJDK `25.0.2` causing `IllegalArgumentException: 25.0.2`; re-ran with `JAVA_HOME` pointing to Java 17 which progressed past the Java-version issue but failed resolving `com.mooltiverse.oss.nyx:gradle:2.5.2` from Maven Central (HTTP 403), so the module compile did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b88bd878832fb4508b323c722cc6)