### PR TITLE
chore(git-manifest): 注释 PuppyGit MainActivity 的 LAUNCHER intent-filter

### DIFF
--- a/core/git/src/main/AndroidManifest.xml
+++ b/core/git/src/main/AndroidManifest.xml
@@ -107,10 +107,10 @@
 
         >
 
-            <intent-filter>
+            <!--<intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+            </intent-filter>-->
             <intent-filter android:label="@string/import_str">
                 <action android:name="android.intent.action.SEND"/>
                 <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
按要求注释 `core/git/src/main/AndroidManifest.xml` 中 `com.catpuppyapp.puppygit.activity.MainActivity` 下的 LAUNCHER intent-filter:

```
<!--<intent-filter>
    <action android:name="android.intent.action.MAIN" />
    <category android:name="android.intent.category.LAUNCHER" />
</intent-filter>-->
```

注释后 PuppyGit 不会作为独立入口出现在 Launcher,只能由其他 Activity(主 IDE 等)或 SEND / VIEW / EDIT intent-filter 触发。该模块仍正常参与编译,不影响主 app 启动。