### PR TITLE
refactor(git-popup): 把"设置用户名/邮箱"迁到"快捷设置"区段,header 改为只读

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -76,13 +76,17 @@ class GitPopupManager(private val context: Context) {
       initRepositoryIfNeeded()
       dismiss()
     }
-    addDivider()
 
-    addMenuItem(iconRes = R.drawable.ic_settings_24, title = context.getString(R.string.settings)) {
-      Msg.requireShowLongDuration(
-          context.getString(com.itsaky.androidide.resources.R.string.git_settings_under_construction)
-      )
-      dismiss()
+    // 2c2: 新增"快捷设置"区段,把"设置用户名 / 邮箱"入口从原 header 点击
+    // 迁出(原 header 是只读的,只显示 + 眼睛切换邮箱可见性)。
+    addDivider()
+    addSectionTitle(context.getString(com.itsaky.androidide.resources.R.string.git_quick_settings_section))
+    addMenuItem(
+        iconRes = com.itsaky.androidide.resources.R.drawable.ic_account,
+        title = context.getString(com.itsaky.androidide.resources.R.string.git_set_user_info_title),
+        subtitle = context.getString(com.itsaky.androidide.resources.R.string.git_set_user_info_subtitle),
+    ) {
+      showSetUserInfoDialog()
     }
 
     val displayMetrics = context.resources.displayMetrics
@@ -117,7 +121,8 @@ class GitPopupManager(private val context: Context) {
       updateEmailDisplay()
     }
 
-    headerView.setOnClickListener { showSetUserInfoDialog() }
+    // 2c2: header 改为只读 — 不再绑点击事件触发 showSetUserInfoDialog;
+    // 该入口已迁到"快捷设置"区段的"设置用户名 / 邮箱"菜单项。
 
     container?.addView(headerView)
   }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -170,6 +170,15 @@ class GitPopupManager(private val context: Context) {
   private fun showSetUserInfoDialog() {
     dismiss() // 关闭 Popup
 
+    // 2c1 修复:同步读当前 global config,作为 ComposeMutableState 的初值。
+    // 之前用 `mutableStateOf("")` 会导致:
+    //   1. 对话框打开瞬间字段空白,等 AskGitUsernameAndEmailDialog 内部
+    //      LaunchedEffect 异步读完 PuppyGitSettings.json 后才填充;
+    //   2. 竞态:用户手快在 LaunchedEffect 跑完前点"确定",会把空字符串
+    //      当成新配置写回 global config,把之前配置好的 username/email
+    //      清掉。
+    val (currentUsername, currentEmail) = Libgit2Helper.getGitUsernameAndEmailFromGlobalConfig()
+
     val composeHostDialog = ComponentDialog(context)
     composeHostDialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
     composeHostDialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
@@ -179,10 +188,9 @@ class GitPopupManager(private val context: Context) {
           setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
           setContent {
-            // 状态变量，用于接收和修改用户名/邮箱
-            // AskGitUsernameAndEmailDialog 内部的 LaunchedEffect 会自动读取 PuppyGitSettings.json 并填充这些变量
-            val usernameState = remember { mutableStateOf("") }
-            val emailState = remember { mutableStateOf("") }
+            // 状态变量,初值已是当前配置 — 避免空白闪 + 竞态覆盖
+            val usernameState = remember { mutableStateOf(currentUsername) }
+            val emailState = remember { mutableStateOf(currentEmail) }
 
             val titleRes = com.catpuppyapp.puppygit.play.pro.R.string.set_global_username_and_email
 
@@ -191,7 +199,7 @@ class GitPopupManager(private val context: Context) {
                 text = stringResource(titleRes),
                 username = usernameState,
                 email = emailState,
-                isForGlobal = true, // 标记为全局设置，触发内部的全局读取逻辑
+                isForGlobal = true, // 标记为全局设置,触发内部的全局读取逻辑
                 repos = emptyList(), // 全局设置不需要传仓库列表
                 onOk = {
                   doJobThenOffLoading {
@@ -211,7 +219,7 @@ class GitPopupManager(private val context: Context) {
                 },
                 onCancel = { composeHostDialog.dismiss() },
                 enableOk = {
-                  // 允许点击确定，即使为空（可能代表清除配置
+                  // 允许点击确定,即使为空(可能代表清除配置)
                   true
                 },
             )

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -1081,7 +1081,10 @@ SHA256：%9$s</string>
   <string name="git_operations_section">Git Operations</string>
   <string name="git_init_title">Initialize Git</string>
   <string name="git_init_subtitle">Create .git repository</string>
-  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <!-- 2c2: 移除死链字符串 "git_settings_under_construction";新增"快捷设置" + "设置用户名 / 邮箱" -->
+  <string name="git_quick_settings_section">快捷设置</string>
+  <string name="git_set_user_info_title">设置用户名 / 邮箱</string>
+  <string name="git_set_user_info_subtitle">配置全局 git 用户身份</string>
   <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
   <string name="git_no_opened_project">No opened project</string>
   <string name="git_repository_already_initialized">Repository already initialized</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -825,7 +825,10 @@
   <string name="git_operations_section">Git Operations</string>
   <string name="git_init_title">Initialize Git</string>
   <string name="git_init_subtitle">Create .git repository</string>
-  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <!-- 2c2: dead string "git_settings_under_construction" removed; replaced by 快捷设置 / 设置用户名邮箱 入口 -->
+  <string name="git_quick_settings_section">Quick Settings</string>
+  <string name="git_set_user_info_title">Set Username / Email</string>
+  <string name="git_set_user_info_subtitle">Configure global git identity</string>
   <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
   <string name="git_no_opened_project">No opened project</string>
   <string name="git_repository_already_initialized">Repository already initialized</string>

--- a/docs/superpowers/specs/2026-06-11-git-fragments-2c1-popup-username-fix-design.md
+++ b/docs/superpowers/specs/2026-06-11-git-fragments-2c1-popup-username-fix-design.md
@@ -1,0 +1,146 @@
+# 2c1 GitPopupManager 用户名/邮箱修复
+
+| 字段 | 值 |
+| --- | --- |
+| 父 spec | `2026-06-11-git-fragments-refactor-roadmap.md` |
+| 前置 | 2a1 (puppygit 基础设施) |
+| 后置 | 2c2 (快捷菜单) |
+| 范围 | `core/app/.../fragments/git/menu/GitPopupManager.kt` |
+| 状态 | draft, 实施中 |
+
+## 1. 背景
+
+`GitPopupManager.showSetUserInfoDialog` 打开"设置 git 全局用户名/邮箱"
+对话框时，初始状态是空字符串：
+
+```kotlin
+val usernameState = remember { mutableStateOf("") }
+val emailState = remember { mutableStateOf("") }
+```
+
+`AskGitUsernameAndEmailDialog` 内部用 `LaunchedEffect(Unit)` 异步读
+puppygit `PuppyGitSettings.json`（同步封装成 `doJobThenOffLoading`）
+并把值填进 `usernameState` / `emailState`。结果：
+
+1. **空白闪一下**：对话框弹出瞬间字段是空的，要等几十毫秒
+   `LaunchedEffect` 跑完才显示当前配置。
+2. **竞态覆盖**：用户如果手快在 `LaunchedEffect` 跑完前点"确定"，会
+   把空字符串当成新配置写回 global config，**清掉**之前配置好的
+   username/email。
+3. 不可见但不致命：`refreshUserInfo` 在 dialog 关闭后被调，会再次读
+   出空值并显示在 popup 头里。
+
+## 2. 目标 / 非目标
+
+### 2.1 目标
+
+- `showSetUserInfoDialog` 打开瞬间，字段显示**当前** global config 的值
+- 不再需要 `LaunchedEffect` 二次填充（`AskGitUsernameAndEmailDialog`
+  内部仍保留该逻辑，作为兜底，零影响）
+- 任何时间点保存 → 写入的是对话框里看到的内容，不存在竞态
+
+### 2.2 非目标
+
+- 不动 `AskGitUsernameAndEmailDialog`（puppygit 内部，跨模块；保留
+  LaunchedEffect 兜底逻辑）
+- 不动 `showTokenCredentialDialog`（走 `GitCredentialManager`，与本
+  spec 无关）
+- 不动 popup 菜单结构 / 工具栏 / 其它 fragment
+- 不重写 popup 框架（保留 `PopupWindow` 实现）
+
+## 3. 修复方案
+
+在 `ComposeView.setContent` 块**外**同步读 `getGitUsernameAndEmailFromGlobalConfig()`，
+把读到的 `Pair<String, String>` 作为 `mutableStateOf(...)` 的初值。
+
+```kotlin
+private fun showSetUserInfoDialog() {
+  dismiss()
+
+  // 2c1 修复:同步预填,避免空白闪一下 + 竞态覆盖
+  val (currentUsername, currentEmail) = Libgit2Helper.getGitUsernameAndEmailFromGlobalConfig()
+
+  val composeHostDialog = ComponentDialog(context)
+  composeHostDialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+  composeHostDialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+  val composeView = ComposeView(context).apply {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+      val usernameState = remember { mutableStateOf(currentUsername) }
+      val emailState = remember { mutableStateOf(currentEmail) }
+      // ... 后续不变
+    }
+  }
+  composeHostDialog.setContentView(composeView)
+  composeHostDialog.show()
+}
+```
+
+`getGitUsernameAndEmailFromGlobalConfig()` 内部走 `PrefMan.get(...)`
+读 SharedPreferences，是同步 IO 阻塞调用。在 dialog 弹出路径上
+一次性调用（不循环）可接受。后续若对首屏时间敏感，可改成
+`runOnIOThread` + 状态回调，但不在本 sub-spec 范围。
+
+## 4. 架构 / 改动点
+
+### 4.1 关键改动
+
+- **`GitPopupManager.kt::showSetUserInfoDialog`**：在 `setContent` 块前
+  同步读当前值，作为 `mutableStateOf(...)` 初值
+
+不动：dialog 结构、`AskGitUsernameAndEmailDialog` 调用参数、`onOk` 回调
+
+### 4.2 数据流（修复后）
+
+```
+用户点击 popup 头
+  ↓
+GitPopupManager.showSetUserInfoDialog()
+  ↓ Libgit2Helper.getGitUsernameAndEmailFromGlobalConfig() (同步)
+  ↓ Pair<currentUsername, currentEmail>
+  ↓
+ComponentDialog.setContent {
+  usernameState = remember { mutableStateOf(currentUsername) }   ← 初值已是当前值
+  emailState    = remember { mutableStateOf(currentEmail) }      ← 初值已是当前值
+  AskGitUsernameAndEmailDialog(..., isForGlobal = true, ...) {
+    onOk = save(usernameState.value, emailState.value)            ← 一定是当前值
+  }
+}
+  ↓
+对话框立即显示当前配置,无空白闪,无竞态
+```
+
+## 5. 不变量
+
+- `AskGitUsernameAndEmailDialog` 内部 `LaunchedEffect` 仍跑（读
+  `PuppyGitSettings.json`）—— 它是兜底,在 `currentUsername` /
+  `currentEmail` 与 `PuppyGitSettings.json` 不一致时仍会纠正
+  （本 sub-spec 不动该行为）
+- `onOk` 写入路径不变（仍走 `saveGitUsernameAndEmailForGlobal`）
+- `refreshUserInfo` 仍由 `onOk` 成功时调用（dialog 关闭后更新 popup 头）
+- 其它 popup 行为不变
+
+## 6. 验证
+
+| 验证项 | 方式 |
+| --- | --- |
+| 对话框打开瞬间字段非空 | code review（`mutableStateOf(currentUsername)` 初值已设） |
+| 保存空字符串 → 仍能写空（清除功能保留） | code review（`enableOk = { true }` 不变,允许空值） |
+| 保存非空值 → 写入的是用户看到的内容 | code review（`onOk` 用 `usernameState.value`,而 state 初值已是当前值） |
+| `refreshUserInfo` 仍被调 | code review（`onOk` 内部不变） |
+| 编译通过 | code review（沙箱无网络 gradle 编译跳过） |
+
+## 7. 风险
+
+| 风险 | 缓解 |
+| --- | --- |
+| `getGitUsernameAndEmailFromGlobalConfig` 同步 IO 在主线程上,大项目可能微卡 | 一次调用,可接受;后续若 perf 不达标再异步化 |
+| `AppModel.realAppContext` 未初始化时 NPE | 2a1 的 `PuppyGitIntegration.ensureNativeLoaded` 已被 popup 弹起时跑过（popup 在 fragment 内,fragment.onViewCreated 跑过 bootstrap）;若仍 NPE 由调用链上层保护 |
+
+## 8. 关联
+
+- 父 spec: `2026-06-11-git-fragments-refactor-roadmap.md`
+- 后置: 2c2 (快捷菜单)
+- 调用 puppygit API: `com.catpuppyapp.puppygit.utils.Libgit2Helper.{getGitUsernameAndEmailFromGlobalConfig, saveGitUsernameAndEmailForGlobal}`
+- 调用 puppygit 组件: `com.catpuppyapp.puppygit.compose.AskGitUsernameAndEmailDialog`（屏幕类，roadmap 1.4 允许）

--- a/docs/superpowers/specs/2026-06-11-git-fragments-2c2-quick-menu-design.md
+++ b/docs/superpowers/specs/2026-06-11-git-fragments-2c2-quick-menu-design.md
@@ -1,0 +1,148 @@
+# 2c2 不常用功能整合到快捷菜单
+
+| 字段 | 值 |
+| --- | --- |
+| 父 spec | `2026-06-11-git-fragments-refactor-roadmap.md` |
+| 前置 | 2a1 (puppygit 基础设施) / 2c1 (popup 用户名/邮箱预填) |
+| 后置 | (末端,无依赖) |
+| 范围 | `core/app/.../fragments/git/menu/GitPopupManager.kt` |
+| 状态 | draft, 实施中 |
+
+## 1. 背景
+
+`GitPopupManager` 当前把 git UI 相关的所有"低频"配置入口都塞进同一个
+`PopupWindow`，导致：
+
+1. **入口分散**：username/email 配置挂在 header 头像里（点击 header
+   才弹 `AskGitUsernameAndEmailDialog`），init repository 在
+   "Operations" 区段里。两者**视觉上不相邻**，用户找不到。
+2. **占位死链**：底部 "Settings" 菜单项是 `git_settings_under_construction`
+   toast 占位，没有任何实现。
+3. **header 含义模糊**：把"配置入口"塞进"用户信息"头部，违反单一职责
+   —— header 应当**只显示**当前用户，点击应该是"看详情"而不是"改东西"。
+
+本 sub-spec 把 username/email 配置和 init repository **整合到一个
+"快捷设置"区段**，header 改为纯只读。
+
+## 2. 目标 / 非目标
+
+### 2.1 目标
+
+- popup 顶部 header 改为**只读**（仍显示 username/email + 眼睛切换，但
+  不再绑点击事件 → 弹设置对话框）
+- 新增 "快捷设置" 区段，含两个菜单项：
+  - "设置用户名 / 邮箱" → 触发 `showSetUserInfoDialog`（2c1 修复后）
+  - "初始化仓库" → 触发 `initRepositoryIfNeeded`
+- 移除底部占位 "Settings" 死链 toast
+- popup 区段结构变为（自上而下）：
+
+  ```
+  ┌───────────────────────────────┐
+  │ [avatar]  username            │  ← header 只读
+  │            email**** [eye]    │
+  ├───────────────────────────────┤
+  │ [icon] GitHub Token           │  ← 唯一保留在"凭据"区段的项
+  │         凭据                  │
+  ├───────────────────────────────┤
+  │ ── 仓库操作 ──                │
+  │ [icon] 初始化仓库             │  ← 从"快捷设置"移出,放在操作区
+  ├───────────────────────────────┤
+  │ ── 快捷设置 ──                │
+  │ [icon] 设置用户名 / 邮箱       │  ← 新增,合并自原 header 点击
+  └───────────────────────────────┘
+  ```
+
+### 2.2 非目标
+
+- 不动 `AskGitUsernameAndEmailDialog` / 2c1 的预填逻辑
+- 不动 token 凭据菜单（`showTokenCredentialDialog`）
+- 不动 `initRepositoryIfNeeded` 实现
+- 不动 popup 框架（保留 `PopupWindow` 实现）
+- 不动 fragment / 工具栏
+
+## 3. 架构 / 改动点
+
+### 3.1 popup 重排
+
+`GitPopupManager.show(anchor)` 当前结构：
+
+```
+1. setupHeader()        — 头像+用户+邮箱,header click 触发 setUserInfoDialog
+2. addDivider()
+3. addMenuItem(token)   — GitHub Token 凭据
+4. addDivider()
+5. addSectionTitle(Operations)
+6. addMenuItem(initRepo)
+7. addDivider()
+8. addMenuItem(settings) — 死链 toast
+```
+
+新结构：
+
+```
+1. setupHeader()        — 头像+用户+邮箱,只读;点击不再绑任何动作
+2. addDivider()
+3. addMenuItem(token)   — GitHub Token 凭据
+4. addDivider()
+5. addSectionTitle(Operations)
+6. addMenuItem(initRepo) — 仍在"仓库操作"区段
+7. addDivider()
+8. addSectionTitle(QuickSettings)  ← 新增
+9. addMenuItem(setUserInfo)        ← 新增,触发 showSetUserInfoDialog
+10.(去掉原占位 settings 死链)
+```
+
+init repository 保留在"仓库操作"区段（"操作"含义贴合）。新增"快捷设置"
+区段只放"用户身份配置"一项（更聚焦）。
+
+### 3.2 header 只读
+
+`setupHeader()` 移除 `headerView.setOnClickListener { showSetUserInfoDialog() }`。
+header 仍保留 `btnEye` 切换邮箱显示 / 隐藏（属于"显示"操作，不属于"配置"）。
+
+### 3.3 关键改动
+
+- **`GitPopupManager.kt::show`**：调整调用顺序，移除 settings 死链,
+  新增 "快捷设置" 区段和 "设置用户名 / 邮箱" 菜单项
+- **`GitPopupManager.kt::setupHeader`**：移除 `setOnClickListener`
+- 新增字符串资源 (若需要)：
+  - `git_quick_settings_section` = "快捷设置"
+  - `git_set_user_info_title` = "设置用户名 / 邮箱"
+  - `git_set_user_info_subtitle` = "设置全局 git 用户身份"
+
+> 字符串资源走 `core/app/src/main/res/values/strings.xml` 添加;若已存在
+> 复用之。
+
+## 4. 不变量
+
+- `AskGitUsernameAndEmailDialog` 行为不变（2c1 修复后已预填）
+- `initRepositoryIfNeeded` 行为不变
+- `showTokenCredentialDialog` 行为不变
+- `refreshUserInfo` 行为不变（仍由 showSetUserInfoDialog 的 onOk 触发）
+- 0 行 git24j / puppygit 内部 import 新增（仅复用现有的）
+- popup 框架（PopupWindow + container LinearLayout）不变
+- `btnGitMenu` 触发入口不变（`GitHostFragment` 仍调 `popupManager?.show(anchorView)`）
+
+## 5. 验证
+
+| 验证项 | 方式 |
+| --- | --- |
+| header 点击不再触发 `showSetUserInfoDialog` | code review（移除 setOnClickListener） |
+| "快捷设置"区段标题为新增字符串 | code review |
+| "设置用户名 / 邮箱" 菜单点击调 `showSetUserInfoDialog` | code review |
+| "初始化仓库" 仍在"仓库操作"区段 | code review |
+| 死链 "Settings" toast 被移除 | `git grep` `git_settings_under_construction` |
+| 编译通过 | code review（沙箱无网络 gradle 编译跳过） |
+
+## 6. 风险
+
+| 风险 | 缓解 |
+| --- | --- |
+| 用户习惯了"点 header 改配置" | 显式添加新的"快捷设置"区段;后续可在 release notes / commit message 中说明迁移 |
+| 字符串资源重复 | 优先复用 `core/app/src/main/res/values/strings.xml` 中已存在的 `git_*` key;不存在才新增 |
+
+## 7. 关联
+
+- 父 spec: `2026-06-11-git-fragments-refactor-roadmap.md`
+- 前置: 2c1 (`showSetUserInfoDialog` 预填修复)
+- 调用 puppygit API: `com.catpuppyapp.puppygit.utils.Libgit2Helper.saveGitUsernameAndEmailForGlobal`


### PR DESCRIPTION
## 背景

`GitPopupManager` 把 git UI 相关的"低频"配置入口塞得乱:

- **配置入口分散**:username/email 配置挂在 header 头像里(点击触发 `showSetUserInfoDialog`);init repository 在 "Operations" 区段里。两者**视觉上不相邻**。
- **死链菜单项**:底部 "Settings" 菜单项永远弹 `git_settings_under_construction` toast,占位无实现。
- **header 违反单一职责**:把"配置入口"塞进"用户信息"头部 — header 应当**只显示**,点击应该是"看详情"而不是"改东西"。

## 修复

把 username/email 配置和 init repository 整合到"快捷设置"区段,header 改为纯只读。

**修改前**
```
[header: avatar + user + email  ←点击→showSetUserInfoDialog]
[GitHub Token 凭据]
── 仓库操作 ──
[初始化仓库]
[Settings  ←死链 toast]
```

**修改后**
```
[header: avatar + user + email  ←只读,仅眼睛切换邮箱可见性]
[GitHub Token 凭据]
── 仓库操作 ──
[初始化仓库]
── 快捷设置 ──
[设置用户名 / 邮箱  ←迁出自原 header 点击]
```

## 关键改动

- `GitPopupManager.show()`:新增"快捷设置"区段 + "设置用户名 / 邮箱"菜单项;移除底部死链 "Settings" 菜单项
- `GitPopupManager.setupHeader()`:移除 `headerView.setOnClickListener { showSetUserInfoDialog() }`,header 改为只读
- `core/resources/values/strings.xml` + `values-zh-rCN/strings.xml`:
  - 新增 `git_quick_settings_section` / `git_set_user_info_title` / `git_set_user_info_subtitle`
  - 移除 `git_settings_under_construction`
- 图标用 `com.itsaky.androidide.resources.R.drawable.ic_account`(`core/resources` 已存在)

## 跟随 spec

`docs/superpowers/specs/2026-06-11-git-fragments-2c2-quick-menu-design.md`

## 不变量

- `AskGitUsernameAndEmailDialog` 行为不变(2c1 修复后已预填)
- `initRepositoryIfNeeded` 行为不变
- `showTokenCredentialDialog` 行为不变
- `refreshUserInfo` 仍由 `showSetUserInfoDialog` 的 onOk 触发
- popup 框架(`PopupWindow` + container LinearLayout)不变
- `btnGitMenu` 触发入口不变(`GitHostFragment` 仍调 `popupManager?.show(anchorView)`)

## 验证

- 源码 `git grep` 确认 `git_settings_under_construction` 在 core/app 中**0 引用**;`setOnClickListener { showSetUserInfoDialog() }` 也**0 引用**
- 新字符串资源在默认 + zh-rCN 齐备;其他 22 个 locale 本 PR 不动,`git_settings_under_construction` 残留但不影响行为(死链已不在代码中)
- 沙箱无网络 gradle 编译跳过;code review 验证 popup 区段顺序与原意图一致