### PR TITLE
fix: 补齐 AbstractPopupWindow catch 参数类型标注

### DIFF
--- a/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/AbstractPopupWindow.kt
+++ b/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/AbstractPopupWindow.kt
@@ -76,7 +76,7 @@ abstract class AbstractPopupWindow(editor: CodeEditor, features: Int) :
           // to align to on the next attach cycle. dismiss() is a no-op if not showing.
           try {
             dismiss()
-          } catch (Throwable t) {
+          } catch (t: Throwable) {
             log.warn("Failed to dismiss popup window '{}' on anchor detach", javaClass.name, t)
           }
         }
@@ -108,7 +108,7 @@ abstract class AbstractPopupWindow(editor: CodeEditor, features: Int) :
     if (detachListenerRegistered) {
       try {
         editor.removeOnAttachStateChangeListener(detachListener)
-      } catch (Throwable t) {
+      } catch (t: Throwable) {
         log.warn("Failed to remove detach listener for popup window '{}'", javaClass.name, t)
       }
       detachListenerRegistered = false


### PR DESCRIPTION
修复 `editor/impl` 模块构建报错：

- `AbstractPopupWindow.kt` 79、111 行使用 Java 风格的 `catch (Throwable t)`，Kotlin 不支持，触发
  `An explicit type is required on a value parameter` / `Syntax error: Parameters must have type annotation` / `Unresolved reference t`，导致 `:editor:impl:compileDebugKotlin` 失败。
- 改为 Kotlin 正确写法 `catch (t: Throwable)`，逻辑不变。