### PR TITLE
Add editor toolbox bottom-sheet tab

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/adapters/EditorBottomSheetTabAdapter.java
+++ b/core/app/src/main/java/com/itsaky/androidide/adapters/EditorBottomSheetTabAdapter.java
@@ -38,7 +38,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.itsaky.androidide.fragments.git.*;
-import android.studio.zero.regular.expression.preview.RegexPreviewFragment;
+import com.itsaky.androidide.fragments.toolbox.EditorToolboxFragment;
+import com.itsaky.androidide.utils.EditorToolboxActions;
 
 public class EditorBottomSheetTabAdapter extends FragmentStateAdapter {
 
@@ -50,32 +51,30 @@ public class EditorBottomSheetTabAdapter extends FragmentStateAdapter {
 
     var index = -1;
     this.fragments = new ArrayList<>();
-    
+    EditorToolboxActions.registerActions(fragmentActivity);
+
     //构建输出
     this.fragments.add(new Tab(fragmentActivity.getString(R.string.build_output),
         BuildOutputFragment.class,++index));
-     
+
      //application log
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.app_logs), 
+    this.fragments.add(new Tab(fragmentActivity.getString(R.string.app_logs),
         AppLogFragment.class, ++index));
         // IDE log
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.ide_logs), 
+    this.fragments.add(new Tab(fragmentActivity.getString(R.string.ide_logs),
         IDELogFragment.class, ++index));
 
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_apm_panel), 
+    this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_apm_panel),
         EditorProcessApmFragment.class, ++index));
-        
-       //正则表达式可视化调试与预览
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_regular_preview), 
-       RegexPreviewFragment.class, ++index));
-       
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_regular_preview), 
-       com.itsaky.androidide.repository.dependencies.analyzer.ui.DependencyUpdateFragment.class, ++index));
-       
+
+       // 多功能入口工具箱：按需打开正则、依赖更新、MCP、AI 路由等工具。
+    this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_editor_toolbox),
+       EditorToolboxFragment.class, ++index));
+
     //诊断
      this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_diags),
          DiagnosticsListFragment.class,++index));
