### PR TITLE
fix: 适配 IProjectManager.projectDir / projectDirPath nullable - 收尾 7 处 core/app 模块编译错误

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -369,7 +369,7 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
   fun initializeProject(buildVariants: Map<String, String>) {
     val manager = ProjectManagerImpl.getInstance()
     val projectDir = manager.projectDir
-    if (!projectDir.exists()) {
+    if (projectDir == null || !projectDir.exists()) {
       log.error("GradleProject directory does not exist. Cannot initialize project")
       return
     }
@@ -414,7 +414,8 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
     this.initializingFuture =
         if (shouldInitialize || (!isFromSavedInstance && !initialized)) {
           log.debug("Sending init request to tooling server..")
-          buildService.initializeProject(createProjectInitParams(projectDir, buildVariants))
+          // 治本：projectDir 已通过前文判空为 non-null，smart-cast 让后续类型为 File。
+          projectDir?.let { buildService.initializeProject(createProjectInitParams(it, buildVariants)) }
         } else {
           log.debug("Using cached initialize result as the project is already initialized")
           CompletableFuture.supplyAsync {

--- a/core/app/src/main/java/com/itsaky/androidide/formatprovider/ktfmt/KtfmtCliFormatter.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/formatprovider/ktfmt/KtfmtCliFormatter.kt
@@ -38,9 +38,10 @@ class KtfmtCliFormatter(private val context: Context, private val file: File) : 
     if (!KtfmtEnv.isInstalled()) return source
 
     // 获取项目根目录 (用于 .editorconfig 读取)
+    // 治本：projectDir 改 nullable 后，未打开工程时回退到 file.parentFile（保留旧语义）
     val projectRoot =
         try {
-          IProjectManager.getInstance().projectDir
+          IProjectManager.getInstance().projectDir ?: file.parentFile
         } catch (e: Exception) {
           file.parentFile
         }
@@ -66,12 +67,15 @@ class KtfmtCliFormatter(private val context: Context, private val file: File) : 
       args.add("--stdin-name=${file.absolutePath}")
       args.add("-")
 
+      // 治本：projectRoot 在上面已经能 fallback 到 file.parentFile，但为了编译期
+      // 避免 smart cast 失效，构造一个本地 val 让下面的 ?.. 表达式更清晰
+      val root = projectRoot ?: file.parentFile
       val result = runBlocking {
         TermuxCommand.run(context) {
           label("Ktfmt CLI (Stdin)")
           executable(Environment.JAVA.absolutePath)
           args(*args.toTypedArray())
-          workingDir(projectRoot.absolutePath)
+          workingDir(root.absolutePath)
           stdin(source)
         }
       }
@@ -89,12 +93,13 @@ class KtfmtCliFormatter(private val context: Context, private val file: File) : 
 
       args.add(file.absolutePath)
 
+      val root = projectRoot ?: file.parentFile
       val result = runBlocking {
         TermuxCommand.run(context) {
           label("Ktfmt CLI (File)")
           executable(Environment.JAVA.absolutePath)
           args(*args.toTypedArray())
-          workingDir(projectRoot.absolutePath)
+          workingDir(root.absolutePath)
         }
       }
 

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitBranchPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitBranchPopupManager.kt
@@ -110,9 +110,9 @@ class GitBranchPopupManager(
 
   private fun loadBranches(): List<BranchModel> {
     val projectDir = IProjectManager.getInstance().getWorkspace()?.getProjectDir()?.path
-    val repoPath =
+    val repoPath: String? =
         projectDir?.takeIf { it.isNotBlank() }
-            ?: IProjectManager.getInstance().projectDirPath.takeIf { it.isNotBlank() }
+            ?: IProjectManager.getInstance().projectDirPath?.takeIf { it.isNotBlank() }
             ?: return emptyList()
 
     return runCatching {

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/git/menu/GitPopupManager.kt
@@ -243,9 +243,9 @@ class GitPopupManager(private val context: Context) {
 
   private fun initRepositoryIfNeeded() {
     val projectDir = IProjectManager.getInstance().getWorkspace()?.getProjectDir()?.path
-    val repoPath =
+    val repoPath: String? =
         projectDir?.takeIf { it.isNotBlank() }
-            ?: IProjectManager.getInstance().projectDirPath.takeIf { it.isNotBlank() }
+            ?: IProjectManager.getInstance().projectDirPath?.takeIf { it.isNotBlank() }
 
     if (repoPath.isNullOrBlank()) {
       Msg.requireShowLongDuration(context.getString(com.itsaky.androidide.resources.R.string.git_no_opened_project))

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -636,11 +636,17 @@ class GradleBuildService :
           val buildInfo = BuildInfo(tasksList)
           prepareBuild(buildInfo)
 
-          try {
-            // 治本：projectDir 改 nullable 后，工程未打开时早退（O(1) 检查）
-            val projectDir = ProjectManagerImpl.getInstance().projectDir ?: return@supplyAsync null
-            val gradlewPath = File(projectDir, "gradlew").absolutePath
+          // 治本：projectDir 改 nullable 后，工程未打开时直接以失败结果结束（避免 return null 让
+          // performBuildTasks 的类型推断为 TaskExecutionResult? 而与签名冲突）。
+          val projectDir =
+              ProjectManagerImpl.getInstance().projectDir
+                  ?: return@supplyAsync TaskExecutionResult(
+                      false,
+                      TaskExecutionResult.Failure.PROJECT_NOT_FOUND,
+                  )
+          val gradlewPath = File(projectDir, "gradlew").absolutePath
 
+          try {
             val command = mutableListOf("sh", gradlewPath)
             command.addAll(tasks)
 
@@ -710,8 +716,9 @@ class GradleBuildService :
                     // every line in memory at once and can OOM the build service on very long
                     // Gradle outputs (see crash: 141MB allocation in
                     // NonEditableEditorFragment.clearOutput).
-                    outputReader.use { stream ->
-                      val reader = stream.bufferedReader()
+                    // outputReader 已是 BufferedReader,直接用 readLine() 即可,
+                    // 不再二次 .bufferedReader()(原写法触发了 Unresolved reference 'bufferedReader')。
+                    outputReader.use { reader ->
                       while (true) {
                         val line = reader.readLine() ?: break
                         logOutput(line)
@@ -729,8 +736,7 @@ class GradleBuildService :
             val errorReaderJob =
                 buildServiceScope.launch(Dispatchers.IO) {
                   try {
-                    errorReader.use { stream ->
-                      val reader = stream.bufferedReader()
+                    errorReader.use { reader ->
                       while (true) {
                         val line = reader.readLine() ?: break
                         logOutput(line)


### PR DESCRIPTION
ProjectManagerImpl 内层治本修复进入 main 后,core/app 模块仍有 7 处调用点需要适配为新的 nullable 契约:

- ProjectHandlerActivity.kt: L372 `projectDir.exists()` 改 `projectDir == null || !projectDir.exists()`; L417 `createProjectInitParams` 改 `projectDir?.let { createProjectInitParams(it, ...) }`
- KtfmtCliFormatter.kt: `projectRoot` 加 `?: file.parentFile` 兜底,避免 smart cast 失效
- GitBranchPopupManager.kt / GitPopupManager.kt: `IProjectManager.projectDirPath` 改 nullable 后,`?:` 链前置 `takeIf`
- GradleBuildService.kt: 之前 `?: return@supplyAsync null` 推断为 `CompletableFuture<TaskExecutionResult?>` 与签名不符,改为显式 `TaskExecutionResult(false, Failure.PROJECT_NOT_FOUND)`; `outputReader.use { stream -> stream.bufferedReader() }` 把 BufferedReader 当 Closeable 调 use 后再 .bufferedReader()(BufferedReader 没有该方法),改为 `use { reader -> reader.readLine() }` 直接消费

性能: 全部为 O(1) 短路与 elvis,无回归; 未打开工程时减少一次 NPE 路径。