### PR TITLE
refactor(git-changes): 重新设计工具栏,分组组织按钮

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/BaseGitPageFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/BaseGitPageFragment.kt
@@ -18,6 +18,7 @@ package com.itsaky.androidide.fragments.git
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.res.Resources
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
@@ -99,6 +100,45 @@ abstract class BaseGitPageFragment : Fragment() {
 
     findToolbarContainer()?.addView(button)
     return button
+  }
+
+  protected fun addToolbarSeparator() {
+    val context = requireContext()
+    val separator = View(context).apply {
+      layoutParams = LinearLayout.LayoutParams(
+          1.dpToPx(),
+          resources.getDimensionPixelSize(R.dimen.git_toolbar_icon_size),
+      ).apply {
+        val margin = 4.dpToPx()
+        marginStart = margin
+        marginEnd = margin
+      }
+      setBackgroundColor(androidx.core.content.ContextCompat.getColor(context, R.color.git_toolbar_separator))
+    }
+    findToolbarContainer()?.addView(separator)
+  }
+
+  protected fun addToolbarSectionLabel(text: String) {
+    val context = requireContext()
+    val label = android.widget.TextView(context).apply {
+      layoutParams = LinearLayout.LayoutParams(
+          LinearLayout.LayoutParams.WRAP_CONTENT,
+          resources.getDimensionPixelSize(R.dimen.git_toolbar_icon_size),
+      ).apply {
+        val margin = 8.dpToPx()
+        marginStart = margin
+        marginEnd = margin
+      }
+      text = text
+      setTextColor(androidx.core.content.ContextCompat.getColor(context, R.color.git_toolbar_label))
+      textSize = 10f
+      gravity = android.view.Gravity.CENTER_VERTICAL
+    }
+    findToolbarContainer()?.addView(label)
+  }
+
+  private fun Int.dpToPx(): Int {
+    return (this * Resources.getSystem().displayMetrics.density).toInt()
   }
 
   protected fun addToolbarCustomView(view: View) {

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitChangesFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitChangesFragment.kt
@@ -67,36 +67,40 @@ class GitChangesFragment : BaseGitPageFragment() {
   }
 
   override fun setupToolbar() {
+    // 2b 重新设计：分组组织按钮，去掉冗余操作
+    //
+    // 分组1: Staged 操作区 (提交已暂存内容)
     addToolbarAction(R.drawable.ic_check_24, getString(R.string.commit)) {
       emitGitOperation("changes", "commit")
       commitChanges()
     }
 
+    // 分组分隔线
+    addToolbarSeparator()
+
+    // 分组2: Remote 操作区 (推送/拉取)
+    // Push - 使用 ic_arrow_upward_24 (上传箭头，区别于 Pull 的云下载)
     addToolbarAction(R.drawable.ic_arrow_upward_24, getString(R.string.push)) {
       emitGitOperation("changes", "push")
       pushCurrentBranch(force = false)
     }
 
+    // Pull - ic_cloud_download_24 (云下载图标)
     addToolbarAction(R.drawable.ic_cloud_download_24, getString(R.string.pull)) {
       emitGitOperation("changes", "pull_fetch_origin")
       pullFromOrigin()
     }
 
+    // Force Push - 危险操作放最后
     addToolbarAction(R.drawable.ic_warning_24, "Force Push") {
       emitGitOperation("changes", "force_push")
       pushCurrentBranch(force = true)
     }
 
-    addToolbarAction(R.drawable.ic_cloud_download_24, "Commit && Push") {
-      emitGitOperation("changes", "commit_and_push")
-      commitThenPush()
-    }
+    // 分组分隔线
+    addToolbarSeparator()
 
-    addToolbarAction(R.drawable.ic_refresh_24, getString(R.string.refresh)) {
-      emitGitOperation("changes", "refresh")
-      loadChanges()
-    }
-
+    // 分组3: Staging 操作区 (暂存/取消暂存/丢弃)
     addToolbarAction(R.drawable.ic_select_all_24, getString(R.string.stage_all)) {
       emitGitOperation("changes", "stage_all")
       stageAll()
@@ -110,6 +114,15 @@ class GitChangesFragment : BaseGitPageFragment() {
     addToolbarAction(R.drawable.ic_delete_sweep_24, getString(R.string.revert)) {
       emitGitOperation("changes", "discard_all")
       discardAll()
+    }
+
+    // 分组分隔线
+    addToolbarSeparator()
+
+    // 分组4: 刷新 (放在最后)
+    addToolbarAction(R.drawable.ic_refresh_24, getString(R.string.refresh)) {
+      emitGitOperation("changes", "refresh")
+      loadChanges()
     }
   }
 

--- a/core/resources/src/main/res/values/colors.xml
+++ b/core/resources/src/main/res/values/colors.xml
@@ -43,4 +43,8 @@
     <!-- 暗缟玛瑙 -->
     <color name="purple_171717">#111111</color>
     
+  <!-- git toolbar -->
+  <color name="git_toolbar_separator">#1F000000</color>
+  <color name="git_toolbar_label">#80000000</color>
+
 </resources>


### PR DESCRIPTION
## 概述

重构 Git Changes 页面工具栏,把 9 个无序按钮重新组织为 4 个分组,改善 UX。

## 改动

### BaseGitPageFragment
- 新增 `addToolbarSeparator()` 帮助方法,插入 1dp 垂直分隔线
- 新增 `addToolbarSectionLabel(text)` 帮助方法(预留,本 PR 暂未使用)
- 颜色资源:新增 `git_toolbar_separator`(12% 黑)/ `git_toolbar_label`(50% 黑)

### GitChangesFragment
- 把 9 个无序按钮重排为 4 个逻辑分组,中间用 `addToolbarSeparator()` 分隔:
  1. **Commit** - 提交(只 1 个 commit 按钮)
  2. **Remote** - Push / Pull / Force Push
  3. **Staging** - Stage All / Unstage / Revert
  4. **Refresh** - 刷新
- **删除冗余**:
  - 删掉重复的 "Commit && Push" 按钮(逻辑与 commit + push 重复)
  - 调整按钮顺序:危险操作(Force Push)放最后

## 验证

代码语法层面已通过手工 review,完整编译验证需要 SDK 环境(当前 sandbox 无网络/SDK)。

## 关联

属于 git fragments 5 子重构中的 **2b** 子 spec 任务。

- 2a1 puppygit 集成 - ✅ PR #308
- 2a2 GitBranchesFragment 试点 - ✅ PR #309
- 2c1 弹窗 username/email 预填充 - ✅ PR #310
- 2c2 快捷设置区段合并 - ✅ PR #312
- **2b 工具栏重新设计 - 本 PR**

## 测试

- 进入 git changes 页面
- 确认工具栏从左到右: [commit] | [push] [pull] [force] | [stage] [unstage] [revert] | [refresh]
- 每个按钮点击行为应与重构前一致
- 横向滚动条应可正常滚动
