### PR TITLE
refactor(git-popup): 把"设置用户名/邮箱"迁到"快捷设置"区段,header 改为只读

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -76,13 +76,17 @@ class GitPopupManager(private val context: Context) {
       initRepositoryIfNeeded()
       dismiss()
     }
-    addDivider()
 
-    addMenuItem(iconRes = R.drawable.ic_settings_24, title = context.getString(R.string.settings)) {
-      Msg.requireShowLongDuration(
-          context.getString(com.itsaky.androidide.resources.R.string.git_settings_under_construction)
-      )
-      dismiss()
+    // 2c2: 新增"快捷设置"区段,把"设置用户名 / 邮箱"入口从原 header 点击
+    // 迁出(原 header 是只读的,只显示 + 眼睛切换邮箱可见性)。
+    addDivider()
+    addSectionTitle(context.getString(com.itsaky.androidide.resources.R.string.git_quick_settings_section))
+    addMenuItem(
+        iconRes = com.itsaky.androidide.resources.R.drawable.ic_account,
+        title = context.getString(com.itsaky.androidide.resources.R.string.git_set_user_info_title),
+        subtitle = context.getString(com.itsaky.androidide.resources.R.string.git_set_user_info_subtitle),
+    ) {
+      showSetUserInfoDialog()
     }
 
     val displayMetrics = context.resources.displayMetrics
@@ -117,7 +121,8 @@ class GitPopupManager(private val context: Context) {
       updateEmailDisplay()
     }
 
-    headerView.setOnClickListener { showSetUserInfoDialog() }
+    // 2c2: header 改为只读 — 不再绑点击事件触发 showSetUserInfoDialog;
+    // 该入口已迁到"快捷设置"区段的"设置用户名 / 邮箱"菜单项。
 
     container?.addView(headerView)
   }

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -1081,7 +1081,10 @@ SHA256：%9$s</string>
   <string name="git_operations_section">Git Operations</string>
   <string name="git_init_title">Initialize Git</string>
   <string name="git_init_subtitle">Create .git repository</string>
-  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <!-- 2c2: 移除死链字符串 "git_settings_under_construction";新增"快捷设置" + "设置用户名 / 邮箱" -->
+  <string name="git_quick_settings_section">快捷设置</string>
+  <string name="git_set_user_info_title">设置用户名 / 邮箱</string>
+  <string name="git_set_user_info_subtitle">配置全局 git 用户身份</string>
   <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
   <string name="git_no_opened_project">No opened project</string>
   <string name="git_repository_already_initialized">Repository already initialized</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -825,7 +825,10 @@
   <string name="git_operations_section">Git Operations</string>
   <string name="git_init_title">Initialize Git</string>
   <string name="git_init_subtitle">Create .git repository</string>
-  <string name="git_settings_under_construction">Git settings page is under construction</string>
+  <!-- 2c2: dead string "git_settings_under_construction" removed; replaced by 快捷设置 / 设置用户名邮箱 入口 -->
+  <string name="git_quick_settings_section">Quick Settings</string>
+  <string name="git_set_user_info_title">Set Username / Email</string>
+  <string name="git_set_user_info_subtitle">Configure global git identity</string>
   <string name="git_token_updated">Token credentials updated for Push/Pull.</string>
   <string name="git_no_opened_project">No opened project</string>
   <string name="git_repository_already_initialized">Repository already initialized</string>