-   
+
    //搜索结果
      this.fragments.add(
         new Tab(

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxFragment.kt
@@ -1,0 +1,310 @@
+package com.itsaky.androidide.fragments.toolbox
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commitNow
+import androidx.fragment.app.commitNowAllowingStateLoss
+import androidx.fragment.app.FragmentContainerView
+import com.itsaky.androidide.resources.R
+
+/** Multi-purpose editor toolbox with a fixed grid tab and lazily materialized tool fragments. */
+class EditorToolboxFragment : Fragment() {
+
+  private var containerId: Int = View.NO_ID
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
+  ): View {
+    containerId = View.generateViewId()
+    return ComposeView(requireContext()).apply {
+      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+      setContent { MaterialTheme { EditorToolboxScreen() } }
+    }
+  }
+
+  override fun onDestroyView() {
+    releaseToolFragments(allowStateLoss = true)
+    containerId = View.NO_ID
+    super.onDestroyView()
+  }
+
+  @Composable
+  private fun EditorToolboxScreen() {
+    val usageStore = remember { ToolboxUsageStore(requireContext()) }
+    var selectedTab by rememberSaveable { mutableStateOf(GRID_TAB_ID) }
+    var openedToolIds by rememberSaveable { mutableStateOf(emptyList<String>()) }
+    var usageVersion by rememberSaveable { mutableIntStateOf(0) }
+
+    val entries = remember(usageVersion) {
+      EditorToolboxRegistry.getEntries().sortedWith(
+          compareByDescending<EditorToolboxEntry> { usageStore.getLaunchCount(it.id) }
+              .thenBy { it.order }
+              .thenBy { it.title }
+      )
+    }
+    val openedEntries = openedToolIds.mapNotNull { EditorToolboxRegistry.find(it) }
+
+    LaunchedEffect(selectedTab, openedToolIds, containerId) {
+      if (selectedTab == GRID_TAB_ID) {
+        releaseToolFragments(allowStateLoss = false)
+      } else {
+        showToolFragment(selectedTab)
+      }
+    }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+      Column(modifier = Modifier.fillMaxSize()) {
+        EditorToolboxTabs(
+            selectedTab = selectedTab,
+            openedEntries = openedEntries,
+            onSelectTab = { selectedTab = it }
+        )
+        HorizontalDivider()
+        Box(modifier = Modifier.fillMaxSize()) {
+          FragmentHost(
+              visible = selectedTab != GRID_TAB_ID,
+              modifier = Modifier.fillMaxSize(),
+          )
+          if (selectedTab == GRID_TAB_ID) {
+            ToolboxGrid(
+                entries = entries,
+                usageStore = usageStore,
+                onOpen = { entry ->
+                  usageStore.recordLaunch(entry.id)
+                  usageVersion++
+                  if (entry.id !in openedToolIds) {
+                    openedToolIds = openedToolIds + entry.id
+                  }
+                  selectedTab = entry.id
+                }
+            )
+          }
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun EditorToolboxTabs(
+      selectedTab: String,
+      openedEntries: List<EditorToolboxEntry>,
+      onSelectTab: (String) -> Unit,
+  ) {
+    val selectedIndex = if (selectedTab == GRID_TAB_ID) {
+      0
+    } else {
+      val openedIndex = openedEntries.indexOfFirst { it.id == selectedTab }
+      if (openedIndex >= 0) openedIndex + 1 else 0
+    }
+
+    ScrollableTabRow(
+        selectedTabIndex = selectedIndex,
+        edgePadding = 8.dp,
+    ) {
+      Tab(
+          selected = selectedTab == GRID_TAB_ID,
+          onClick = { onSelectTab(GRID_TAB_ID) },
+          text = { Text(text = getString(R.string.title_editor_toolbox_grid), maxLines = 1) },
+          icon = {
+            Icon(painterResource(R.drawable.ic_widget_grid_view), contentDescription = null)
+          },
+      )
+      openedEntries.forEach { entry ->
+        Tab(
+            selected = selectedTab == entry.id,
+            onClick = { onSelectTab(entry.id) },
+            text = { Text(text = entry.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            icon = { Icon(painterResource(entry.iconRes), contentDescription = null) },
+        )
+      }
+    }
+  }
+
+  @Composable
+  private fun ToolboxGrid(
+      entries: List<EditorToolboxEntry>,
+      usageStore: ToolboxUsageStore,
+      onOpen: (EditorToolboxEntry) -> Unit,
+  ) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 108.dp),
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      items(items = entries, key = { it.id }) { entry ->
+        ToolboxGridButton(
+            entry = entry,
+            launchCount = usageStore.getLaunchCount(entry.id),
+            onClick = { onOpen(entry) }
+        )
+      }
+    }
+  }
+
+  @Composable
+  private fun ToolboxGridButton(entry: EditorToolboxEntry, launchCount: Int, onClick: () -> Unit) {
+    ElevatedCard(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().height(126.dp),
+        shape = RoundedCornerShape(22.dp),
+        elevation =
+            CardDefaults.elevatedCardElevation(defaultElevation = 3.dp, pressedElevation = 8.dp),
+        colors =
+            CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            ),
+    ) {
+      Column(
+          modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp, vertical = 12.dp),
+          horizontalAlignment = Alignment.CenterHorizontally,
+          verticalArrangement = Arrangement.Center,
+      ) {
+        Icon(
+            painter = painterResource(entry.iconRes),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = entry.title,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (launchCount > 0) {
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+              text = getString(R.string.editor_toolbox_usage_count, launchCount),
+              style = MaterialTheme.typography.labelSmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              maxLines = 1,
+          )
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun FragmentHost(visible: Boolean, modifier: Modifier = Modifier) {
+    androidx.compose.ui.viewinterop.AndroidView(
+        modifier = modifier,
+        factory = { context ->
+          FragmentContainerView(context).apply {
+            id = containerId
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+          }
+        },
+        update = { it.visibility = if (visible) View.VISIBLE else View.GONE },
+    )
+  }
+
+  private fun showToolFragment(toolId: String) {
+    val entry = EditorToolboxRegistry.find(toolId) ?: return
+    if (containerId == View.NO_ID || view == null) return
+    val manager = childFragmentManager
+    val tag = toolTag(toolId)
+    val current = manager.findFragmentByTag(tag)
+    manager.commitNowAllowingStateLoss {
+      manager.fragments
+          .filter { it.tag?.startsWith(TOOL_TAG_PREFIX) == true && it.tag != tag }
+          .forEach { remove(it) }
+      if (current == null) {
+        val fragment =
+            manager.fragmentFactory.instantiate(
+                entry.fragmentClass.classLoader!!,
+                entry.fragmentClass.name,
+            )
+        replace(containerId, fragment, tag)
+      } else if (!current.isAdded) {
+        add(containerId, current, tag)
+      } else {
+        setMaxLifecycle(current, androidx.lifecycle.Lifecycle.State.RESUMED)
+      }
+      setReorderingAllowed(true)
+    }
+  }
+
+  private fun releaseToolFragments(allowStateLoss: Boolean) {
+    if (childFragmentManager.isStateSaved && !allowStateLoss) return
+    val fragments =
+        childFragmentManager.fragments.filter { it.tag?.startsWith(TOOL_TAG_PREFIX) == true }
+    if (fragments.isEmpty()) return
+    if (allowStateLoss) {
+      childFragmentManager.commitNowAllowingStateLoss { fragments.forEach { remove(it) } }
+    } else {
+      childFragmentManager.commitNow { fragments.forEach { remove(it) } }
+    }
+  }
+
+  private class ToolboxUsageStore(context: Context) {
+    private val preferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getLaunchCount(id: String): Int = preferences.getInt(id, 0)
+
+    fun recordLaunch(id: String) {
+      preferences.edit().putInt(id, getLaunchCount(id) + 1).apply()
+    }
+  }
+
+  private companion object {
+    const val GRID_TAB_ID = "editor.toolbox.grid"
+    const val TOOL_TAG_PREFIX = "editor.toolbox.tool."
+    const val PREFS_NAME = "editor_toolbox_usage"
+
+    fun toolTag(toolId: String): String = TOOL_TAG_PREFIX + toolId
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxRegistry.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxRegistry.kt
@@ -1,0 +1,37 @@
+package com.itsaky.androidide.fragments.toolbox
+
+import androidx.annotation.DrawableRes
+import androidx.fragment.app.Fragment
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Registry for editor toolbox entries.
+ *
+ * Entries are deliberately lightweight descriptors so tools can be plugged in or removed without
+ * instantiating their Fragment until the user opens that tool tab.
+ */
+object EditorToolboxRegistry {
+  private val entries = CopyOnWriteArrayList<EditorToolboxEntry>()
+
+  fun register(entry: EditorToolboxEntry) {
+    entries.removeAll { it.id == entry.id }
+    entries += entry
+  }
+
+  fun unregister(id: String) {
+    entries.removeAll { it.id == id }
+  }
+
+  fun getEntries(): List<EditorToolboxEntry> = entries.sortedWith(compareBy<EditorToolboxEntry> { it.order }.thenBy { it.title })
+
+  fun find(id: String): EditorToolboxEntry? = entries.firstOrNull { it.id == id }
+}
+
+data class EditorToolboxEntry(
+  val id: String,
+  val title: String,
+  val description: String,
+  @DrawableRes val iconRes: Int,
+  val fragmentClass: Class<out Fragment>,
+  val order: Int,
+)

--- a/core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -45,7 +45,6 @@ import com.itsaky.androidide.actions.sidebar.BuildVariantsSidebarAction
 import com.itsaky.androidide.actions.sidebar.CloseProjectSidebarAction
 import com.itsaky.androidide.actions.sidebar.DataFileTreeSidebarAction
 import com.itsaky.androidide.actions.sidebar.FileTreeSidebarAction
-import com.itsaky.androidide.actions.sidebar.McpFragmentSidebarAction
 import com.itsaky.androidide.actions.sidebar.PreferencesSidebarAction
 import com.itsaky.androidide.actions.sidebar.ProjectMaterialsSidebarAction
 import com.itsaky.androidide.actions.sidebar.TerminalSidebarAction
@@ -71,7 +70,6 @@ internal object EditorSidebarActions {
     registry.registerAction(DataFileTreeSidebarAction(context, ++order))
     registry.registerAction(BuildVariantsSidebarAction(context, ++order))
     registry.registerAction(TerminalSidebarAction(context, ++order))
-    registry.registerAction(McpFragmentSidebarAction(context, ++order))
     registry.registerAction(ProjectMaterialsSidebarAction(context, ++order))
     registry.registerAction(PreferencesSidebarAction(context, ++order))
     registry.registerAction(CloseProjectSidebarAction(context, ++order))

--- a/core/app/src/main/java/com/itsaky/androidide/utils/EditorToolboxActions.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/utils/EditorToolboxActions.kt
@@ -1,0 +1,58 @@
+package com.itsaky.androidide.utils
+
+import android.content.Context
+import android.studio.zero.regular.expression.preview.RegexPreviewFragment
+import android.zero.studio.chatai.server.mcp.McpFragment
+import com.itsaky.androidide.fragments.toolbox.EditorToolboxEntry
+import com.itsaky.androidide.fragments.toolbox.EditorToolboxRegistry
+import com.itsaky.androidide.repository.dependencies.analyzer.ui.DependencyUpdateFragment
+import com.itsaky.androidide.resources.R
+import me.rerere.rikkahub.RouteFragment
+
+/** Registers pluggable tools shown by the editor toolbox bottom-sheet tab. */
+object EditorToolboxActions {
+  @JvmStatic
+  fun registerActions(context: Context) {
+    var order = -1
+    EditorToolboxRegistry.register(
+        EditorToolboxEntry(
+            id = "editor.toolbox.dependencyUpdates",
+            title = context.getString(R.string.title_dependency_updates),
+            description = context.getString(R.string.desc_dependency_updates),
+            iconRes = R.drawable.ic_tools_android_build_sdkmanager,
+            fragmentClass = DependencyUpdateFragment::class.java,
+            order = ++order,
+        )
+    )
+    EditorToolboxRegistry.register(
+        EditorToolboxEntry(
+            id = "editor.toolbox.regexPreview",
+            title = context.getString(R.string.title_regular_preview),
+            description = context.getString(R.string.desc_regular_preview),
+            iconRes = R.drawable.ic_widget_grid_layout,
+            fragmentClass = RegexPreviewFragment::class.java,
+            order = ++order,
+        )
+    )
+    EditorToolboxRegistry.register(
+        EditorToolboxEntry(
+            id = "editor.toolbox.mcpServer",
+            title = context.getString(R.string.title_mcp_server),
+            description = context.getString(R.string.desc_mcp_server),
+            iconRes = R.drawable.ic_ai_mcp_server,
+            fragmentClass = McpFragment::class.java,
+            order = ++order,
+        )
+    )
+    EditorToolboxRegistry.register(
+        EditorToolboxEntry(
+            id = "editor.toolbox.chatRoute",
+            title = context.getString(R.string.title_chat_route),
+            description = context.getString(R.string.desc_chat_route),
+            iconRes = R.drawable.ic_settings,
+            fragmentClass = RouteFragment::class.java,
+            order = ++order,
+        )
+    )
+  }
+}

--- a/core/resources/src/main/res/values-zh-rCN/strings_b.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings_b.xml
@@ -19,4 +19,14 @@
     <string name="lsp_clangd_fuzzy_ratio">Fuzzy match ratio: %1$d</string>
     <string name="lsp_clangd_reset_defaults">Reset defaults</string>
     <string name="title_template_native_build_imgui">C++ image gui</string>
+
+    <string name="title_editor_toolbox">工具箱</string>
+    <string name="title_editor_toolbox_grid">工具</string>
+    <string name="editor_toolbox_usage_count">已使用 %1$d 次</string>
+    <string name="title_dependency_updates">依赖更新</string>
+    <string name="title_chat_route">AI 聊天</string>
+    <string name="desc_dependency_updates">分析项目依赖并生成更新建议。</string>
+    <string name="desc_regular_preview">可视化预览和调试正则表达式。</string>
+    <string name="desc_mcp_server">打开 MCP 服务器控制台。</string>
+    <string name="desc_chat_route">打开内嵌 AI 聊天路由页面。</string>
 </resources>

--- a/core/resources/src/main/res/values/strings_b.xml
+++ b/core/resources/src/main/res/values/strings_b.xml
@@ -331,4 +331,14 @@ Permission: %5$s
 %6$s
 MD5: %7$s
 SHA1: %8$s
-SHA256: %9$s</string></resources>
+SHA256: %9$s</string>
+    <string name="title_editor_toolbox">Toolbox</string>
+    <string name="title_editor_toolbox_grid">Tools</string>
+    <string name="editor_toolbox_usage_count">Used %1$d times</string>
+    <string name="title_dependency_updates">Dependency Updates</string>
+    <string name="title_chat_route">AI Chat</string>
+    <string name="desc_dependency_updates">Analyze project dependencies and prepare update suggestions.</string>
+    <string name="desc_regular_preview">Preview and debug regular expressions visually.</string>
+    <string name="desc_mcp_server">Open the MCP server control console.</string>
+    <string name="desc_chat_route">Open the embedded AI chat route page.</string>
+</resources>


### PR DESCRIPTION
### Motivation
- Consolidate multiple scattered editor tool entries (regex preview, dependency updates, MCP, chat route) into a single multi-tool toolbox to simplify discovery and management.
- Provide a pluggable registry so tools can be added/removed quickly without instantiating their Fragments until needed. 
- Reduce idle resource usage by lazily creating and releasing tool Fragments and improving lifecycle management for bottom-sheet tool tabs.

### Description
- Added a lightweight registry and entry descriptor with `EditorToolboxRegistry` and `EditorToolboxEntry` to register/unregister toolbox tools without immediate Fragment instantiation (`core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxRegistry.kt`).
- Implemented a Compose + Material3 based toolbox UI in `EditorToolboxFragment` featuring a fixed grid tab, scrollable adaptive grid of card buttons (icon above, title below), usage-count sorting, dynamic opened-tool tabs, and a child `FragmentContainerView` that lazily creates/replaces/removes tool Fragments to reclaim resources (`core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxFragment.kt`).
- Added `EditorToolboxActions` to register default tools (Dependency Updates, Regex Preview, MCP Server, and `RouteFragment`) into the registry and replaced direct bottom-sheet tabs with a single Toolbox tab by registering toolbox actions at adapter creation time (`core/app/src/main/java/com/itsaky/androidide/utils/EditorToolboxActions.kt` and modified `EditorBottomSheetTabAdapter` to include `EditorToolboxFragment`).
- Removed the direct MCP sidebar registration to avoid duplicate entry points and added necessary string resources (English and Simplified Chinese) for toolbox UI labels and descriptions (`core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt`, `core/resources/src/main/res/values/strings_b.xml`, `core/resources/src/main/res/values-zh-rCN/strings_b.xml`).

### Testing
- Ran `git diff --check` to ensure no whitespace or obvious diff issues, which passed.
- Validated the added string resource XML files with a quick parse using Python (`python3 - <<'PY' ... ET.parse(...) ... PY`) and the XML parsing succeeded for updated files.
- Attempted to compile Kotlin with `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ./gradlew :core:app:compileDebugKotlin`, but the build failed due to an external dependency resolution error (Maven Central returned HTTP 403 for `com.mooltiverse.oss.nyx:gradle:2.5.2`), so a full local build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d6ad98848832f82486beb78a5e692)