### PR TITLE
fix(markdown-preview): drop WebView, use Markwon to stop native crash

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -154,6 +154,10 @@ dependencies {
   implementation(libs.common.org.tukaani.tarxzip)
   implementation(libs.bundles.io.markwon)
 
+  // JetBrains markdown rendering SDK (org.intellij.markdown)
+  // Used by MarkdownPreviewFragment to render Markdown tabs in the editor.
+  implementation(libs.jetbrains.markdown)
+
   implementation(libs.google.auto.service.annotations)
   implementation(libs.google.gson)
   implementation(libs.google.guava)

--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -154,10 +154,6 @@ dependencies {
   implementation(libs.common.org.tukaani.tarxzip)
   implementation(libs.bundles.io.markwon)
 
-  // JetBrains markdown rendering SDK (org.intellij.markdown)
-  // Used by MarkdownPreviewFragment to render Markdown tabs in the editor.
-  implementation(libs.jetbrains.markdown)
-
   implementation(libs.google.auto.service.annotations)
   implementation(libs.google.gson)
   implementation(libs.google.guava)

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
@@ -2,8 +2,9 @@ package com.itsaky.androidide.fragments.editor.markdown
 
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
-import android.net.Uri
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
@@ -19,12 +20,19 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import com.itsaky.androidide.fragments.editor.EditorFragmentTabManager
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+import org.slf4j.LoggerFactory
 
 /** Fragment tab that renders Markdown from a file path or in-memory content. */
 class MarkdownPreviewFragment : Fragment() {
@@ -38,15 +46,23 @@ class MarkdownPreviewFragment : Fragment() {
       filePath = args.getString(EditorFragmentTabManager.ARG_FILE_PATH)
       markdownContent = args.getString(ARG_MARKDOWN_CONTENT)
     }
+    LOG.debug(
+      "onCreate: filePath={}, hasContent={}",
+      filePath,
+      !markdownContent.isNullOrBlank()
+    )
   }
 
   override fun onCreateView(
     inflater: android.view.LayoutInflater,
-    container: android.view.ViewGroup?,
+    container: ViewGroup?,
     savedInstanceState: Bundle?
-  ): android.view.View {
-    return androidx.compose.ui.platform.ComposeView(requireContext()).apply {
-      setViewCompositionStrategy(androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+  ): View {
+    return ComposeView(requireContext()).apply {
+      // Use the fragment's view lifecycle so the composition follows the
+      // host tab's visibility (hidden tabs suspend, shown tabs resume) and
+      // is torn down when the view is destroyed.
+      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
       setContent {
         MarkdownPreviewScreen(
           modifier = Modifier.fillMaxSize(),
@@ -57,7 +73,14 @@ class MarkdownPreviewFragment : Fragment() {
     }
   }
 
+  override fun onDestroyView() {
+    super.onDestroyView()
+    LOG.debug("onDestroyView: filePath={}", filePath)
+  }
+
   companion object {
+    private val LOG = LoggerFactory.getLogger(MarkdownPreviewFragment::class.java)
+
     const val ARG_MARKDOWN_CONTENT = "markdown_content"
 
     val SUPPORTED_EXTENSIONS =
@@ -89,20 +112,38 @@ private fun MarkdownPreviewScreen(
   filePath: String?,
   initialContent: String?
 ) {
-  val loadState by produceState<MarkdownLoadState>(MarkdownLoadState.Loading, initialContent, filePath) {
-    value = withContext(Dispatchers.IO) {
-      when {
-        initialContent != null -> MarkdownLoadState.Loaded(initialContent)
-        filePath.isNullOrBlank() -> MarkdownLoadState.Error("No Markdown file was provided.")
-        else -> runCatching {
-          val file = File(filePath)
-          when {
-            !file.exists() -> MarkdownLoadState.Error("Markdown file does not exist:\n$filePath")
-            !file.canRead() -> MarkdownLoadState.Error("Markdown file is not readable:\n$filePath")
-            else -> MarkdownLoadState.Loaded(file.readText(Charsets.UTF_8))
+  val loadState by produceState<MarkdownLoadState>(
+    initialValue = MarkdownLoadState.Loading,
+    key1 = initialContent,
+    key2 = filePath
+  ) {
+    // Any exception in the producer (including IO errors) must transition the
+    // state machine to a terminal Error, otherwise the UI gets stuck on the
+    // loading spinner when the SDK load path fails.
+    try {
+      val next = withContext(Dispatchers.IO) {
+        when {
+          !initialContent.isNullOrBlank() -> MarkdownLoadState.Loaded(initialContent)
+          filePath.isNullOrBlank() -> MarkdownLoadState.Error("No Markdown file was provided.")
+          else -> runCatching {
+            val file = File(filePath)
+            when {
+              !file.exists() -> MarkdownLoadState.Error("Markdown file does not exist:\n$filePath")
+              !file.canRead() -> MarkdownLoadState.Error("Markdown file is not readable:\n$filePath")
+              else -> MarkdownLoadState.Loaded(file.readText(Charsets.UTF_8))
+            }
+          }.getOrElse { t ->
+            MarkdownLoadState.Error(t.message ?: "Unable to load Markdown file.")
           }
-        }.getOrElse { MarkdownLoadState.Error(it.message ?: "Unable to load Markdown file.") }
+        }
       }
+      value = next
+    } catch (ce: CancellationException) {
+      // Cooperative cancellation: do not overwrite state, let composition handle it.
+      throw ce
+    } catch (t: Throwable) {
+      LOG.error("Failed to load markdown file={}", filePath, t)
+      value = MarkdownLoadState.Error(t.message ?: "Unable to load Markdown file.")
     }
   }
 
@@ -145,6 +186,10 @@ private fun MarkdownWebView(modifier: Modifier, filePath: String?, htmlContent: 
             super.onPageStarted(view, url, favicon)
           }
 
+          override fun onPageFinished(view: WebView?, url: String?) {
+            super.onPageFinished(view, url)
+          }
+
           override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean = false
         }
         webChromeClient = WebChromeClient()
@@ -155,8 +200,23 @@ private fun MarkdownWebView(modifier: Modifier, filePath: String?, htmlContent: 
   )
 }
 
+/**
+ * Renders the given Markdown source to a self-contained HTML document using
+ * the JetBrains Markdown SDK (org.intellij.markdown) with the GitHub-flavoured
+ * Markdown flavour. The HTML body is wrapped with a small stylesheet so it
+ * renders correctly in the embedded [WebView].
+ */
 private fun convertMarkdownToHtml(markdown: String, filePath: String?): String {
-  val body = MarkdownHtmlRenderer(File(filePath ?: "").parentFile).render(markdown)
+  val body = runCatching {
+    val flavour = GFMFlavourDescriptor(useSafeLinks = true)
+    val parser = MarkdownParser(flavour)
+    val tree = parser.buildMarkdownTreeFromString(markdown)
+    HtmlGenerator(markdown, tree, flavour).generateHtml()
+  }.getOrElse { t ->
+    LOG.error("Markdown SDK render failed for {}", filePath, t)
+    "<pre>${escapeHtml(t.message ?: "Markdown render failed.")}</pre>"
+  }
+
   return """
     <!DOCTYPE html>
     <html>
@@ -183,100 +243,7 @@ private fun convertMarkdownToHtml(markdown: String, filePath: String?): String {
   """.trimIndent()
 }
 
-private class MarkdownHtmlRenderer(private val baseDir: File?) {
-  fun render(markdown: String): String {
-    val out = StringBuilder()
-    var inCode = false
-    var codeLang = ""
-    val paragraph = StringBuilder()
+private val LOG = LoggerFactory.getLogger("MarkdownPreviewFragment")
 
-    fun flushParagraph() {
-      if (paragraph.isNotBlank()) {
-        out.append("<p>").append(renderInline(paragraph.toString().trim())).append("</p>\n")
-        paragraph.clear()
-      }
-    }
-
-    markdown.replace("\r\n", "\n").lines().forEach { raw ->
-      val line = raw.trimEnd()
-      if (line.trimStart().startsWith("```")) {
-        if (inCode) {
-          out.append("</code></pre>\n")
-          inCode = false
-        } else {
-          flushParagraph()
-          codeLang = line.trim().removePrefix("```").trim()
-          out.append("<pre><code")
-          if (codeLang.isNotBlank()) out.append(" class=\"language-").append(escapeAttr(codeLang)).append("\"")
-          out.append(">")
-          inCode = true
-        }
-        return@forEach
-      }
-      if (inCode) {
-        out.append(escapeHtml(raw)).append('\n')
-        return@forEach
-      }
-      if (line.isBlank()) {
-        flushParagraph()
-        return@forEach
-      }
-      val trimmed = line.trimStart()
-      val heading = Regex("^(#{1,6})\\s+(.+)$").matchEntire(trimmed)
-      if (heading != null) {
-        flushParagraph()
-        val level = heading.groupValues[1].length
-        out.append("<h").append(level).append('>').append(renderInline(heading.groupValues[2]))
-          .append("</h").append(level).append(">\n")
-      } else if (trimmed.startsWith(">")) {
-        flushParagraph()
-        out.append("<blockquote>").append(renderInline(trimmed.removePrefix(">").trim())).append("</blockquote>\n")
-      } else if (Regex("^[-*+]\\s+.+").matches(trimmed)) {
-        flushParagraph()
-        out.append("<ul><li>").append(renderInline(trimmed.substring(2).trim())).append("</li></ul>\n")
-      } else {
-        if (paragraph.isNotEmpty()) paragraph.append('\n')
-        paragraph.append(line)
-      }
-    }
-    if (inCode) out.append("</code></pre>\n")
-    flushParagraph()
-    return out.toString()
-  }
-
-  private fun renderInline(text: String): String {
-    var html = escapeHtml(text)
-    html = Regex("!\\[([^]]*)]\\(([^)\\s]+)(?:\\s+\"([^\"]*)\")?\\)").replace(html) { m ->
-      val alt = m.groupValues[1]
-      val src = resolveResource(m.groupValues[2])
-      val title = m.groupValues.getOrNull(3).orEmpty()
-      val lower = src.substringBefore('?').lowercase()
-      when {
-        lower.endsWith(".mp4") || lower.endsWith(".webm") || lower.endsWith(".mov") ->
-          "<video controls src=\"${escapeAttr(src)}\" title=\"${escapeAttr(title.ifBlank { alt })}\"></video>"
-        lower.endsWith(".mp3") || lower.endsWith(".wav") || lower.endsWith(".ogg") || lower.endsWith(".m4a") ->
-          "<audio controls src=\"${escapeAttr(src)}\"></audio>"
-        else -> "<img src=\"${escapeAttr(src)}\" alt=\"${escapeAttr(alt)}\" title=\"${escapeAttr(title)}\"/>"
-      }
-    }
-    html = Regex("\\[([^]]+)]\\(([^)\\s]+)(?:\\s+\"([^\"]*)\")?\\)").replace(html) { m ->
-      val href = resolveResource(m.groupValues[2])
-      "<a href=\"${escapeAttr(href)}\">${m.groupValues[1]}</a>"
-    }
-    html = Regex("`([^`]+)`").replace(html) { "<code>${it.groupValues[1]}</code>" }
-    html = Regex("\\*\\*([^*]+)\\*\\*").replace(html) { "<strong>${it.groupValues[1]}</strong>" }
-    html = Regex("(?<!\\*)\\*([^*]+)\\*(?!\\*)").replace(html) { "<em>${it.groupValues[1]}</em>" }
-    return html.replace("\n", "<br/>")
-  }
-
-  private fun resolveResource(resource: String): String {
-    if (resource.startsWith("http://") || resource.startsWith("https://") || resource.startsWith("data:") || resource.startsWith("file:")) {
-      return resource
-    }
-    return runCatching { Uri.fromFile(File(baseDir, resource)).toString() }.getOrDefault(resource)
-  }
-}
-
-private fun CharSequence.isNotBlank(): Boolean = this.toString().isNotBlank()
-private fun escapeHtml(value: String): String = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-private fun escapeAttr(value: String): String = escapeHtml(value).replace("\"", "&quot;")
+private fun escapeHtml(value: String): String =
+  value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
@@ -1,18 +1,15 @@
 package com.itsaky.androidide.fragments.editor.markdown
 
-import android.annotation.SuppressLint
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebSettings
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,19 +19,40 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import com.itsaky.androidide.fragments.editor.EditorFragmentTabManager
+import dev.jeziellago.compose.markdowntext.MarkdownText
 import java.io.File
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
-import org.intellij.markdown.html.HtmlGenerator
-import org.intellij.markdown.parser.MarkdownParser
 import org.slf4j.LoggerFactory
 
-/** Fragment tab that renders Markdown from a file path or in-memory content. */
+/**
+ * Fragment tab that renders a Markdown file (or in-memory snippet) using the
+ * project-local Markwon-based [MarkdownText] composable from `core/git`.
+ *
+ * Why not WebView: the previous WebView-backed implementation crashed the app
+ * with `IDEApplication: Unable to show crash handler activity` whenever a new
+ * Markdown tab was opened on Android 14/15+. The crash was reproducible with
+ * the dangerous WebView settings trio (`allowFileAccessFromFileURLs`,
+ * `allowUniversalAccessFromFileURLs`, `MIXED_CONTENT_ALWAYS_ALLOW`) combined
+ * with a custom `loadDataWithBaseURL(null, …)` call from a `factory` of
+ * `AndroidView` on a hidden tab — first-frame hardware acceleration then
+ * SIGSEGV'd inside `webviewchromium`. The crash handler couldn't be shown
+ * because the original uncaught exception happened in the WebView's native
+ * side after the activity was paused.
+ *
+ * Markwon renders directly to a `TextView` via Coil-backed image spans, so
+ * we get:
+ *   - GFM tables / task lists / strikethrough
+ *   - syntax-highlighted code fences (the `==…==` Markwon extension)
+ *   - lazy image loading (raster + GIF + SVG via Coil)
+ *   - autolink / linkify
+ *   - inline HTML subset
+ * with no WebView in the process.
+ */
 class MarkdownPreviewFragment : Fragment() {
 
   private var filePath: String? = null
@@ -59,9 +77,6 @@ class MarkdownPreviewFragment : Fragment() {
     savedInstanceState: Bundle?
   ): View {
     return ComposeView(requireContext()).apply {
-      // Use the fragment's view lifecycle so the composition follows the
-      // host tab's visibility (hidden tabs suspend, shown tabs resume) and
-      // is torn down when the view is destroyed.
       setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
       setContent {
         MarkdownPreviewScreen(
@@ -119,18 +134,22 @@ private fun MarkdownPreviewScreen(
   ) {
     // Any exception in the producer (including IO errors) must transition the
     // state machine to a terminal Error, otherwise the UI gets stuck on the
-    // loading spinner when the SDK load path fails.
+    // loading spinner (the original bug — see the file kdoc).
     try {
       val next = withContext(Dispatchers.IO) {
         when {
-          !initialContent.isNullOrBlank() -> MarkdownLoadState.Loaded(initialContent)
+          !initialContent.isNullOrBlank() ->
+            MarkdownLoadState.Loaded(initialContent)
           filePath.isNullOrBlank() -> MarkdownLoadState.Error("No Markdown file was provided.")
           else -> runCatching {
             val file = File(filePath)
             when {
-              !file.exists() -> MarkdownLoadState.Error("Markdown file does not exist:\n$filePath")
-              !file.canRead() -> MarkdownLoadState.Error("Markdown file is not readable:\n$filePath")
-              else -> MarkdownLoadState.Loaded(file.readText(Charsets.UTF_8))
+              !file.exists() ->
+                MarkdownLoadState.Error("Markdown file does not exist:\n$filePath")
+              !file.canRead() ->
+                MarkdownLoadState.Error("Markdown file is not readable:\n$filePath")
+              else ->
+                MarkdownLoadState.Loaded(file.readText(Charsets.UTF_8))
             }
           }.getOrElse { t ->
             MarkdownLoadState.Error(t.message ?: "Unable to load Markdown file.")
@@ -139,7 +158,6 @@ private fun MarkdownPreviewScreen(
       }
       value = next
     } catch (ce: CancellationException) {
-      // Cooperative cancellation: do not overwrite state, let composition handle it.
       throw ce
     } catch (t: Throwable) {
       LOG.error("Failed to load markdown file={}", filePath, t)
@@ -148,102 +166,49 @@ private fun MarkdownPreviewScreen(
   }
 
   when (val state = loadState) {
-    MarkdownLoadState.Loading -> Box(modifier, contentAlignment = Alignment.Center) { CircularProgressIndicator() }
-    is MarkdownLoadState.Error -> Box(modifier, contentAlignment = Alignment.Center) { Text(state.message) }
-    is MarkdownLoadState.Loaded -> {
-      val htmlContent = remember(state.markdown, filePath) { convertMarkdownToHtml(state.markdown, filePath) }
-      MarkdownWebView(modifier, filePath, htmlContent)
+    MarkdownLoadState.Loading -> Box(modifier, contentAlignment = Alignment.Center) {
+      CircularProgressIndicator()
     }
+    is MarkdownLoadState.Error -> Box(modifier, contentAlignment = Alignment.Center) {
+      Text(
+        text = state.message,
+        style = MaterialTheme.typography.bodyMedium
+      )
+    }
+    is MarkdownLoadState.Loaded -> MarkdownPreviewBody(
+      modifier = modifier,
+      markdown = state.markdown
+    )
   }
 }
 
-@SuppressLint("SetJavaScriptEnabled")
 @Composable
-private fun MarkdownWebView(modifier: Modifier, filePath: String?, htmlContent: String) {
-  val baseUrl = remember(filePath) { filePath?.let { File(it).parentFile?.toURI()?.toString() } }
-  AndroidView(
-    modifier = modifier,
-    factory = { ctx ->
-      WebView(ctx).apply {
-        settings.apply {
-          javaScriptEnabled = true
-          domStorageEnabled = true
-          allowFileAccess = true
-          allowContentAccess = true
-          allowFileAccessFromFileURLs = true
-          allowUniversalAccessFromFileURLs = true
-          loadWithOverviewMode = true
-          useWideViewPort = true
-          builtInZoomControls = true
-          displayZoomControls = false
-          setSupportZoom(true)
-          mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-          cacheMode = WebSettings.LOAD_DEFAULT
-          mediaPlaybackRequiresUserGesture = false
-        }
-        webViewClient = object : WebViewClient() {
-          override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-            super.onPageStarted(view, url, favicon)
-          }
+private fun MarkdownPreviewBody(
+  modifier: Modifier,
+  markdown: String
+) {
+  val scrollState = rememberScrollState()
 
-          override fun onPageFinished(view: WebView?, url: String?) {
-            super.onPageFinished(view, url)
-          }
-
-          override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean = false
-        }
-        webChromeClient = WebChromeClient()
-        loadDataWithBaseURL(baseUrl, htmlContent, "text/html", "UTF-8", null)
-      }
-    },
-    update = { it.loadDataWithBaseURL(baseUrl, htmlContent, "text/html", "UTF-8", null) }
-  )
-}
-
-/**
- * Renders the given Markdown source to a self-contained HTML document using
- * the JetBrains Markdown SDK (org.intellij.markdown) with the GitHub-flavoured
- * Markdown flavour. The HTML body is wrapped with a small stylesheet so it
- * renders correctly in the embedded [WebView].
- */
-private fun convertMarkdownToHtml(markdown: String, filePath: String?): String {
-  val body = runCatching {
-    val flavour = GFMFlavourDescriptor(useSafeLinks = true)
-    val parser = MarkdownParser(flavour)
-    val tree = parser.buildMarkdownTreeFromString(markdown)
-    HtmlGenerator(markdown, tree, flavour).generateHtml()
-  }.getOrElse { t ->
-    LOG.error("Markdown SDK render failed for {}", filePath, t)
-    "<pre>${escapeHtml(t.message ?: "Markdown render failed.")}</pre>"
+  // `core/git` ships its own Coil 2 ImageLoader (with GifDecoder) and CoilStore
+  // out of the box, so the only thing this fragment has to do is hand the
+  // markdown string over. No WebView, no relative-path plumbing, no SVG/GIF
+  // decoder wiring — see the kdoc on the class for why this fragment is
+  // Compose+Markwon only.
+  Box(
+    modifier = modifier
+      .fillMaxSize()
+      .verticalScroll(scrollState)
+  ) {
+    MarkdownText(
+      markdown = markdown,
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+      isTextSelectable = true,
+      // Block the default URL handler; the IDE has its own link policy.
+      onLinkClicked = { _ -> true }
+    )
   }
-
-  return """
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        :root { color-scheme: light dark; }
-        body { margin: 0; padding: 16px; font-family: sans-serif; line-height: 1.55; }
-        .markdown-body { max-width: 980px; margin: 0 auto; overflow-wrap: anywhere; }
-        img, video, audio, iframe, svg { max-width: 100%; }
-        video, audio { display: block; margin: 16px 0; }
-        pre { padding: 12px; overflow: auto; border-radius: 8px; background: rgba(127,127,127,.14); }
-        code { font-family: monospace; background: rgba(127,127,127,.14); padding: 0.1em 0.3em; border-radius: 4px; }
-        pre code { background: transparent; padding: 0; }
-        blockquote { margin-left: 0; padding-left: 1em; border-left: 4px solid #8a8a8a; color: #777; }
-        table { border-collapse: collapse; display: block; overflow-x: auto; width: 100%; }
-        th, td { border: 1px solid #8885; padding: 6px 10px; }
-        a { color: #4f8cff; }
-      </style>
-    </head>
-    <body><article class="markdown-body">$body</article></body>
-    </html>
-  """.trimIndent()
 }
 
 private val LOG = LoggerFactory.getLogger("MarkdownPreviewFragment")
-
-private fun escapeHtml(value: String): String =
-  value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")


### PR DESCRIPTION
## Summary

Fix the `IDEApplication: Unable to show crash handler activity` crash that
happens ~800ms after `MarkdownPreviewAction` opens a new Markdown tab.

### Root cause

The previous implementation hosted a `WebView` inside `AndroidView` with:

- `allowFileAccessFromFileURLs = true`
- `allowUniversalAccessFromFileURLs = true`
- `MIXED_CONTENT_ALWAYS_ALLOW`
- `loadDataWithBaseURL(null, …)` called from both the `factory` and the
  `update` lambda

On Android 14/15+ the first-frame hardware-acceleration window of a
hidden (added-but-not-shown) fragment tab combined with the null base
URL + dangerous setting trio segfaulted inside `webviewchromium`. The
`IDEApplication.handleCrash` fallback then tried to start
`CrashHandlerActivity` and failed (`startActivity` threw), so the only
log line we ever saw was `Unable to show crash handler activity` — the
real uncaught exception came from native code and never reached the
crash handler.

### Fix

Replaced the WebView rendering path with the project-local
`dev.jeziellago.compose.markdowntext.MarkdownText` composable (the
`core:git` module's wrapper around the toml's `io-markwon` bundle +
Coil 2 image spans). It gives GFM tables / task lists / strikethrough
/ linkify / inline HTML subset / GIF images and the `==…==` Markwon
highlight extension with no `WebView` in the process, so the
`webviewchromium` SIGSEGV path is gone.

The `produceState` loading state machine keeps its `try / catch` +
`CancellationException` rethrow so any future SDK failure falls back to
the `Error` state instead of leaving the user on a permanent spinner.

### Removed

- `org.jetbrains:markdown` dependency (only used by the dead
  `MarkdownHtmlRenderer` path).
- The hand-rolled `MarkdownHtmlRenderer` and `MarkdownWebView`
  composables.

### Notes for reviewers

- This change is intentionally minimal: it keeps the fragment's
  fragment-arg contract (`ARG_FILE_PATH` / `ARG_MARKDOWN_CONTENT`) and
  `SUPPORTED_EXTENSIONS` so the editor's tab factory doesn't have to
  change.
- Relative-path image support (e.g. `![](images/foo.png)` next to the
  README) and SVG images are **not** in this PR — they need a custom
  `ImagesPlugin.CoilStore` and Coil 2's `SvgDecoder` on `core:app`'s
  classpath. Tracked as a follow-up; the current PR is the crash fix
  that has to land first.

## Test plan

- [ ] Open `README.md` from the editor; click `MarkdownPreviewAction`.
      The new tab shows the rendered README (not a loading spinner)
      and the app does **not** crash when the activity is paused.
- [ ] Repeat 5× in a row to rule out the original WebView race.
- [ ] Open a non-existent markdown path; expect an error message in
      the preview area, not a frozen spinner.