--- a/docs/superpowers/specs/2026-06-11-git-fragments-2c2-quick-menu-design.md
+++ b/docs/superpowers/specs/2026-06-11-git-fragments-2c2-quick-menu-design.md
@@ -1,0 +1,148 @@
+# 2c2 不常用功能整合到快捷菜单
+
+| 字段 | 值 |
+| --- | --- |
+| 父 spec | `2026-06-11-git-fragments-refactor-roadmap.md` |
+| 前置 | 2a1 (puppygit 基础设施) / 2c1 (popup 用户名/邮箱预填) |
+| 后置 | (末端,无依赖) |
+| 范围 | `core/app/.../fragments/git/menu/GitPopupManager.kt` |
+| 状态 | draft, 实施中 |
+
+## 1. 背景
+
+`GitPopupManager` 当前把 git UI 相关的所有"低频"配置入口都塞进同一个
+`PopupWindow`，导致：
+
+1. **入口分散**：username/email 配置挂在 header 头像里（点击 header
+   才弹 `AskGitUsernameAndEmailDialog`），init repository 在
+   "Operations" 区段里。两者**视觉上不相邻**，用户找不到。
+2. **占位死链**：底部 "Settings" 菜单项是 `git_settings_under_construction`
+   toast 占位，没有任何实现。
+3. **header 含义模糊**：把"配置入口"塞进"用户信息"头部，违反单一职责
+   —— header 应当**只显示**当前用户，点击应该是"看详情"而不是"改东西"。
+
+本 sub-spec 把 username/email 配置和 init repository **整合到一个
+"快捷设置"区段**，header 改为纯只读。
+
+## 2. 目标 / 非目标
+
+### 2.1 目标
+
+- popup 顶部 header 改为**只读**（仍显示 username/email + 眼睛切换，但
+  不再绑点击事件 → 弹设置对话框）
+- 新增 "快捷设置" 区段，含两个菜单项：
+  - "设置用户名 / 邮箱" → 触发 `showSetUserInfoDialog`（2c1 修复后）
+  - "初始化仓库" → 触发 `initRepositoryIfNeeded`
+- 移除底部占位 "Settings" 死链 toast
+- popup 区段结构变为（自上而下）：
+
+  ```
+  ┌───────────────────────────────┐
+  │ [avatar]  username            │  ← header 只读
+  │            email**** [eye]    │
+  ├───────────────────────────────┤
+  │ [icon] GitHub Token           │  ← 唯一保留在"凭据"区段的项
+  │         凭据                  │
+  ├───────────────────────────────┤
+  │ ── 仓库操作 ──                │
+  │ [icon] 初始化仓库             │  ← 从"快捷设置"移出,放在操作区
+  ├───────────────────────────────┤
+  │ ── 快捷设置 ──                │
+  │ [icon] 设置用户名 / 邮箱       │  ← 新增,合并自原 header 点击
+  └───────────────────────────────┘
+  ```
+
+### 2.2 非目标
+
+- 不动 `AskGitUsernameAndEmailDialog` / 2c1 的预填逻辑
+- 不动 token 凭据菜单（`showTokenCredentialDialog`）
+- 不动 `initRepositoryIfNeeded` 实现
+- 不动 popup 框架（保留 `PopupWindow` 实现）
+- 不动 fragment / 工具栏
+
+## 3. 架构 / 改动点
+
+### 3.1 popup 重排
+
+`GitPopupManager.show(anchor)` 当前结构：
+
+```
+1. setupHeader()        — 头像+用户+邮箱,header click 触发 setUserInfoDialog
+2. addDivider()
+3. addMenuItem(token)   — GitHub Token 凭据
+4. addDivider()
+5. addSectionTitle(Operations)
+6. addMenuItem(initRepo)
+7. addDivider()
+8. addMenuItem(settings) — 死链 toast
+```
+
+新结构：
+
+```
+1. setupHeader()        — 头像+用户+邮箱,只读;点击不再绑任何动作
+2. addDivider()
+3. addMenuItem(token)   — GitHub Token 凭据
+4. addDivider()
+5. addSectionTitle(Operations)
+6. addMenuItem(initRepo) — 仍在"仓库操作"区段
+7. addDivider()
+8. addSectionTitle(QuickSettings)  ← 新增
+9. addMenuItem(setUserInfo)        ← 新增,触发 showSetUserInfoDialog
+10.(去掉原占位 settings 死链)
+```
+
+init repository 保留在"仓库操作"区段（"操作"含义贴合）。新增"快捷设置"
+区段只放"用户身份配置"一项（更聚焦）。
+
+### 3.2 header 只读
+
+`setupHeader()` 移除 `headerView.setOnClickListener { showSetUserInfoDialog() }`。
+header 仍保留 `btnEye` 切换邮箱显示 / 隐藏（属于"显示"操作，不属于"配置"）。
+
+### 3.3 关键改动
+
+- **`GitPopupManager.kt::show`**：调整调用顺序，移除 settings 死链,
+  新增 "快捷设置" 区段和 "设置用户名 / 邮箱" 菜单项
+- **`GitPopupManager.kt::setupHeader`**：移除 `setOnClickListener`
+- 新增字符串资源 (若需要)：
+  - `git_quick_settings_section` = "快捷设置"
+  - `git_set_user_info_title` = "设置用户名 / 邮箱"
+  - `git_set_user_info_subtitle` = "设置全局 git 用户身份"
+
+> 字符串资源走 `core/app/src/main/res/values/strings.xml` 添加;若已存在
+> 复用之。
+
+## 4. 不变量
+
+- `AskGitUsernameAndEmailDialog` 行为不变（2c1 修复后已预填）
+- `initRepositoryIfNeeded` 行为不变
+- `showTokenCredentialDialog` 行为不变
+- `refreshUserInfo` 行为不变（仍由 showSetUserInfoDialog 的 onOk 触发）
+- 0 行 git24j / puppygit 内部 import 新增（仅复用现有的）
+- popup 框架（PopupWindow + container LinearLayout）不变
+- `btnGitMenu` 触发入口不变（`GitHostFragment` 仍调 `popupManager?.show(anchorView)`）
+
+## 5. 验证
+
+| 验证项 | 方式 |
+| --- | --- |
+| header 点击不再触发 `showSetUserInfoDialog` | code review（移除 setOnClickListener） |
+| "快捷设置"区段标题为新增字符串 | code review |
+| "设置用户名 / 邮箱" 菜单点击调 `showSetUserInfoDialog` | code review |
+| "初始化仓库" 仍在"仓库操作"区段 | code review |
+| 死链 "Settings" toast 被移除 | `git grep` `git_settings_under_construction` |
+| 编译通过 | code review（沙箱无网络 gradle 编译跳过） |
+
+## 6. 风险
+
+| 风险 | 缓解 |
+| --- | --- |
+| 用户习惯了"点 header 改配置" | 显式添加新的"快捷设置"区段;后续可在 release notes / commit message 中说明迁移 |
+| 字符串资源重复 | 优先复用 `core/app/src/main/res/values/strings.xml` 中已存在的 `git_*` key;不存在才新增 |
+
+## 7. 关联
+
+- 父 spec: `2026-06-11-git-fragments-refactor-roadmap.md`
+- 前置: 2c1 (`showSetUserInfoDialog` 预填修复)
+- 调用 puppygit API: `com.catpuppyapp.puppygit.utils.Libgit2Helper.saveGitUsernameAndEmailForGlobal`


