### PR TITLE
build(app): add androidx.compose.runtime:runtime-livedata dependency

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -189,6 +189,8 @@ dependencies {
 
   // UI/UX
   implementation(libs.bundles.compose) // androidx compose
+  // androidx.compose.runtime.livedata.observeAsState (used by MarkdownPreviewFragment)
+  implementation(libs.androidx.compose.runtime.livedata)
   implementation(libs.androidx.core.ktx)
 
   implementation(libs.common.kotlin)


### PR DESCRIPTION
## 背景 / Background

PR #304 merge 之后 `MarkdownPreviewFragment.kt` 在 CI 构建中报错：

```
e: ...MarkdownPreviewFragment.kt:20:33 Unresolved reference 'livedata'.
e: ...MarkdownPreviewFragment.kt:113:32 Unresolved reference 'observeAsState'.
```

## 根因 / Root cause

PR #304 引入了 `MarkdownPreviewFragment.kt`，里面用到了：

```kotlin
import androidx.compose.runtime.livedata.observeAsState
...
val state by viewModel.state.observeAsState(MarkdownPreviewState.Loading)
```

`androidx.compose.runtime.livedata.observeAsState` 是 `androidx.compose.runtime:runtime-livedata` 这个 artifact 里的扩展函数，**不会** 跟随 `androidx.compose:compose-bom` 自动引入，core/app 的 `libs.bundles.compose` 也没有包含 `runtime-livedata`，所以编译时找不到。

## 修复 / Fix

在 `core/app/build.gradle.kts` 显式声明：

```kotlin
implementation(libs.androidx.compose.runtime.livedata)
```

lib alias 已在 `gradle/libs.versions.toml` 声明：

```toml
androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
```

## 改动 / Changes

| 文件 | 行 | 说明 |
| --- | --- | --- |
| `core/app/build.gradle.kts` | +2 | 新增 `implementation(libs.androidx.compose.runtime.livedata)` |

净增 2 行，单一 commit。

## 验证 / Verification

- 沙箱网络隔离无法执行 `./gradlew :core:app:compileDebugKotlin`
- 已确认 `libs.androidx.compose.runtime.livedata` 在 `gradle/libs.versions.toml:331` 已定义且 `composeBom = "2026.05.00"` 提供 BOM 版本管理，无需额外指定 version
- import 路径 `androidx.compose.runtime.livedata.observeAsState` 与 `runtime-livedata:1.7.0` 完全匹配

## 关联 / Related

- PR #304 (merged)：引入 `MarkdownPreviewFragment.kt`
- `gradle/libs.versions.toml` 已有 `androidx-compose-runtime-livedata` 别名