### PR TITLE
fix(compile): resolve post-merge compilation errors after #307-#316

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/editor/markdown/MarkdownPreviewFragment.kt
@@ -3,6 +3,7 @@ package com.itsaky.androidide.fragments.editor.markdown
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.util.Linkify
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -21,10 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
-import androidx.compose.ui.text.util.Linkify
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
-import com.itsaky.androidide.fragments.EditorFragmentTabManager
+import com.itsaky.androidide.fragments.editor.EditorFragmentTabManager
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/BaseGitPageFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/BaseGitPageFragment.kt
@@ -33,6 +33,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.catpuppyapp.puppygit.ui.theme.InitContent
 import com.itsaky.androidide.R
+import com.itsaky.androidide.projects.IProjectManager
 
 /**
  * 所有 Git 子页面的基类。
@@ -133,7 +134,7 @@ abstract class BaseGitPageFragment : Fragment() {
         marginStart = margin
         marginEnd = margin
       }
-      text = text
+      setText(text)
       setTextColor(androidx.core.content.ContextCompat.getColor(context, R.color.git_toolbar_label))
       textSize = 10f
       gravity = android.view.Gravity.CENTER_VERTICAL
@@ -207,5 +208,25 @@ abstract class BaseGitPageFragment : Fragment() {
     val rootView = view ?: return null
     val scrollView = rootView.findViewById<HorizontalScrollView>(R.id.git_mini_toolbar_scroll)
     return scrollView?.findViewById(R.id.git_mini_toolbar_container)
+  }
+
+  /**
+   * 解析当前打开的工程目录绝对路径。
+   *
+   * 2a2 之后多个子 fragment 都需要拿到 workdir 才能让 puppygit 解析 repoId，
+   * 把这段逻辑从 `GitChangesFragment` / `GitBranchesFragment` 上提到基类共享。
+   *
+   * @return 工程目录绝对路径；当前没有打开工程时返回 `null`
+   */
+  protected fun resolveWorkspaceDirPath(): String? {
+    val projectManager = IProjectManager.getInstance()
+    val workspaceDir =
+        runCatching { projectManager.getWorkspace()?.getProjectDir()?.path }.getOrNull()
+    if (!workspaceDir.isNullOrBlank()) {
+      return workspaceDir
+    }
+    return runCatching { projectManager.projectDirPath }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitBranchesFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitBranchesFragment.kt
@@ -24,12 +24,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.ViewModelProvider
 import com.catpuppyapp.puppygit.screen.BranchListScreen
 import com.itsaky.androidide.R
 import com.itsaky.androidide.databinding.FragmentGitBranchesComposeBinding
-import com.itsaky.androidide.projects.IProjectManager
 
 /**
  * 分支管理页面（2a2 版本）。
@@ -102,23 +99,5 @@ class GitBranchesFragment : BaseGitPageFragment() {
     binding.gitContentContainer.removeAllViews()
     super.onDestroyView()
     _binding = null
-  }
-
-  private fun resolveWorkspaceDirPath(): String? {
-    val projectManager = IProjectManager.getInstance()
-    val workspaceDir =
-        runCatching { projectManager.getWorkspace()?.getProjectDir()?.path }.getOrNull()
-    if (!workspaceDir.isNullOrBlank()) {
-      return workspaceDir
-    }
-    return runCatching { projectManager.projectDirPath }
-        .getOrNull()
-        ?.takeIf { it.isNotBlank() }
-  }
-
-  private fun emitGitOperation(section: String, action: String) {
-    val activity = activity as? FragmentActivity ?: return
-    ViewModelProvider(activity)[GitUiEventViewModel::class.java]
-        .emit(GitUiEvent.Operation(section = section, action = action))
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitChangesFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/GitChangesFragment.kt
@@ -36,7 +36,6 @@ import com.catpuppyapp.puppygit.utils.Libgit2Helper
 import com.github.git24j.core.Repository
 import com.itsaky.androidide.R
 import com.itsaky.androidide.databinding.FragmentGitChangesBinding
-import com.itsaky.androidide.projects.IProjectManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -343,19 +342,6 @@ class GitChangesFragment : BaseGitPageFragment() {
             delay(1500)
           }
         }
-  }
-
-  private fun resolveWorkspaceDirPath(): String? {
-    val projectManager = IProjectManager.getInstance()
-    val workspaceDir =
-        runCatching { projectManager.getWorkspace()?.getProjectDir()?.path }.getOrNull()
-    if (!workspaceDir.isNullOrBlank()) {
-      return workspaceDir
-    }
-
-    return runCatching { projectManager.projectDirPath }
-        .getOrNull()
-        ?.takeIf { it.isNotBlank() }
   }
 
   private fun readChangeSnapshot(projectDir: String): ChangeSnapshot {


### PR DESCRIPTION
## 背景

CI 在依次合入 #307 → #308 → #309 → #310 → #312 → #313 → #314 → #315 → #316 之后，compileDebugKotlin 红了一大片。本 PR 集中修这一组编译错误，让 main 重新可编译。

## 错误分类 & 修复

### 1. `MarkdownPreviewFragment.kt`（来自 #307）
- `import androidx.compose.ui.text.util.Linkify` → 这个包不存在；`Linkify.EMAIL_ADDRESSES / Linkify.WEB_URLS` 常量在 `android.text.util.Linkify`（Android framework）。
- `import com.itsaky.androidide.fragments.EditorFragmentTabManager` → 正确路径是 `com.itsaky.androidide.fragments.editor.EditorFragmentTabManager`（缺 `editor` 子包）。

修完后 `Linkify.EMAIL_ADDRESSES or Linkify.WEB_URLS` 自动恢复成 `Int`（之前被推成 `BigInteger`）。

### 2. `BaseGitPageFragment.addToolbarSectionLabel`（来自 #313）
- `text = text` 在当前 compose + kotlin 组合下推断 `TextView.text` 为 `val`，赋值被拒。改 `setText(text)` 显式调用。

### 3. `resolveWorkspaceDirPath` 重复 + 不可见（来自 #314 + #309）
- 原来 `GitChangesFragment` 和 `GitBranchesFragment` 各有一份 `private fun resolveWorkspaceDirPath()`；
- #314 把它用到了 `GitHistoryFragment` / `GitStashFragment` / `GitDiffFragment`，但 private 不可见，所以 `Unresolved reference`。
- 上提到 `BaseGitPageFragment` 作为 `protected` 共享，删掉两份重复实现 + 各自用不到的 import。

### 4. `emitGitOperation` 重复（来自 #309）
- `GitBranchesFragment` 有一份 `private fun emitGitOperation(section, action)`，跟 `BaseGitPageFragment` 暴露的同名 protected 方法签名完全一致，触发"hides member of supertype"警告 → 编译失败。
- 删掉本地版本 + `FragmentActivity` / `ViewModelProvider` / `IProjectManager` 几个随之失效的 import。

### 5. `GitChangesFragment` import 清理
- 删掉本地的 `resolveWorkspaceDirPath` 后 `IProjectManager` 变成孤儿 import，一并删掉。

## 净改动

```
4 files changed, 24 insertions(+), 38 deletions(-)
```

## 验证

- 本地 `gradle :core:app:compileDebugKotlin` 因系统 Java 25 跟项目要求的 17 不兼容、Gradle 8.14.4 + Kotlin 内嵌的 JavaVersion 解析器不识别 25.x，**无法在沙箱里跑**。等 CI 跑通即可（GitHub Actions 默认装 Java 17/21）。
- 所有改动都是把 9 个 PR 之间的 import 路径 / 可见性 / 重复定义拉齐，没有引入新逻辑。

## 后续

合入本 PR 后，可以继续走：
- 2d 规划里"补单元测试"（MarkdownRender、LocalResourceHttpServer）
- markdown preview 的 XSS 清洗 + WebView 内存清理

但那些属于新工作，本 PR 只为让 main 恢复绿色。