### PR TITLE
fix: 适配 IProjectManager.projectDir nullable 契约 - 消除构建报错

### DIFF
--- a/core/projects/src/main/java/com/itsaky/androidide/projects/internal/ProjectManagerImpl.kt
+++ b/core/projects/src/main/java/com/itsaky/androidide/projects/internal/ProjectManagerImpl.kt
@@ -122,13 +122,13 @@ class ProjectManagerImpl : IProjectManager, EventReceiver {
     // 缓存插件项目标志
     pluginProjectCached =
         withContext(Dispatchers.IO) {
-          File(projectDir, Environment.PLUGIN_API_JAR_RELATIVE_PATH).exists()
+          projectDir?.let { File(it, Environment.PLUGIN_API_JAR_RELATIVE_PATH).exists() } ?: false
         }
 
     this._workspace =
         withStopWatch("Transform project proxy") {
           withContext(Dispatchers.IO) {
-            WorkspaceModelBuilder.build(projectDir, CachingProject(project))
+            projectDir?.let { WorkspaceModelBuilder.build(it, CachingProject(project)) }
           }
         }
 
@@ -287,8 +287,8 @@ class ProjectManagerImpl : IProjectManager, EventReceiver {
 
         val variantName = subproject.configuredVariant?.name ?: IAndroidProject.DEFAULT_VARIANT
 
-        val moduleDir = File(projectDir, subproject.path.replace(":", File.separator))
-        val gradleInfo = GradleFileParser.parseModuleBuildGradle(moduleDir)
+        val moduleDir = projectDir?.let { File(it, subproject.path.replace(":", File.separator)) }
+        val gradleInfo = moduleDir?.let { GradleFileParser.parseModuleBuildGradle(it) }
 
         buildVariants[subproject.path] =
             BuildVariantInfo(


### PR DESCRIPTION
修复 `ProjectManagerImpl.kt` 中把可空 `IProjectManager.projectDir: File?` 传入期望 `File` 的函数（`File(...)`、`WorkspaceModelBuilder.build(...)`、`GradleFileParser.parseModuleBuildGradle(...)`）导致的 `Argument type mismatch` 编译错误。

- setupProject 阶段用 `projectDir?.let { File(it, ...).exists() } ?: false` 计算插件项目标志；
- WorkspaceModelBuilder.build 改为 `projectDir?.let { build(it, CachingProject(project)) }`，未打开工程时 `_workspace` 保持 null，后续 `getWorkspace() ?: return` 自然提前返回；
- updateBuildVariants 中 `moduleDir` 与 `gradleInfo` 改为 `?.let` 安全传播可空性。