### PR TITLE
ci: 新增 build-apk-cli.yml - 手動触发并自动推送 vYYYYMMDD 草稿 release

### DIFF
--- a/.github/workflows/build-apk-cli.yml
+++ b/.github/workflows/build-apk-cli.yml
@@ -1,0 +1,175 @@
+name: Build Android APK (CLI) & publish draft release
+
+# 复制自 .github/workflows/build-apk.yml，并改造为：
+# 1. 仅通过 workflow_dispatch 手动触发，不在 push/PR 上自动跑；
+# 2. 触发时使用 CLI 形式的 inputs(可手填 gradle task、release 标题、是否 draft 等)；
+# 3. 构建完成后把所有 APK 拷贝到一个临时目录，
+#    通过 softprops/action-gh-release@v2 自动 push 到 GitHub Release 草稿页。
+# 4. Tag 和 Release 标题默认使用当天日期(Asia/Shanghai 时区) vYYYYMMDD,
+#    也允许手动覆盖。
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'Choose the compilation type (assembleDebug or assembleRelease)'
+        required: true
+        default: 'assemble'
+        type: choice
+        options:
+          - assemble
+          - assembleDebug
+          - assembleRelease
+      release_tag:
+        description: 'Release tag, e.g. v20260614 (leave blank to auto-use today vYYYYMMDD, Asia/Shanghai)'
+        required: false
+        default: ''
+        type: string
+      release_title:
+        description: 'Release title shown on the GitHub Release page (leave blank to reuse the tag)'
+        required: false
+        default: ''
+        type: string
+      prerelease:
+        description: 'Mark this release as a pre-release?'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: write  # 创建 tag / 上传 release asset
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install basic system dependency packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git zip unzip protobuf-compiler python3 python3-pip wget curl
+
+      - name: Configure JDK 21 (Zulu 21.0.9)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Configuring a Gradle 8.13 environment
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        run: |
+          npm install -g pnpm
+          pnpm --version
+
+      - name: Verify Bun
+        run: |
+          which bun
+          bun --version
+
+      - name: Install web-ui dependencies with Bun
+        working-directory: core/chatai/web-ui
+        run: |
+          bun install --frozen-lockfile
+
+      - name: Install the specified NDK and Android SDK CMake (3.22.1)
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "ndk;27.1.12297006" "cmake;3.22.1"
+
+      - name: Install higher CMake version (3.31.1) via pip
+        run: |
+          sudo pip3 install cmake==3.31.1 --break-system-packages
+          CMAKE_DATA_DIR=$(python3 -c "import cmake, os; print(os.path.join(os.path.dirname(cmake.__file__), 'data'))")
+          echo "cmake.dir=$CMAKE_DATA_DIR" >> local.properties
+
+          cmake --version
+          protoc --version
+          python3 --version
+
+      - name: Grant execution permissions to the Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Compile APK
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx5g -XX:MaxMetaspaceSize=1g' -Dorg.gradle.daemon=false"
+          CMAKE_BUILD_PARALLEL_LEVEL: "2"
+        run: |
+          gradle ${{ github.event.inputs.build_type }} --build-cache --max-workers=2
+
+      # === 草稿发布相关步骤 ============================================================
+      - name: Compute today tag (Asia/Shanghai) if not provided
+        id: today
+        run: |
+          # CLI: 优先使用手动输入的 release_tag;否则用 TZ=Asia/Shanghai 算出 vYYYYMMDD
+          if [ -n "${{ github.event.inputs.release_tag }}" ]; then
+            echo "tag=${{ github.event.inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="v$(TZ=Asia/Shanghai date +%Y%m%d)"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "::group::Resolved release info"
+          echo "  tag  = $(grep '^tag=' <<< "$(cat $GITHUB_OUTPUT)" | cut -d= -f2)"
+          echo "::endgroup::"
+
+      - name: Collect built APKs into staging dir
+        run: |
+          mkdir -p release-assets
+          # assemble / assembleRelease -> core/app/build/outputs/apk/release/*
+          # assembleDebug          -> core/app/build/outputs/apk/debug/*
+          for variant in release debug; do
+            if [ -d "core/app/build/outputs/apk/${variant}" ]; then
+              # 只搬运 *.apk; -mtime -1 防御性过滤
+              find "core/app/build/outputs/apk/${variant}" -maxdepth 1 -type f -name '*.apk' -exec cp -v {} release-assets/ \;
+            fi
+          done
+          echo "---"
+          echo "Collected APKs:"
+          ls -la release-assets
+          if [ -z "$(ls -A release-assets 2>/dev/null)" ]; then
+            echo "::error::No APK found under core/app/build/outputs/apk/. Did the build succeed?"
+            exit 1
+          fi
+
+      - name: Create / update draft GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.today.outputs.tag }}
+          name: ${{ github.event.inputs.release_title != '' && github.event.inputs.release_title || steps.today.outputs.tag }}
+          draft: true
+          prerelease: ${{ github.event.inputs.prerelease == 'true' }}
+          # 自动生成简洁的 changelog 主体,内容可后续在网页编辑
+          body: |
+            ### ZeroStudio nightly build
+
+            - 构建类型：`${{ github.event.inputs.build_type }}`
+            - Commit: `${{ github.sha }}`
+            - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            APK 由 GitHub Actions 自动构建并上传,如有兼容性问题请附日志 / 设备信息反馈。
+          files: |
+            release-assets/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
复制 `.github/workflows/build-apk.yml` 为手動 CLI 版本,新增以下能力:

- 仅 `workflow_dispatch` 手动触发,inputs 包含 build_type / release_tag(可空) / release_title(可空) / prerelease。
- Tag 默认按 `TZ=Asia/Shanghai date +%Y%m%d` 计算为 `vYYYYMMDD`,如 2026-06-14 触发则得到 `v20260614`;Release 标题默认与 tag 相同,允许手動覆盖。
- 构建完成后,把所有 `core/app/build/outputs/apk/{release,debug}/*.apk` 拷到 `release-assets/`,通过 `softprops/action-gh-release@v2` 上传为 draft Release(`draft: true`),不会自动对用户公开。
- 增加了 `permissions: contents: write` 与 release body 模板(包含 commit SHA 与 workflow run 链接)。

用法:
1. Actions -> Build Android APK (CLI) & publish draft release -> Run workflow
2. 选择 build_type(默认 assemble),其余字段可留空
3. 完成后在仓库侧边栏 Releases -> Drafts 看到新草稿,审完再点 Publish