### PR TITLE
revert(base-app): drop startInitThread helper and undo application-time init

### DIFF
--- a/core/common/src/main/java/com/itsaky/androidide/app/BaseApplication.java
+++ b/core/common/src/main/java/com/itsaky/androidide/app/BaseApplication.java
@@ -28,7 +28,6 @@ import com.itsaky.androidide.managers.PreferenceManager;
 import com.itsaky.androidide.utils.Environment;
 import com.itsaky.androidide.utils.FileUtil;
 import com.itsaky.androidide.utils.FlashbarUtilsKt;
-import com.itsaky.androidide.utils.JavaCharacter;
 import java.io.File;
 import com.itsaky.androidide.app.BaseConstants;
 import java.util.concurrent.CountDownLatch;
@@ -67,29 +66,6 @@ public class BaseApplication extends Application {
     super.onCreate();
 
     mPrefsManager = new PreferenceManager(this);
-    
-    startInitThread("JavaChar-Init-Thread", JavaCharacter::initMap);
-    startInitThread("BaseApp-Init-Thread", Environment::initSecondaryDirs);
-
-
-    
-    
-  }
-
-
-  private void startInitThread(String name, Runnable task) {
-    // Some Android 12 Samsung builds have crashed inside libc realpath()/OpenJDK
-    // canonicalize on the default small Java thread stack while the environment
-    // directory tree is created. Use an explicit larger stack and keep failures
-    // contained so background initialization cannot take down the process.
-    Thread thread = new Thread(null, () -> {
-      try {
-        task.run();
-      } catch (Throwable th) {
-        writeException(th);
-      }
-    }, name, 2L * 1024L * 1024L);
-    thread.start();
   }
 
   public void writeException(Throwable th) {


### PR DESCRIPTION
## Summary
- Reverts the `startInitThread` helper in `BaseApplication.java` and the two background initialization launches (`JavaChar-Init-Thread`, `BaseApp-Init-Thread`) it added in `onCreate()`.
- Removes the now-unused `com.itsaky.androidide.utils.JavaCharacter` import.

## Why
The earlier 2 MiB stack + `try/catch` wrapper did not actually fix the Android 12 Samsung crash (SM-A217F / a21s / exynos850). The fault trace is:

```
signal 11 (SIGSEGV), code 2 (SEGV_ACCERR)
Cause: stack pointer is close to top of stack; likely stack overflow.
backtrace:
  #00 libc realpath / __vfprintf
  #01 libc vsnprintf
  #02 libc __vsnprintf_chk
  #03 libc snprintf
  #04 libc realpath
  #05 libopenjdk canonicalize
  #06 libopenjdk Java_java_io_UnixFileSystem_canonicalize0
```

Increasing the Java thread stack and catching `Throwable` cannot change the fact that `Environment::initSecondaryDirs` ends up calling `new File(...).getCanonicalPath()` (and similar `realpath()`-backed paths) through OpenJDK on a system where `realpath` itself crashes — that path has to be fixed at the call site, not by widening the wrapper around it.

`Environment` is already lazy via `ensureInitialized()` and is invoked on first use from feature code; it does not need to be eagerly primed at process start. The precomputed `JavaCharacter` map is also a pure optimization, so removing its eager warmup is safe.

## Changes
- `core/common/src/main/java/com/itsaky/androidide/app/BaseApplication.java`
  - Removed the two `startInitThread(...)` calls in `onCreate()`.
  - Removed the private `startInitThread(String, Runnable)` helper.
  - Removed the unused `com.itsaky.androidide.utils.JavaCharacter` import.

Refs: c3107c1