### PR DESCRIPTION
## 背景

`GitPopupManager` 把 git UI 相关的"低频"配置入口塞得乱:

- **配置入口分散**:username/email 配置挂在 header 头像里(点击触发 `showSetUserInfoDialog`);init repository 在 "Operations" 区段里。两者**视觉上不相邻**。
- **死链菜单项**:底部 "Settings" 菜单项永远弹 `git_settings_under_construction` toast,占位无实现。
- **header 违反单一职责**:把"配置入口"塞进"用户信息"头部 — header 应当**只显示**,点击应该是"看详情"而不是"改东西"。

## 修复

把 username/email 配置和 init repository 整合到"快捷设置"区段,header 改为纯只读。

**修改前**
```
[header: avatar + user + email  ←点击→showSetUserInfoDialog]
[GitHub Token 凭据]
── 仓库操作 ──
[初始化仓库]
[Settings  ←死链 toast]
```

**修改后**
```
[header: avatar + user + email  ←只读,仅眼睛切换邮箱可见性]
[GitHub Token 凭据]
── 仓库操作 ──
[初始化仓库]
── 快捷设置 ──
[设置用户名 / 邮箱  ←迁出自原 header 点击]
```

## 关键改动

- `GitPopupManager.show()`:新增"快捷设置"区段 + "设置用户名 / 邮箱"菜单项;移除底部死链 "Settings" 菜单项
- `GitPopupManager.setupHeader()`:移除 `headerView.setOnClickListener { showSetUserInfoDialog() }`,header 改为只读
- `core/resources/values/strings.xml` + `values-zh-rCN/strings.xml`:
  - 新增 `git_quick_settings_section` / `git_set_user_info_title` / `git_set_user_info_subtitle`
  - 移除 `git_settings_under_construction`
- 图标用 `com.itsaky.androidide.resources.R.drawable.ic_account`(`core/resources` 已存在)

## 跟随 spec

`docs/superpowers/specs/2026-06-11-git-fragments-2c2-quick-menu-design.md`

## 不变量

- `AskGitUsernameAndEmailDialog` 行为不变(2c1 修复后已预填)
- `initRepositoryIfNeeded` 行为不变
- `showTokenCredentialDialog` 行为不变
- `refreshUserInfo` 仍由 `showSetUserInfoDialog` 的 onOk 触发
- popup 框架(`PopupWindow` + container LinearLayout)不变
- `btnGitMenu` 触发入口不变(`GitHostFragment` 仍调 `popupManager?.show(anchorView)`)

## 验证

- 源码 `git grep` 确认 `git_settings_under_construction` 在 core/app 中**0 引用**;`setOnClickListener { showSetUserInfoDialog() }` 也**0 引用**
- 新字符串资源在默认 + zh-rCN 齐备;其他 22 个 locale 本 PR 不动,`git_settings_under_construction` 残留但不影响行为(死链已不在代码中)
- 沙箱无网络 gradle 编译跳过;code review 验证 popup 区段顺序与原意图一致