### PR TITLE
fix(markdown-preview): actually load HTML into the WebView

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
@@ -74,7 +74,13 @@ class MarkdownPreviewFragment : Fragment() {
       filePath = args.getString(EditorFragmentTabManager.ARG_FILE_PATH)
       inlineContent = args.getString(ARG_MARKDOWN_CONTENT)
     }
-    LOG.debug("onCreate: filePath={}, hasInlineContent={}", filePath, !inlineContent.isNullOrBlank())
+    // Info 级别：方便在 logcat 里直接看到文件路径是否被正确传入 fragment
+    LOG.info(
+        "MarkdownPreviewFragment.onCreate: filePath={}, hasInlineContent={}, hasArguments={}",
+        filePath,
+        !inlineContent.isNullOrBlank(),
+        arguments != null,
+    )
   }
 
   override fun onCreateView(
@@ -128,6 +134,11 @@ private fun MarkdownPreviewScreen(
  *  - 在 `AndroidView.factory` 内构造 WebView（崩溃隔离）
  *  - 等 view attached 后再 loadDataWithBaseURL
  *  - 构造失败时降级为 TextView
+ *
+ * 注意：factory **不能** 给 WebView 设置 `tag = PendingLoad(...)`，
+ * 否则紧随其后的第一次 update 会因为「prev == current」而提前 return，
+ * `loadDataWithBaseURL` 永远不会被调用，WebView 一直是空白的。
+ * tag 只在 update 里「标记为已加载」，用来在多次 recomposition 时跳过重复 load。
  */
 @Composable
 private fun WebViewContainer(html: String, baseUrl: String) {
@@ -135,9 +146,7 @@ private fun WebViewContainer(html: String, baseUrl: String) {
     modifier = Modifier.fillMaxSize(),
     factory = { ctx ->
       try {
-        createSafeWebView(ctx).also { wv ->
-          wv.tag = PendingLoad(html, baseUrl)
-        }
+        createSafeWebView(ctx)
       } catch (t: Throwable) {
         LOG.error("Failed to create WebView; falling back to TextView", t)
         TextView(ctx).apply {
@@ -148,13 +157,21 @@ private fun WebViewContainer(html: String, baseUrl: String) {
     },
     update = { view ->
       if (view !is WebView) return@AndroidView
-      // 总是把最新的内容写到 tag；如果和上次一样就跳过
+      // 如果已经为同一份 (html, baseUrl) 加载过，就跳过（避免 recomposition 重复 load）
       val prev = view.tag as? PendingLoad
-      if (prev != null && prev.matches(html, baseUrl)) return@AndroidView
+      if (prev != null && prev.matches(html, baseUrl)) {
+        LOG.debug("WebView already loaded this content, skip")
+        return@AndroidView
+      }
+      // 记录待加载内容；加载完成后保留 tag，标记「已加载」
       view.tag = PendingLoad(html, baseUrl)
+      LOG.info(
+          "Loading markdown preview into WebView: htmlLen={}, baseUrl={}",
+          html.length,
+          baseUrl,
+      )
       if (view.isAttachedToWindow) {
-        doLoad(view, view.tag as PendingLoad)
-        view.tag = null
+        doLoad(view, PendingLoad(html, baseUrl))
       } else {
         // 等 attach 后再加载；用一次性 listener 避免每次 update 都注册
         view.removeOnAttachStateChangeListener(PendingAttachListener)
@@ -169,8 +186,8 @@ private val PendingAttachListener = object : View.OnAttachStateChangeListener {
     v.removeOnAttachStateChangeListener(this)
     if (v is WebView) {
       val pending = v.tag as? PendingLoad ?: return
-      v.tag = null
       doLoad(v, pending)
+      // tag 保留为 PendingLoad(html, baseUrl)，下一次 update 同内容会跳过
     }
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewViewModel.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewViewModel.kt
@@ -42,7 +42,9 @@ class MarkdownPreviewViewModel(application: Application) : AndroidViewModel(appl
    * 启动一次渲染。重复调用会取消上一次的协程。
    */
   fun load(filePath: String?, inlineContent: String?) {
+    LOG.info("MarkdownPreviewViewModel.load: filePath={}, hasInlineContent={}", filePath, !inlineContent.isNullOrBlank())
     if (filePath == lastFilePath && inlineContent == lastInline && _state.value is MarkdownPreviewState.Loaded) {
+      LOG.debug("Same inputs as last successful load; skip")
       return
     }
     lastFilePath = filePath
@@ -56,6 +58,10 @@ class MarkdownPreviewViewModel(application: Application) : AndroidViewModel(appl
         val result = withContext(Dispatchers.IO) {
           loadAndRender(app, filePath, inlineContent)
         }
+        LOG.info(
+            "MarkdownPreviewViewModel load completed: state={}",
+            result::class.java.simpleName,
+        )
         _state.value = result
       } catch (ce: CancellationException) {
         throw ce


### PR DESCRIPTION
## 现象 / Symptom

打开任意 `.md` 文件 → 点击 `MarkdownPreviewAction` → 新建 markdown 预览 tab → 页面**完全空白**（既没有 Loading 圈，也没有 Error 文本，也没有渲染内容）。

但 tab 标题（来自 `getTabTitle(entry, filePath)`）显示是正确的文件名（例如 `README_ZH_CN.md`），说明 `filePath` **已经**从 `MarkdownPreviewAction` 传到了 `EditorFragmentTabManager`，再到 `Fragment.arguments`，再到 `MarkdownPreviewFragment.onCreate` 与 `MarkdownPreviewViewModel.load`。

## 根因 / Root cause

不是 "file path 没有传入"，而是 WebView **拿到了 HTML 但从未真正调用 `loadDataWithBaseURL`**。

`MarkdownPreviewFragment.WebViewContainer` 里 `AndroidView.factory` 把 `PendingLoad(html, baseUrl)` 提前写进了新建 WebView 的 `tag`：

```kotlin
factory = { ctx ->
    createSafeWebView(ctx).also { wv ->
        wv.tag = PendingLoad(html, baseUrl)   // ← 提前塞 tag
    }
}

update = { view ->
    if (view !is WebView) return@AndroidView
    val prev = view.tag as? PendingLoad
    if (prev != null && prev.matches(html, baseUrl)) return@AndroidView  // ← 命中，return
    view.tag = PendingLoad(html, baseUrl)
    if (view.isAttachedToWindow) {
        doLoad(view, view.tag as PendingLoad)
        view.tag = null
    } else { ... }
}
```

Compose `AndroidView` 总是先调 `factory` 创建 view，紧接着第一次 `update`。Factory 刚塞进去的 `tag` 就是当前 `html`/`baseUrl`，于是 `prev.matches(html, baseUrl)` 立即命中 → 早退 → `doLoad` / `loadDataWithBaseURL` 永远不被调用。

WebView 是创建了，但从来没有 HTML 内容，所以是「空白 WebView」（不会触发 Error 分支，也不会显示 Loading 圈）。

另外两个隐藏 bug：

1. `update` 路径 `doLoad` 之后又把 `tag` 置 `null`，下一次相同 `html` 的 update 又会重新 load（无害但浪费）；
2. `PendingAttachListener` 加载完后同样把 `tag` 置 `null`，与上面同理。

## 修复 / Fix

- `factory` 只创建 WebView，**不**预设 `tag`，让第一次 `update` 必然走 `doLoad`
- `update` 路径加载完成后保留 `tag = PendingLoad(html, baseUrl)`，标记「已加载」，下次 recomposition 同内容直接 skip
- `PendingAttachListener` 加载完成后同样保留 `tag`
- `Fragment.onCreate` 与 `ViewModel.load` 升级到 `LOG.info` 输出 `filePath` / `state`，方便在 logcat 直接看到流转

## 改动 / Changes

| 文件 | 改动 |
| --- | --- |
| `MarkdownPreviewFragment.kt` | factory 不再预设 tag；update / listener 保留 tag 标记已加载；Fragment.onCreate 输出 filePath |
| `MarkdownPreviewViewModel.kt` | `load()` 输出 filePath / state |

净增 32 行 / 删除 9 行，单一 commit。

## 验证 / Verification

- 沙箱无网络，Gradle 编译跳过；已逐行对照 Compose `AndroidView.factory` / `update` 行为与 AndroidView 文档
- 新版逻辑：
  1. factory 仅 `createSafeWebView(ctx)` → 不设 tag
  2. update 第一次跑 → `prev == null` → 设 `tag = PendingLoad(...)` → `doLoad`
  3. 后续相同 `html`/`baseUrl` 的 recomposition → `prev.matches(...)` 命中 → skip（避免重复 load）
  4. 后续不同 `html` 的 recomposition → `prev.matches(...)` 不命中 → 重新设 tag → `doLoad`

## 关联 / Related

- PR #304 (merged): 引入 WebView + nanohttpd 渲染方案
- PR #305 (open): 补 `androidx.compose.runtime:runtime-livedata` 依赖