### PR TITLE
Fix app Kotlin build references and adapt tooling operation types

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -225,6 +225,7 @@ dependencies {
   implementation(projects.xml.lsp)
   implementation(projects.xml.utils)
   implementation(projects.tooling.api)
+  implementation(projects.tooling.buildGrpc)
   implementation(projects.tooling.pluginConfig)
   compileOnly(projects.tooling.impl)
   implementation(projects.utilities.buildInfo)

--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -75,7 +75,6 @@ import java.util.stream.Collectors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.gradle.tooling.events.OperationType
 
 /** @author Akash Yadav */
 @Suppress("MemberVisibilityCanBePrivate")
@@ -492,13 +491,13 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
         ToolingClientCapabilities(
             requestedOperationTypes =
                 linkedSetOf(
-                    OperationType.TASK,
-                    OperationType.TEST,
-                    OperationType.PROJECT_CONFIGURATION,
-                    OperationType.FILE_DOWNLOAD,
-                    OperationType.TRANSFORM,
-                    OperationType.WORK_ITEM,
-                    OperationType.GENERIC,
+                    "TASK",
+                    "TEST",
+                    "PROJECT_CONFIGURATION",
+                    "FILE_DOWNLOAD",
+                    "TRANSFORM",
+                    "WORK_ITEM",
+                    "GENERIC",
                 ),
             // keep default aligned with DEFAULT_MAX_TOOLING_EVENTS_PER_SECOND
             // so client/server event traffic is bounded on constrained devices

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -74,7 +74,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import org.gradle.tooling.events.OperationType
 import org.slf4j.LoggerFactory
 
 /**
@@ -362,7 +361,7 @@ class GradleBuildService :
     }
   }
 
-  override fun logOutput(line: String) {
+  private fun logOutput(line: String) {
     eventListener?.onOutput(line)
   }
 
@@ -435,7 +434,7 @@ class GradleBuildService :
     return CompletableFuture.completedFuture(extraArgs)
   }
 
-  override fun checkGradleWrapperAvailability(): CompletableFuture<GradleWrapperCheckResult> {
+  fun checkGradleWrapperAvailability(): CompletableFuture<GradleWrapperCheckResult> {
     return if (isGradleWrapperAvailable)
         CompletableFuture.completedFuture(GradleWrapperCheckResult(true))
     else installWrapper()
@@ -581,7 +580,7 @@ class GradleBuildService :
     return performBuildTasks(
         CompletableFuture.supplyAsync {
           val buildInfo = BuildInfo(tasksList)
-          prepareBuild(buildInfo)
+          onBuildPrepared(buildInfo)
 
           try {
             val projectDir = ProjectManagerImpl.getInstance().projectDir
@@ -779,7 +778,7 @@ class GradleBuildService :
     return performBuildTasks(requireServerEndpoint().execute(sanitized))
   }
 
-  private fun resolvePreferredOperationTypes(): Set<OperationType> {
+  private fun resolvePreferredOperationTypes(): Set<String> {
     val fromInitialize = lastInitializeResult?.negotiatedOperationTypes.orEmpty()
     if (fromInitialize.isNotEmpty()) {
       return fromInitialize
@@ -791,15 +790,15 @@ class GradleBuildService :
         negotiated
       } else {
         linkedSetOf(
-            OperationType.TASK,
-            OperationType.PROJECT_CONFIGURATION,
+            "TASK",
+            "PROJECT_CONFIGURATION",
         )
       }
     } catch (error: Throwable) {
       log.warn("Unable to load negotiated operation types from tooling metadata", error)
       linkedSetOf(
-          OperationType.TASK,
-          OperationType.PROJECT_CONFIGURATION,
+          "TASK",
+          "PROJECT_CONFIGURATION",
       )
     }
   }
@@ -996,7 +995,7 @@ class GradleBuildService :
       null
     } else
         object : EventListener {
-          override fun onBuildPrepared(buildInfo: BuildInfo) {
+          override fun prepareBuild(buildInfo: BuildInfo) {
             runOnUiThread { listener.prepareBuild(buildInfo) }
           }
 


### PR DESCRIPTION
### Motivation
- Resolve Kotlin compilation errors caused by unresolved build-bridge types and direct references to Gradle's `OperationType` enum in app code, and align app-side build callbacks with the current tooling transport observer contract.

### Description
- Add the `tooling:build-grpc` project dependency to `core/app` so app sources can resolve integrated build bridge/runtime types by adding `implementation(projects.tooling.buildGrpc)` to `core/app/build.gradle.kts`.
- Replace usages of `org.gradle.tooling.events.OperationType` with the string operation-type names (e.g. `"TASK"`, `"PROJECT_CONFIGURATION"`) in `ProjectHandlerActivity.kt` and `GradleBuildService.kt` so the app uses the same wire-format operation types carried by the tooling API models.
- Change `GradleBuildService` helper/callback signatures to match the transport/observer contract by making `logOutput` private, making `checkGradleWrapperAvailability` a plain function, calling `onBuildPrepared(buildInfo)` from shell-path builds, and implementing `prepareBuild(buildInfo)` in the wrapped `EventListener` adapter.

### Testing
- Ran `git diff --check` with no issues reported (success).
- Verified the Gradle runtime with `./gradlew --version` under `java@17.0.2` (success).
- Attempted to compile the app with `./gradlew :core:app:compileDebugKotlin` and `ZEROSTUDIO_SKIP_NYX=true ./gradlew :core:app:compileDebugKotlin`, but the build was blocked by environment/network issues: initial run failed due to the system JDK being Java 25 so switched to `java@17.0.2`, then dependency resolution to the Gradle plugin portal failed with HTTP 403 for `com.mooltiverse.oss.nyx:gradle:2.5.2` and the offline run failed because the artifact was not cached (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba3764b84832ab2ab7da989307760)