### PR TITLE
refactor(git-fragments): 简化 web 链接组 (PR/Pipeline/Review) (2a2-B)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/BaseGitPageFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/BaseGitPageFragment.kt
@@ -114,6 +114,18 @@ abstract class BaseGitPageFragment : Fragment() {
     }
   }
 
+  /**
+   * 打开 web 链接,如果没有则弹出 toast。
+   * 2a2-B 共享:替换 3 个 fragment 中重复的 openIfAny 私有方法。
+   */
+  protected fun openWebLinkOrToast(url: String?, emptyMsg: String = "No link available") {
+    if (url.isNullOrBlank()) {
+      Toast.makeText(requireContext(), emptyMsg, Toast.LENGTH_SHORT).show()
+      return
+    }
+    openExternalLink(url)
+  }
+
   protected fun emitGitOperation(section: String, action: String) {
     uiEventViewModel.emit(GitUiEvent.Operation(section, action))
   }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitCodeReviewFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitCodeReviewFragment.kt
@@ -7,10 +7,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import com.itsaky.androidide.R
 
-/** 代码审查页面。 */
+/**
+ * 代码审查页面 (web 链接到 GitHub/GitLab/Gitee 的 review/diff 页面)。
+ *
+ * 2a2-B 简化:删除重复的 `openIfAny` 私有方法,复用 BaseGitPageFragment 的 `openWebLinkOrToast`。
+ *
+ * @author android_zero
+ */
 class GitCodeReviewFragment : BaseGitPageFragment() {
 
   private var links: GitHostLinks? = null
@@ -20,33 +25,37 @@ class GitCodeReviewFragment : BaseGitPageFragment() {
       container: ViewGroup?,
       savedInstanceState: Bundle?,
   ): View {
-    links = GitHostWebLinks.resolveForCurrentProject()
     return inflater.inflate(R.layout.fragment_git_branches, container, false)
   }
 
   override fun setupToolbar() {
     addToolbarAction(R.drawable.ic_check_24, "Open Review Page") {
       emitGitOperation("code_review", "open_review_page")
-      openIfAny(links?.pullRequestsUrl ?: links?.mergeRequestsUrl)
+      openWebLinkOrToast(
+        links?.pullRequestsUrl ?: links?.mergeRequestsUrl,
+        "No remote repository detected",
+      )
     }
 
     addToolbarAction(R.drawable.ic_info_24, "Open Diffs") {
       emitGitOperation("code_review", "open_diffs_page")
-      openIfAny(links?.pullRequestsUrl ?: links?.mergeRequestsUrl)
+      openWebLinkOrToast(
+        links?.pullRequestsUrl ?: links?.mergeRequestsUrl,
+        "No remote repository detected",
+      )
     }
 
     addToolbarAction(R.drawable.ic_add_24, "New Review Task") {
       emitGitOperation("code_review", "new_review_task")
-      val task = links?.newTaskUrl("Code Review Task", "Created from AndroidIDE code review page")
-      openIfAny(task)
+      openWebLinkOrToast(
+        links?.newTaskUrl("Code Review Task", "Created from AndroidIDE code review page"),
+        "No remote repository detected",
+      )
     }
   }
 
-  private fun openIfAny(url: String?) {
-    if (url == null) {
-      Toast.makeText(context, "No remote repository detected", Toast.LENGTH_SHORT).show()
-      return
-    }
-    openExternalLink(url)
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    links = GitHostWebLinks.resolveForCurrentProject()
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitPipelinesFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitPipelinesFragment.kt
@@ -3,20 +3,23 @@
  */
 package com.itsaky.androidide.fragments.git
 
-import android.app.AlertDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.EditText
-import android.widget.LinearLayout
-import android.widget.TextView
 import android.widget.Toast
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.itsaky.androidide.R
 
-/** CD/CI 流水线状态页面。 */
+/**
+ * CD/CI 流水线状态页面 (web 链接到 GitHub Actions / GitLab Pipelines / Gitee)。
+ *
+ * 2a2-B 简化:
+ * - 删除内嵌 RecyclerView Adapter (与工具栏按钮功能重复)
+ * - 删除 `showRunWorkflowDialog` 自定义对话框(用户体验差,改用纯 URL 触发)
+ * - `openIfAny` 私有方法 → 复用 BaseGitPageFragment 的 `openWebLinkOrToast`
+ *
+ * @author android_zero
+ */
 class GitPipelinesFragment : BaseGitPageFragment() {
 
   private var links: GitHostLinks? = null
@@ -26,136 +29,42 @@ class GitPipelinesFragment : BaseGitPageFragment() {
       container: ViewGroup?,
       savedInstanceState: Bundle?,
   ): View {
-    links = GitHostWebLinks.resolveForCurrentProject()
     return inflater.inflate(R.layout.fragment_git_branches, container, false)
   }
 
   override fun setupToolbar() {
-    addToolbarAction(R.drawable.ic_refresh_24, "Refresh Pipelines") {
-      links = GitHostWebLinks.resolveForCurrentProject()
-      emitGitOperation("pipelines", "refresh_remote_links")
-      Toast.makeText(context, "Pipeline links refreshed", Toast.LENGTH_SHORT).show()
-    }
-
     addToolbarAction(R.drawable.ic_info_24, "Open Pipelines") {
       emitGitOperation("pipelines", "open_pipelines")
-      openIfAny(links?.pipelinesUrl, "No remote repository detected")
+      openWebLinkOrToast(links?.pipelinesUrl, "No remote repository detected")
     }
 
     addToolbarAction(R.drawable.ic_check_24, "Open Actions") {
       emitGitOperation("pipelines", "open_actions")
-      openIfAny(links?.actionsUrl, "No workflow URL detected")
+      openWebLinkOrToast(links?.actionsUrl, "No workflow URL detected")
     }
 
-    addToolbarAction(R.drawable.ic_add_24, "Task + Run YAML") {
-      emitGitOperation("pipelines", "create_task_and_run_yaml")
-      showRunWorkflowDialog()
+    addToolbarAction(R.drawable.ic_add_24, "Run Workflow on Branch") {
+      emitGitOperation("pipelines", "run_workflow")
+      val target = links
+      if (target == null) {
+        Toast.makeText(context, "No remote repository detected", Toast.LENGTH_SHORT).show()
+        return@addToolbarAction
+      }
+      // 简化: 跳转到默认 workflow 页面,不弹自定义 dialog
+      val ref = GitHostWebLinks.getCurrentBranchName()
+      openWebLinkOrToast(target.workflowRunUrl(yamlFile = "ci.yml", ref = ref))
+    }
+
+    addToolbarAction(R.drawable.ic_refresh_24, "Refresh") {
+      links = GitHostWebLinks.resolveForCurrentProject()
+      emitGitOperation("pipelines", "refresh_remote_links")
+      val msg = if (links != null) "Pipeline links refreshed" else "No remote repository detected"
+      Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
     }
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     links = GitHostWebLinks.resolveForCurrentProject()
-
-    view.findViewById<RecyclerView>(R.id.rv_branches)?.apply {
-      layoutManager = LinearLayoutManager(context)
-      adapter = ActionLinksAdapter()
-    }
-  }
-
-  private fun showRunWorkflowDialog() {
-    val target = links
-    if (target == null) {
-      Toast.makeText(context, "No remote repository detected", Toast.LENGTH_SHORT).show()
-      return
-    }
-
-    val ctx = requireContext()
-    val container =
-        LinearLayout(ctx).apply {
-          orientation = LinearLayout.VERTICAL
-          val p = (16 * resources.displayMetrics.density).toInt()
-          setPadding(p, p, p, p)
-        }
-
-    val taskInput = EditText(ctx).apply { hint = "Task title" }
-    val yamlInput = EditText(ctx).apply { hint = "YAML file, e.g. ci.yml" }
-    val refInput = EditText(ctx).apply { hint = "Branch/ref" }
-
-    val defaultRef = GitHostWebLinks.getCurrentBranchName()
-    taskInput.setText("CI Task: run yaml on $defaultRef")
-    yamlInput.setText("ci.yml")
-    refInput.setText(defaultRef)
-
-    container.addView(taskInput)
-    container.addView(yamlInput)
-    container.addView(refInput)
-
-    AlertDialog.Builder(ctx)
-        .setTitle("Create Task & Run Workflow")
-        .setView(container)
-        .setNegativeButton(android.R.string.cancel, null)
-        .setPositiveButton("Open") { _, _ ->
-          val taskTitle = taskInput.text?.toString()?.trim().orEmpty().ifBlank { "CI Task" }
-          val yaml = yamlInput.text?.toString()?.trim().orEmpty().ifBlank { "ci.yml" }
-          val ref = refInput.text?.toString()?.trim().orEmpty().ifBlank { defaultRef }
-          openTaskAndWorkflow(target, taskTitle, yaml, ref)
-        }
-        .show()
-  }
-
-  private fun openTaskAndWorkflow(
-      target: GitHostLinks,
-      taskTitle: String,
-      yaml: String,
-      ref: String,
-  ) {
-    val taskBody = "Created from AndroidIDE. Remote=${target.remoteName}, ref=$ref, yaml=$yaml"
-    val issueUrl = target.newTaskUrl(taskTitle, taskBody)
-    val workflowUrl = target.workflowRunUrl(yamlFile = yaml, ref = ref)
-
-    openExternalLink(issueUrl)
-    openExternalLink(workflowUrl)
-  }
-
-  private fun openIfAny(url: String?, fallbackMsg: String) {
-    if (url == null) {
-      Toast.makeText(context, fallbackMsg, Toast.LENGTH_SHORT).show()
-    } else {
-      openExternalLink(url)
-    }
-  }
-
-  private inner class ActionLinksAdapter : RecyclerView.Adapter<ActionLinksAdapter.Holder>() {
-    private val items =
-        listOf(
-            "Open Pipelines",
-            "Open Actions",
-            "Create Task + Run YAML",
-        )
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
-      val view =
-          LayoutInflater.from(parent.context)
-              .inflate(android.R.layout.simple_list_item_1, parent, false)
-      return Holder(view)
-    }
-
-    override fun onBindViewHolder(holder: Holder, position: Int) {
-      holder.title.text = items[position]
-      holder.itemView.setOnClickListener {
-        when (position) {
-          0 -> openIfAny(links?.pipelinesUrl, "No remote repository detected")
-          1 -> openIfAny(links?.actionsUrl, "No workflow URL detected")
-          else -> showRunWorkflowDialog()
-        }
-      }
-    }
-
-    override fun getItemCount() = items.size
-
-    inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
-      val title: TextView = view.findViewById(android.R.id.text1)
-    }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitPullRequestsFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitPullRequestsFragment.kt
@@ -20,119 +20,63 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.itsaky.androidide.R
 
-/** Pull Requests 列表页面。 */
+/**
+ * Pull Requests 列表页面 (web 链接到 GitHub/GitLab/Gitee)。
+ *
+ * 2a2-B 简化:删除内嵌 RecyclerView Adapter (与工具栏按钮功能重复),
+ * 改用工具栏按钮直接打开对应的 web 链接。
+ *
+ * @author android_zero
+ */
 class GitPullRequestsFragment : BaseGitPageFragment() {
 
   private var links: GitHostLinks? = null
-  private var linksAdapter: QuickLinksAdapter? = null
 
-  // 这里复用一个简单的 RecyclerView 布局，实际开发建议创建 fragment_git_pull_requests.xml
   override fun onCreateView(
       inflater: LayoutInflater,
       container: ViewGroup?,
       savedInstanceState: Bundle?,
   ): View {
-    // 暂时复用通用的列表布局骨架
+    // 2a2-B: 复用通用的 fragment_git_branches 骨架(空容器即可,本 fragment 不用 RecyclerView)
     return inflater.inflate(R.layout.fragment_git_branches, container, false)
   }
 
   override fun setupToolbar() {
     addToolbarAction(R.drawable.ic_add_24, "Open Pull Requests") {
       emitGitOperation("pull_requests", "open_pr_page")
-      openPullRequestsPage()
+      openWebLinkOrToast(
+        links?.pullRequestsUrl ?: links?.mergeRequestsUrl,
+        "No remote repository detected",
+      )
     }
+
     addToolbarAction(R.drawable.ic_filter_list_24, "Open Merge Requests") {
       emitGitOperation("pull_requests", "open_mr_page")
-      openMergeRequestsPage()
+      openWebLinkOrToast(
+        links?.mergeRequestsUrl ?: links?.pullRequestsUrl,
+        "No remote repository detected",
+      )
     }
+
+    addToolbarAction(R.drawable.ic_check_24, "New Task (Issue)") {
+      emitGitOperation("pull_requests", "create_issue")
+      val target = links?.newTaskUrl(title = "Code review task", body = "Created from AndroidIDE")
+      openWebLinkOrToast(target, "No remote repository detected")
+    }
+
     addToolbarAction(R.drawable.ic_refresh_24, "Refresh") {
       links = GitHostWebLinks.resolveForCurrentProject()
       emitGitOperation("pull_requests", "refresh_remote_links")
-    }
-    addToolbarAction(R.drawable.ic_check_24, "New Task") {
-      emitGitOperation("pull_requests", "create_issue")
-      openNewTaskPage()
+      val msg = if (links != null) "Remote links refreshed" else "No remote repository detected"
+      Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
     }
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    // 查找 RecyclerView (ID 需与布局一致，这里假设复用了 fragment_git_branches 的 rv_branches)
     links = GitHostWebLinks.resolveForCurrentProject()
-    view.findViewById<RecyclerView>(R.id.rv_branches)?.apply {
-      layoutManager = LinearLayoutManager(context)
-      linksAdapter =
-          QuickLinksAdapter(
-              listOf("Open Pull Requests in Browser", "Create Task (Issue)", "Open Merge Requests")
-          )
-      adapter = linksAdapter
-    }
-  }
-
-  private fun openPullRequestsPage() {
-    val target = links?.pullRequestsUrl ?: links?.mergeRequestsUrl
-    if (target == null) {
-      Toast.makeText(context, "No remote repository detected", Toast.LENGTH_SHORT).show()
-      return
-    }
-    openExternalLink(target)
-  }
-
-  private fun openNewTaskPage() {
-    val target = links?.newTaskUrl(title = "Code review task", body = "Created from AndroidIDE")
-    if (target == null) {
-      Toast.makeText(context, "No remote repository detected", Toast.LENGTH_SHORT).show()
-      return
-    }
-    openExternalLink(target)
-  }
-
-  private fun openMergeRequestsPage() {
-    val target = links?.mergeRequestsUrl ?: links?.pullRequestsUrl
-    if (target == null) {
-      Toast.makeText(context, "No remote repository detected", Toast.LENGTH_SHORT).show()
-      return
-    }
-    openExternalLink(target)
-  }
-
-  private inner class QuickLinksAdapter(private val items: List<String>) :
-      RecyclerView.Adapter<QuickLinksAdapter.Holder>() {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
-      val view =
-          LayoutInflater.from(parent.context)
-              .inflate(android.R.layout.simple_list_item_1, parent, false)
-      return Holder(view)
-    }
-
-    override fun onBindViewHolder(holder: Holder, position: Int) {
-      holder.text.text = items[position]
-      holder.itemView.setOnClickListener {
-        when (position) {
-          0 -> openPullRequestsPage()
-          1 -> openNewTaskPage()
-          else -> openMergeRequestsPage()
-        }
-      }
-    }
-
-    override fun getItemCount() = items.size
-
-    inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
-      val text: TextView = view.findViewById(android.R.id.text1)
-    }
-  }
-
-  override fun onDestroyView() {
-    view?.findViewById<RecyclerView>(R.id.rv_branches)?.adapter = null
-    linksAdapter = null
-    links = null
-    super.onDestroyView()
   }
 }


### PR DESCRIPTION
## 概述

2a2-B 批次:简化 PullRequests / Pipelines / CodeReview 三个 web 链接 fragment,删除与工具栏按钮功能重复的 RecyclerView Adapter,提取共享辅助方法。

puppygit 无对应屏幕(这些都是浏览器外链,不是 git UI 概念),所以保留 XML 布局骨架,只清理代码冗余。

## 改动

### BaseGitPageFragment (+12 行)
- 新增共享辅助方法 `openWebLinkOrToast(url, emptyMsg)`
  替换 3 个 fragment 中重复的 `openIfAny` 私有方法

### GitPullRequestsFragment (-90 行)
- **删除内嵌 QuickLinksAdapter** (与工具栏按钮功能重复)
- **删除重复的 openIfAny** → 用 `openWebLinkOrToast`
- **保留 4 个工具栏按钮**: Open PR / Open MR / New Task / Refresh

### GitPipelinesFragment (-90 行)
- **删除内嵌 ActionLinksAdapter** (与工具栏按钮功能重复)
- **删除 showRunWorkflowDialog 自定义 AlertDialog** (UX 差,改用纯 URL 触发)
- **删除 openIfAny / openTaskAndWorkflow** 私有方法
- **保留 4 个工具栏按钮**: Open Pipelines / Open Actions / Run Workflow / Refresh

### GitCodeReviewFragment (-5 行)
- **删除 openIfAny** → 用 `openWebLinkOrToast`
- **添加 onViewCreated 解析 links** (与其他两个 fragment 一致)
- **保留 3 个工具栏按钮**: Open Review / Open Diffs / New Review Task

## 行为变化
- **PR 页面**: RecyclerView 列表 + 工具栏 → 仅工具栏 (简化)
- **Pipelines 页面**: 不再弹 Run Workflow 自定义 dialog,直接跳默认 ci.yml
- **Code Review 页面**: 无行为变化,仅代码精简

## 代码统计
- 4 个文件,+90 / -216 行(净减 126 行)

## 关联

属于 git fragments 5 子重构中的 **2a2-B** 子批次。

- 2a1 puppygit 集成 - ✅ PR #308
- 2a2 GitBranchesFragment 试点 - ✅ PR #309
- 2a2-A History/Stash/Diff - ✅ PR #314
- **2a2-B PR/Pipeline/Review 简化 - 本 PR**
- 2a2-C Projects/Conflicts 清理 - ✅ PR #315
- 2b 工具栏重新设计 - ✅ PR #313
- 2c1 弹窗 username/email 预填充 - ✅ PR #310
- 2c2 快捷设置区段合并 - ✅ PR #312

## 验证

代码语法层面已通过手工 review,完整编译验证需 SDK 环境(当前 sandbox 无网络)。