### PR TITLE
Avoid duplicate REAPI proto generation

### DIFF
--- a/tooling/build-grpc/build.gradle.kts
+++ b/tooling/build-grpc/build.gradle.kts
@@ -19,7 +19,13 @@ sourceSets {
   main {
     proto {
       srcDir("src/main/proto")
-      include("**/*.proto")
+
+      // The build/bazel protos are kept under this source directory only as imports for
+      // build_service.proto. Generate their Java/Kotlin classes from :tooling:reapi-proto
+      // instead, otherwise Android receives the same build.bazel.* classes from both
+      // modules and D8 fails while merging dex archives.
+      include("binary_protocol.proto")
+      include("build_service.proto")
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent Android D8 duplicate-class failures caused by generating the same `build.bazel.*` classes from both `:tooling:build-grpc` and `:tooling:reapi-proto` by making a single module the source of truth for REAPI-generated classes.

### Description
- Restrict protobuf generation in `tooling/build-grpc/build.gradle.kts` to only its own files by replacing the previous `include("**/*.proto")` with explicit `include("binary_protocol.proto")` and `include("build_service.proto")`, keeping the `build/bazel` protos present only as imports and allowing `:tooling:reapi-proto` to generate the shared Java/Kotlin classes.

### Testing
- Ran `git diff --check` (success) and attempted `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ZEROSTUDIO_SKIP_NYX=true ./gradlew :tooling:build-grpc:compileKotlin --no-daemon`, but the build could not complete in this environment due to plugin resolution / JVM version issues so the dex-merge fix was not fully re-verified by an Android build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3c8ab3748322b29dd0d17364208f)