### PR TITLE
Add editor toolbox bottom drawer (Compose grid + on-demand tabs)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/adapters/EditorBottomSheetTabAdapter.java
+++ b/core/app/src/main/java/com/itsaky/androidide/adapters/EditorBottomSheetTabAdapter.java
@@ -38,7 +38,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.itsaky.androidide.fragments.git.*;
-import android.studio.zero.regular.expression.preview.RegexPreviewFragment;
+import com.itsaky.androidide.fragments.toolbox.EditorToolboxFragment;
 
 public class EditorBottomSheetTabAdapter extends FragmentStateAdapter {
 
@@ -65,12 +65,9 @@ public class EditorBottomSheetTabAdapter extends FragmentStateAdapter {
     this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_apm_panel), 
         EditorProcessApmFragment.class, ++index));
         
-       //正则表达式可视化调试与预览
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_regular_preview), 
-       RegexPreviewFragment.class, ++index));
-       
-    this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_regular_preview), 
-       com.itsaky.androidide.repository.dependencies.analyzer.ui.DependencyUpdateFragment.class, ++index));
+       //多功能工具箱：按需打开正则预览、依赖更新、MCP、AI Chat 等工具。
+    this.fragments.add(new Tab(fragmentActivity.getString(R.string.title_editor_toolbox),
+       EditorToolboxFragment.class, ++index));
        
     //诊断
      this.fragments.add(new Tab(fragmentActivity.getString(R.string.view_diags),

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxEntry.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxEntry.kt
@@ -1,0 +1,17 @@
+package com.itsaky.androidide.fragments.toolbox
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import kotlin.reflect.KClass
+
+/**
+ * Pluggable descriptor for an editor toolbox entry.
+ */
+data class EditorToolboxEntry(
+    val id: String,
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+    @DrawableRes val iconRes: Int,
+    val fragmentClass: KClass<out Fragment>,
+)

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxFragment.kt
@@ -1,0 +1,188 @@
+package com.itsaky.androidide.fragments.toolbox
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import com.google.android.material.tabs.TabLayout
+import com.itsaky.androidide.R
+
+/**
+ * Editor bottom-drawer toolbox. Tabs are metadata only until selected; the active page is created on
+ * demand and the previously active fragment is removed to release view/lifecycle resources while
+ * keeping its tab mounted for quick re-entry.
+ */
+class EditorToolboxFragment : Fragment(), EditorToolboxGridFragment.ToolSelectionListener {
+
+  private var tabLayout: TabLayout? = null
+  private var container: ViewGroup? = null
+  private val openedTabs = linkedMapOf<String, EditorToolboxEntry>()
+  private var selectedTabId: String = HOME_TAB_ID
+  private var suppressTabCallback = false
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?,
+  ): View {
+    val context = requireContext()
+    return LinearLayout(context).apply {
+      orientation = LinearLayout.VERTICAL
+      layoutParams =
+          ViewGroup.LayoutParams(
+              ViewGroup.LayoutParams.MATCH_PARENT,
+              ViewGroup.LayoutParams.MATCH_PARENT,
+          )
+
+      tabLayout =
+          TabLayout(context).apply {
+            id = R.id.editor_toolbox_tabs
+            tabMode = TabLayout.MODE_SCROLLABLE
+            tabGravity = TabLayout.GRAVITY_START
+            layoutParams =
+                LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                )
+          }
+      addView(tabLayout)
+
+      this@EditorToolboxFragment.container =
+          androidx.fragment.app.FragmentContainerView(context).apply {
+            id = R.id.editor_toolbox_fragment_container
+            layoutParams =
+                LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    0,
+                    1f,
+                )
+          }
+      addView(this@EditorToolboxFragment.container)
+    }
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    restoreTabs(savedInstanceState)
+    setupTabs()
+    selectTab(selectedTabId)
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putStringArrayList(STATE_OPENED_TABS, ArrayList(openedTabs.keys))
+    outState.putString(STATE_SELECTED_TAB, selectedTabId)
+  }
+
+  override fun onDestroyView() {
+    container = null
+    tabLayout = null
+    super.onDestroyView()
+  }
+
+  override fun onToolSelected(entry: EditorToolboxEntry) {
+    openedTabs[entry.id] = entry
+    val tabs = tabLayout ?: return
+    val existingTab = findTabById(entry.id)
+    val tab = existingTab ?: tabs.newTab().apply {
+      tag = entry.id
+      text = getString(entry.titleRes)
+      contentDescription = getString(entry.descriptionRes)
+      tabs.addTab(this, false)
+    }
+    tab.select()
+  }
+
+  private fun restoreTabs(savedInstanceState: Bundle?) {
+    openedTabs.clear()
+    savedInstanceState?.getStringArrayList(STATE_OPENED_TABS)?.forEach { id ->
+      EditorToolboxRegistry.findEntry(id)?.let { openedTabs[id] = it }
+    }
+    selectedTabId = savedInstanceState?.getString(STATE_SELECTED_TAB) ?: HOME_TAB_ID
+  }
+
+  private fun setupTabs() {
+    val tabs = tabLayout ?: return
+    tabs.clearOnTabSelectedListeners()
+    tabs.removeAllTabs()
+    tabs.addTab(
+        tabs.newTab().apply {
+          tag = HOME_TAB_ID
+          text = getString(R.string.title_editor_toolbox_home)
+          contentDescription = getString(R.string.desc_editor_toolbox)
+        },
+        false,
+    )
+    openedTabs.values.forEach { entry ->
+      tabs.addTab(
+          tabs.newTab().apply {
+            tag = entry.id
+            text = getString(entry.titleRes)
+            contentDescription = getString(entry.descriptionRes)
+          },
+          false,
+      )
+    }
+    tabs.addOnTabSelectedListener(
+        object : TabLayout.OnTabSelectedListener {
+          override fun onTabSelected(tab: TabLayout.Tab) {
+            if (!suppressTabCallback) {
+              showTab(tab.tag as? String ?: HOME_TAB_ID)
+            }
+          }
+
+          override fun onTabUnselected(tab: TabLayout.Tab) = Unit
+
+          override fun onTabReselected(tab: TabLayout.Tab) {
+            if (!suppressTabCallback) {
+              showTab(tab.tag as? String ?: HOME_TAB_ID)
+            }
+          }
+        }
+    )
+  }
+
+  private fun selectTab(tabId: String) {
+    val tab = findTabById(tabId) ?: findTabById(HOME_TAB_ID) ?: return
+    suppressTabCallback = true
+    tab.select()
+    suppressTabCallback = false
+    showTab(tab.tag as? String ?: HOME_TAB_ID)
+  }
+
+  private fun showTab(tabId: String) {
+    selectedTabId = tabId
+    val containerId = container?.id ?: return
+    val fragment =
+        if (tabId == HOME_TAB_ID) {
+          EditorToolboxGridFragment()
+        } else {
+          val entry = openedTabs[tabId] ?: EditorToolboxRegistry.findEntry(tabId) ?: return
+          entry.fragmentClass.java.getDeclaredConstructor().newInstance()
+        }
+    childFragmentManager.commit {
+      setReorderingAllowed(true)
+      replace(containerId, fragment, tabId)
+    }
+  }
+
+  private fun findTabById(id: String): TabLayout.Tab? {
+    val tabs = tabLayout ?: return null
+    for (index in 0 until tabs.tabCount) {
+      val tab = tabs.getTabAt(index)
+      if (tab?.tag == id) {
+        return tab
+      }
+    }
+    return null
+  }
+
+  companion object {
+    private const val HOME_TAB_ID = "toolbox_home"
+    private const val STATE_OPENED_TABS = "opened_tabs"
+    private const val STATE_SELECTED_TAB = "selected_tab"
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxGridFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxGridFragment.kt
@@ -1,0 +1,169 @@
+package com.itsaky.androidide.fragments.toolbox
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import com.itsaky.androidide.R
+
+class EditorToolboxGridFragment : Fragment() {
+
+  fun interface ToolSelectionListener {
+    fun onToolSelected(entry: EditorToolboxEntry)
+  }
+
+  private var toolSelectionListener: ToolSelectionListener? = null
+
+  override fun onAttach(context: Context) {
+    super.onAttach(context)
+    toolSelectionListener = parentFragment as? ToolSelectionListener
+  }
+
+  override fun onDetach() {
+    toolSelectionListener = null
+    super.onDetach()
+  }
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?,
+  ): View {
+    return ComposeView(requireContext()).apply {
+      setContent {
+        MaterialTheme {
+          Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            var entries by remember { mutableStateOf(loadSortedEntries()) }
+            ToolboxGrid(
+                entries = entries,
+                onEntryClick = { entry ->
+                  recordUsage(entry)
+                  entries = loadSortedEntries()
+                  toolSelectionListener?.onToolSelected(entry)
+                },
+            )
+          }
+        }
+      }
+    }
+  }
+
+  private fun loadSortedEntries(): List<EditorToolboxEntry> {
+    val prefs = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return EditorToolboxRegistry.getEntries()
+        .sortedWith(
+            compareByDescending<EditorToolboxEntry> { prefs.getInt(usageKey(it.id), 0) }
+                .thenBy { it.id }
+        )
+  }
+
+  private fun recordUsage(entry: EditorToolboxEntry) {
+    val prefs = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val nextCount = prefs.getInt(usageKey(entry.id), 0) + 1
+    prefs.edit().putInt(usageKey(entry.id), nextCount).apply()
+  }
+
+  @Composable
+  private fun ToolboxGrid(entries: List<EditorToolboxEntry>, onEntryClick: (EditorToolboxEntry) -> Unit) {
+    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 12.dp)) {
+      Text(
+          text = stringResource(R.string.title_editor_toolbox),
+          style = MaterialTheme.typography.titleMedium,
+          fontWeight = FontWeight.SemiBold,
+      )
+      Text(
+          text = stringResource(R.string.desc_editor_toolbox),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          modifier = Modifier.padding(top = 4.dp),
+      )
+      Spacer(modifier = Modifier.height(12.dp))
+      LazyVerticalGrid(
+          columns = GridCells.Fixed(3),
+          modifier = Modifier.fillMaxSize(),
+          contentPadding = PaddingValues(bottom = 24.dp),
+          horizontalArrangement = Arrangement.spacedBy(12.dp),
+          verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        items(items = entries, key = { it.id }) { entry ->
+          ToolboxTile(entry = entry, onClick = { onEntryClick(entry) })
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun ToolboxTile(entry: EditorToolboxEntry, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().height(118.dp).clickable(onClick = onClick),
+        shape = RoundedCornerShape(18.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp, pressedElevation = 8.dp),
+    ) {
+      Box(modifier = Modifier.fillMaxSize().padding(10.dp), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+          Icon(
+              painter = painterResource(entry.iconRes),
+              contentDescription = stringResource(entry.titleRes),
+              modifier = Modifier.size(34.dp),
+              tint = MaterialTheme.colorScheme.primary,
+          )
+          Spacer(modifier = Modifier.height(10.dp))
+          Text(
+              text = stringResource(entry.titleRes),
+              style = MaterialTheme.typography.labelLarge,
+              textAlign = TextAlign.Center,
+              maxLines = 2,
+              overflow = TextOverflow.Ellipsis,
+          )
+        }
+      }
+    }
+  }
+
+  companion object {
+    private const val PREFS_NAME = "editor_toolbox_usage"
+    private fun usageKey(id: String) = "usage_$id"
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxRegistry.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxRegistry.kt
@@ -1,0 +1,71 @@
+package com.itsaky.androidide.fragments.toolbox
+
+import android.studio.zero.regular.expression.preview.RegexPreviewFragment
+import android.zero.studio.chatai.server.mcp.McpFragment
+import com.itsaky.androidide.R
+import com.itsaky.androidide.repository.dependencies.analyzer.ui.DependencyUpdateFragment
+import me.rerere.rikkahub.RouteFragment
+
+/**
+ * Central registry for editor toolbox tiles. Add or remove entries here to plug tools into the
+ * toolbox without changing the toolbox UI/container implementation.
+ */
+object EditorToolboxRegistry {
+
+  private val entries = linkedMapOf<String, EditorToolboxEntry>()
+
+  init {
+    register(
+        EditorToolboxEntry(
+            id = "dependency_updates",
+            titleRes = R.string.title_dependency_updates,
+            descriptionRes = R.string.desc_dependency_updates,
+            iconRes = R.drawable.ic_package,
+            fragmentClass = DependencyUpdateFragment::class,
+        )
+    )
+    register(
+        EditorToolboxEntry(
+            id = "regex_preview",
+            titleRes = R.string.title_regular_preview,
+            descriptionRes = R.string.desc_regular_preview,
+            iconRes = R.drawable.ic_find_replace,
+            fragmentClass = RegexPreviewFragment::class,
+        )
+    )
+    register(
+        EditorToolboxEntry(
+            id = "mcp_server",
+            titleRes = R.string.title_mcp_server,
+            descriptionRes = R.string.desc_mcp_server,
+            iconRes = R.drawable.ic_ai_mcp_server,
+            fragmentClass = McpFragment::class,
+        )
+    )
+    register(
+        EditorToolboxEntry(
+            id = "chatai_route",
+            titleRes = R.string.title_chatai_route,
+            descriptionRes = R.string.desc_chatai_route,
+            iconRes = R.drawable.ic_account,
+            fragmentClass = RouteFragment::class,
+        )
+    )
+  }
+
+  @Synchronized
+  fun register(entry: EditorToolboxEntry) {
+    entries[entry.id] = entry
+  }
+
+  @Synchronized
+  fun unregister(id: String) {
+    entries.remove(id)
+  }
+
+  @Synchronized
+  fun getEntries(): List<EditorToolboxEntry> = entries.values.toList()
+
+  @Synchronized
+  fun findEntry(id: String): EditorToolboxEntry? = entries[id]
+}

--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -140,7 +140,7 @@ class EditorBottomSheet @JvmOverloads constructor(
 
     mediator.attach()
     binding.pager.isUserInputEnabled = false
-    binding.pager.offscreenPageLimit = pagerAdapter.itemCount - 1
+    binding.pager.offscreenPageLimit = 1
 
     binding.tabs.addOnTabSelectedListener(
         object : OnTabSelectedListener {

--- a/core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -45,7 +45,6 @@ import com.itsaky.androidide.actions.sidebar.BuildVariantsSidebarAction
 import com.itsaky.androidide.actions.sidebar.CloseProjectSidebarAction
 import com.itsaky.androidide.actions.sidebar.DataFileTreeSidebarAction
 import com.itsaky.androidide.actions.sidebar.FileTreeSidebarAction
-import com.itsaky.androidide.actions.sidebar.McpFragmentSidebarAction
 import com.itsaky.androidide.actions.sidebar.PreferencesSidebarAction
 import com.itsaky.androidide.actions.sidebar.ProjectMaterialsSidebarAction
 import com.itsaky.androidide.actions.sidebar.TerminalSidebarAction
@@ -71,7 +70,6 @@ internal object EditorSidebarActions {
     registry.registerAction(DataFileTreeSidebarAction(context, ++order))
     registry.registerAction(BuildVariantsSidebarAction(context, ++order))
     registry.registerAction(TerminalSidebarAction(context, ++order))
-    registry.registerAction(McpFragmentSidebarAction(context, ++order))
     registry.registerAction(ProjectMaterialsSidebarAction(context, ++order))
     registry.registerAction(PreferencesSidebarAction(context, ++order))
     registry.registerAction(CloseProjectSidebarAction(context, ++order))

--- a/core/resources/src/main/res/values/ids.xml
+++ b/core/resources/src/main/res/values/ids.xml
@@ -111,6 +111,13 @@
           name="fragment_containers_parent"
           type="id" />
           
+     <item
+          name="editor_toolbox_tabs"
+          type="id" />
+     <item
+          name="editor_toolbox_fragment_container"
+          type="id" />
+
 </resources>
 
 

--- a/core/resources/src/main/res/values/strings_b.xml
+++ b/core/resources/src/main/res/values/strings_b.xml
@@ -331,4 +331,14 @@ Permission: %5$s
 %6$s
 MD5: %7$s
 SHA1: %8$s
-SHA256: %9$s</string></resources>
+SHA256: %9$s</string>
+     <string name="title_editor_toolbox">Toolbox</string>
+     <string name="title_editor_toolbox_home">Tools</string>
+     <string name="desc_editor_toolbox">Frequently used tools are sorted first automatically.</string>
+     <string name="title_dependency_updates">Dependency Updates</string>
+     <string name="desc_dependency_updates">Analyze project dependencies and update versions.</string>
+     <string name="desc_regular_preview">Preview, debug, and visualize regular expressions.</string>
+     <string name="desc_mcp_server">Manage the local MCP server and exposed tools.</string>
+     <string name="title_chatai_route">AI Chat</string>
+     <string name="desc_chatai_route">Open the embedded AI assistant route page.</string>
+</resources>


### PR DESCRIPTION
### Motivation
- Provide a unified, pluggable toolbox in the editor bottom drawer to host multiple quick-tool entries (regex preview, dependency updates, MCP server, AI chat) and make adding/removing tools simple. 
- Reduce runtime lifecycle/memory overhead by only creating heavy tool fragments on demand and keeping unused tabs mounted without active fragment lifecycles.
- Offer a modern UI using Jetpack Compose + Material3 for the 3xN grid tool launcher and improve UX (icons above title, spacing, elevation, scrollable grid).

### Description
- Added a lightweight registry and descriptor to register pluggable tools: `EditorToolboxEntry` and `EditorToolboxRegistry` (files: `core/app/src/main/java/com/itsaky/androidide/fragments/toolbox/EditorToolboxEntry.kt`, `EditorToolboxRegistry.kt`).
- Implemented a Compose Material3 nine-grid launcher `EditorToolboxGridFragment` that records usage counts and sorts entries by frequency (file: `EditorToolboxGridFragment.kt`).
- Implemented `EditorToolboxFragment` as a TabLayout container that keeps tabs visible but creates/destroys the actual tool `Fragment` instances on demand using `childFragmentManager.replace(...)`, minimizing unused fragment lifecycles (file: `EditorToolboxFragment.kt`).
- Integrated the toolbox into the editor bottom drawer by adding a toolbox tab to `EditorBottomSheetTabAdapter` and removed the previous direct bottom-drawer entries for regex/dependency tools (file: `EditorBottomSheetTabAdapter.java`).
- Removed the old MCP sidebar registration so the MCP entry is managed by the toolbox instead (`EditorSidebarActions.kt`).
- Resource updates: added `id` values and string resources used by the toolbox (`core/resources/src/main/res/values/ids.xml`, `strings_b.xml`).
- Performance tweak: reduced `ViewPager2` offscreen page limit in the editor bottom sheet from `pagerAdapter.itemCount - 1` to `1` to avoid keeping all pages alive (file: `EditorBottomSheet.kt`).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and ensured no check errors (passed).
- Attempted to compile `:core:app` with `./gradlew :core:app:compileDebugKotlin` under the sandbox; initial run failed due to Java version parsing against the environment (OpenJDK 25), then re-run with `JAVA_HOME` set to Java 17 and `ZEROSTUDIO_SKIP_NYX=true` to avoid an optional buildscript dependency, but the build could not complete in this environment because the Gradle/Kotlin plugin artifact (`org.jetbrains.kotlin.jvm:2.2.20`) and other plugin resolution steps could not be fetched from plugin repositories (network / repository resolution restrictions), so compilation was not verified here.
- Summary of automated checks: `git diff --check` succeeded; `./gradlew` compile attempts were blocked by external dependency/plugin resolution in this environment (not by local code errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d6ad98848832f82486beb78a5e692)