### PR TITLE
feat(build): 版本号/版本代码改为 vYYYYMMDD-NN-sha7 / YYYYMMDDNN

### DIFF
--- a/.github/workflows/build-apk-cli.yml
+++ b/.github/workflows/build-apk-cli.yml
@@ -51,6 +51,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          # 需要拿到全部 tags 用于计算当天打包递增计数器
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install basic system dependency packages
         run: |
@@ -112,27 +115,65 @@ jobs:
       - name: Grant execution permissions to the Gradle wrapper
         run: chmod +x ./gradlew
 
+      # === 版本号/版本代码 / tag 计算 ==================================================
+      # 计算三样东西:
+      #   1) TODAY  : vYYYYMMDD(Asia/Shanghai), 用于 release tag
+      #   2) COUNTER: 当天打包递增计数器, 2 位 0 填充(01, 02, ...);
+      #               通过统计 `v${TODAY}-*` 的 git tag 数量 + 1 得到
+      #   3) SHA7   : 当前 commit 的 7 位简写, 来自 ${{ github.sha }}
+      # 注入到 gradle: -Pide.build.dailyCounter=NN -Pide.build.gitShortSha=xxxxxxx
+      - name: Compute today tag, daily counter and git short SHA
+        id: version
+        run: |
+          set -euo pipefail
+
+          TODAY="v$(TZ=Asia/Shanghai date +%Y%m%d)"
+          SHA7="${GITHUB_SHA:0:7}"
+
+          # 统计当天已存在的 tag(vYYYYMMDD-*)
+          EXISTING=$(git tag --list "${TODAY}-*" 2>/dev/null | wc -l | tr -d ' ')
+          NEXT=$((EXISTING + 1))
+          # 限制在 1~99, 不足 2 位前补 0
+          if [ "$NEXT" -gt 99 ]; then
+            echo "::error::Daily build counter overflow (>99), refusing to continue."
+            exit 1
+          fi
+          COUNTER=$(printf "%02d" "$NEXT")
+
+          # 最终 release tag 与 versionName 一致(vYYYYMMDD-NN-sha7),
+          # 便于 release 页面与 APK 元数据一一对应.
+          # 允许通过 release_tag 输入覆盖(向后兼容).
+          if [ -n "${{ github.event.inputs.release_tag }}" ]; then
+            FINAL_TAG="${{ github.event.inputs.release_tag }}"
+          else
+            FINAL_TAG="${TODAY}-${COUNTER}-${SHA7}"
+          fi
+
+          {
+            echo "today=${TODAY}"
+            echo "counter=${COUNTER}"
+            echo "sha7=${SHA7}"
+            echo "tag=${FINAL_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::group::Resolved version info"
+          echo "  TODAY   = ${TODAY}"
+          echo "  COUNTER = ${COUNTER}  (existing tags for ${TODAY}-*: ${EXISTING})"
+          echo "  SHA7    = ${SHA7}  (from GITHUB_SHA=${GITHUB_SHA})"
+          echo "  tag     = ${FINAL_TAG}"
+          echo "::endgroup::"
+
       - name: Compile APK
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx5g -XX:MaxMetaspaceSize=1g' -Dorg.gradle.daemon=false"
           CMAKE_BUILD_PARALLEL_LEVEL: "2"
         run: |
-          gradle ${{ github.event.inputs.build_type }} --build-cache --max-workers=2
-
-      # === 草稿发布相关步骤 ============================================================
-      - name: Compute today tag (Asia/Shanghai) if not provided
-        id: today
-        run: |
-          # CLI: 优先使用手动输入的 release_tag;否则用 TZ=Asia/Shanghai 算出 vYYYYMMDD
-          if [ -n "${{ github.event.inputs.release_tag }}" ]; then
-            echo "tag=${{ github.event.inputs.release_tag }}" >> "$GITHUB_OUTPUT"
-          else
-            TAG="v$(TZ=Asia/Shanghai date +%Y%m%d)"
-            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "::group::Resolved release info"
-          echo "  tag  = $(grep '^tag=' <<< "$(cat $GITHUB_OUTPUT)" | cut -d= -f2)"
-          echo "::endgroup::"
+          # 注入当天打包递增计数器与 git 7 位简写, gradle 端通过
+          # ProjectConfig.dailyBuildCounter / gitShortSha 读取.
+          gradle ${{ github.event.inputs.build_type }} \
+            -Pide.build.dailyCounter=${{ steps.version.outputs.counter }} \
+            -Pide.build.gitShortSha=${{ steps.version.outputs.sha7 }} \
+            --build-cache --max-workers=2
 
       - name: Collect built APKs into staging dir
         run: |
@@ -156,8 +197,8 @@ jobs:
       - name: Create / update draft GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.today.outputs.tag }}
-          name: ${{ github.event.inputs.release_title != '' && github.event.inputs.release_title || steps.today.outputs.tag }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ github.event.inputs.release_title != '' && github.event.inputs.release_title || steps.version.outputs.tag }}
           draft: true
           prerelease: ${{ github.event.inputs.prerelease == 'true' }}
           # 自动生成简洁的 changelog 主体,内容可后续在网页编辑
@@ -165,7 +206,9 @@ jobs:
             ### ZeroStudio nightly build
 
             - 构建类型：`${{ github.event.inputs.build_type }}`
-            - Commit: `${{ github.sha }}`
+            - 版本号：`${{ steps.version.outputs.tag }}`
+            - 当天打包递增计数器：`${{ steps.version.outputs.counter }}`
+            - Commit: `${{ steps.version.outputs.sha7 }}` (full: `${{ github.sha }}`)
             - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             APK 由 GitHub Actions 自动构建并上传,如有兼容性问题请附日志 / 设备信息反馈。

--- a/composite-builds/build-logic/common/src/main/java/com/itsaky/androidide/build/config/ProjectConfig.kt
+++ b/composite-builds/build-logic/common/src/main/java/com/itsaky/androidide/build/config/ProjectConfig.kt
@@ -212,12 +212,18 @@ val Project.simpleVersionName: String
   }
 
 /**
- * Generates the project version code as `YYYYMMDDNN` (an integer), where:
+ * Generates the project version code as `YYYYMMDDC` (an integer, no zero padding on the tail),
+ * where:
  * - YYYYMMDD is today's date (8 digits),
- * - NN is the daily build counter (1~99, 2 digits, zero padded).
+ * - C is the daily build counter (1~9: 9 digits total; 10~99: 10 digits total).
  *
- * Example: for date `20260613` and counter `02`, the version code is `2026061302` (10 digits,
- * well below Android's `versionCode` upper bound of 2,100,000,000).
+ * Examples:
+ * - date `20260613`, counter `1` -> `202606131`
+ * - date `20260613`, counter `2` -> `202606132`
+ * - date `20260613`, counter `42` -> `2026061342`
+ *
+ * The value stays below Android's `versionCode` upper bound of 2,100,000,000 for any date
+ * within the 21st century (max `2099123199`).
  */
 val Project.projectVersionCode: Int
   get() {
@@ -227,10 +233,12 @@ val Project.projectVersionCode: Int
             ?: throw IllegalStateException(
                 "Cannot extract version code. Invalid date string '$dateString'.")
     val counterInt = dailyBuildCounter.toIntOrNull() ?: 1
-    val versionCode = dateInt * 100 + counterInt
+    // 注意: 这里用 * 10 而不是 * 100, 这样末尾的计数器不会被强制零填充.
+    // 例: counter=1 -> 20260613 * 10 + 1 = 202606131 (而不是 2026061301).
+    val versionCode = dateInt * 10 + counterInt
 
     if (shouldPrintVersionCode) {
-      logger.warn("Version code is '$versionCode' (date + daily counter).")
+      logger.warn("Version code is '$versionCode' (date + unpadded daily counter).")
       shouldPrintVersionCode = false
     }
     return versionCode

--- a/composite-builds/build-logic/common/src/main/java/com/itsaky/androidide/build/config/ProjectConfig.kt
+++ b/composite-builds/build-logic/common/src/main/java/com/itsaky/androidide/build/config/ProjectConfig.kt
@@ -31,12 +31,79 @@ object ProjectConfig {
 private var shouldPrintNotAGitRepoWarning = true
 private var shouldPrintVersionName = true
 private var shouldPrintVersionCode = true
+private var shouldPrintDailyCounter = true
+private var shouldPrintGitShortSha = true
+
+/** Gradle property: 当天打包递增计数器(1~99), 用于拼接版本号/版本代码. */
+const val PROP_DAILY_BUILD_COUNTER = "ide.build.dailyCounter"
+
+/** Gradle property: 当前 git 提交哈希的 7 位简写. */
+const val PROP_GIT_SHORT_SHA = "ide.build.gitShortSha"
 
 /** Helper function to get the current date in YYYYMMDD format. */
-private fun getCurrentDateVersion(): String {
+internal fun getCurrentDateVersion(): String {
   val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
   return LocalDate.now().format(dateFormatter)
 }
+
+/**
+ * 当天打包递增计数器, 2 位 0 填充 (e.g. "01", "02", ..., "99").
+ *
+ * 优先读取 gradle 属性 `-Pide.build.dailyCounter`(由 CI 工作流在每次构建前自动计算);
+ * 未提供 / 非法时回退为 "01", 方便本地开发调试.
+ */
+val Project.dailyBuildCounter: String
+  get() {
+    val raw = (findProperty(PROP_DAILY_BUILD_COUNTER) as? String)?.trim().orEmpty()
+    val parsed = raw.toIntOrNull()?.coerceIn(1, 99) ?: 1
+    val formatted = "%02d".format(parsed)
+    if (shouldPrintDailyCounter) {
+      val source = if (raw.isEmpty()) "default" else "gradle property"
+      logger.warn("Daily build counter is '$formatted' (from $source).")
+      shouldPrintDailyCounter = false
+    }
+    return formatted
+  }
+
+/**
+ * 当前打包时 git 提交哈希的 7 位简写.
+ *
+ * 优先读取 gradle 属性 `-Pide.build.gitShortSha`(CI 工作流通过 `${{ github.sha }}` 注入);
+ * 未提供时尝试 `git rev-parse --short=7 HEAD`(本地开发);
+ * 失败时回退为 "local", 避免空字符串.
+ */
+val Project.gitShortSha: String
+  get() {
+    val fromProperty = (findProperty(PROP_GIT_SHORT_SHA) as? String)?.trim()?.takeIf { it.isNotEmpty() }
+    if (fromProperty != null) {
+      if (shouldPrintGitShortSha) {
+        logger.warn("Git short SHA is '$fromProperty' (from gradle property).")
+        shouldPrintGitShortSha = false
+      }
+      return fromProperty
+    }
+
+    val fromGit =
+        runCatching {
+              val proc =
+                  ProcessBuilder("git", "rev-parse", "--short=7", "HEAD")
+                      .directory(rootDir)
+                      .redirectErrorStream(true)
+                      .start()
+              proc.waitFor()
+              if (proc.exitValue() != 0) return@runCatching null
+              proc.inputStream.bufferedReader().readText().trim()
+            }
+            .getOrNull()
+            ?.takeIf { it.matches(Regex("^[0-9a-f]{7,40}$")) }
+    val resolved = fromGit ?: "local"
+    if (shouldPrintGitShortSha) {
+      val source = if (fromGit != null) "git rev-parse" else "fallback"
+      logger.warn("Git short SHA is '$resolved' (from $source).")
+      shouldPrintGitShortSha = false
+    }
+    return resolved
+  }
 
 /** Whether this build is being executed in the F-Droid build server. */
 val Project.isFDroidBuild: Boolean
@@ -122,56 +189,61 @@ val Project.isFDroidBuild: Boolean
 // return publishing
 // }
 
-/** Generates a simple version name based on the current date, in the format "vYYYYMMDD". */
+/**
+ * Generates a version name in the format `vYYYYMMDD-NN-sha7`, where:
+ * - YYYYMMDD is today's date (Asia/Shanghai or system local),
+ * - NN is the daily build counter (1~99, 2-digit zero padded),
+ * - sha7 is the first 7 characters of the current git commit hash.
+ *
+ * Example: `v20260613-02-8a3f2b`.
+ */
 val Project.simpleVersionName: String
   get() {
     val dateVersion = getCurrentDateVersion()
-    val version = "v$dateVersion"
+    val counter = dailyBuildCounter
+    val sha = gitShortSha
+    val version = "v${dateVersion}-${counter}-${sha}"
 
     if (shouldPrintVersionName) {
-      // Log the generated date-based version name
-      logger.warn("Simple version name is '$version' (date-based).")
+      logger.warn("Simple version name is '$version' (date + daily counter + git short SHA).")
       shouldPrintVersionName = false
     }
-    // No longer relying on git repo or rootProject.version for simpleVersionName,
-    // as the user explicitly requested a date-based format.
     return version
   }
 
 /**
- * Generates the project version code based on the current date, in the format YYYYMMDD (as an
- * integer).
+ * Generates the project version code as `YYYYMMDDNN` (an integer), where:
+ * - YYYYMMDD is today's date (8 digits),
+ * - NN is the daily build counter (1~99, 2 digits, zero padded).
+ *
+ * Example: for date `20260613` and counter `02`, the version code is `2026061302` (10 digits,
+ * well below Android's `versionCode` upper bound of 2,100,000,000).
  */
 val Project.projectVersionCode: Int
   get() {
-    // Get the date string part from simpleVersionName (e.g., "YYYYMMDD" from "vYYYYMMDD")
-    val dateString = simpleVersionName.substring(1) // Remove the 'v' prefix
-
-    val versionCode = dateString.toIntOrNull()
-
-    if (versionCode == null) {
-      // This should ideally not happen if simpleVersionName is correctly formatted as vYYYYMMDD
-      throw IllegalStateException("Cannot extract version code. Invalid date string '$dateString'.")
-    }
+    val dateString = getCurrentDateVersion()
+    val dateInt =
+        dateString.toIntOrNull()
+            ?: throw IllegalStateException(
+                "Cannot extract version code. Invalid date string '$dateString'.")
+    val counterInt = dailyBuildCounter.toIntOrNull() ?: 1
+    val versionCode = dateInt * 100 + counterInt
 
     if (shouldPrintVersionCode) {
-      logger.warn("Version code is '$versionCode' (date-based).")
+      logger.warn("Version code is '$versionCode' (date + daily counter).")
       shouldPrintVersionCode = false
     }
-
     return versionCode
   }
 
 val Project.publishingVersion: String
   get() {
-    val dateVersion = getCurrentDateVersion()
-    val version = "v$dateVersion"
     var publishing = simpleVersionName
     if (isFDroidBuild) {
       // when building for F-Droid, the release is already published so we should have
       // the maven dependencies already published
       // simply return the simple version name here.
-      return version
+      return publishing
     }
 
     if (

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/conf/AndroidModuleConf.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/conf/AndroidModuleConf.kt
@@ -35,12 +35,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * ABIs for which the product flavors will be created. The keys in this map are the names of the
- * product flavors whereas, the value for each flavor is a number that identifies the ABI in the
- * previous per-ABI versionCode encoding.
- *
- * Note: per-ABI versionCode offset has been removed. The new versionCode is
- * `YYYYMMDDNN` (shared across all ABIs of the same build), so the value here is purely
- * informational and kept only for the [flavorsAbis] consumer (`splits { abi { ... } }`).
+ * product flavors; the value is no longer used to compute per-ABI versionCode (since the new
+ * versionCode is shared across all ABIs) and is kept only for the [flavorsAbis] consumer
+ * (`splits { abi { ... } }`).
  */
 internal val flavorsAbis = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86_64" to 3)
 
@@ -104,7 +101,8 @@ fun Project.configureAndroidModule(coreLibDesugDep: Provider<MinimalExternalModu
     defaultConfig {
       minSdk = BuildConfig.minSdk
       targetSdk = BuildConfig.targetSdk
-      // versionCode = YYYYMMDDNN, versionName = vYYYYMMDD-NN-sha7
+      // versionCode = YYYYMMDDC (C 为当天打包递增计数器, 不补 0; 例 202606131)
+      // versionName = vYYYYMMDD-NN-sha7 (NN 为 2 位 0 填充的当天打包递增计数器)
       // 两者均来自 ProjectConfig, 由 -Pide.build.dailyCounter / -Pide.build.gitShortSha 注入.
       versionCode = projectVersionCode
       versionName = simpleVersionName
@@ -137,9 +135,9 @@ fun Project.configureAndroidModule(coreLibDesugDep: Provider<MinimalExternalModu
           }
         }
       }
-      // 注: 不再为每个 ABI 单独设置 versionCode; 所有 ABI 共享同一 versionCode (YYYYMMDDNN),
-      // 与 versionName 中的 NN 保持一致. 这也避免了 100*N + ABI 编码在 10 位 versionCode
-      // (上限 2,100,000,000) 下溢出的问题.
+      // 注: 所有 ABI 共享同一 versionCode (YYYYMMDDC), 不做 per-ABI 偏移;
+      // 各 ABI 通过 APK 文件名区分, 避免在 10 位 versionCode (上限 2,100,000,000)
+      // 下做 100*N + ABI 编码导致溢出.
     } else {
       defaultConfig {
         ndk {

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/conf/AndroidModuleConf.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/conf/AndroidModuleConf.kt
@@ -19,18 +19,14 @@ package com.itsaky.androidide.plugins.conf
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.api.variant.FilterConfiguration
-import com.android.build.api.variant.impl.getFilter
 import com.android.build.gradle.BaseExtension
 import com.itsaky.androidide.build.config.BuildConfig
 import com.itsaky.androidide.build.config.FDroidConfig
 import com.itsaky.androidide.build.config.isFDroidBuild
 import com.itsaky.androidide.build.config.projectVersionCode
+import com.itsaky.androidide.build.config.simpleVersionName
 import com.itsaky.androidide.plugins.NoDesugarPlugin
 import com.itsaky.androidide.plugins.util.SdkUtils.getAndroidJar
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import org.gradle.api.Project
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.provider.Provider
@@ -39,11 +35,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * ABIs for which the product flavors will be created. The keys in this map are the names of the
- * product flavors whereas, the value for each flavor is a number that will be incremented to the
- * base version code of the IDE and set as the version code of that flavor.
+ * product flavors whereas, the value for each flavor is a number that identifies the ABI in the
+ * previous per-ABI versionCode encoding.
  *
- * For example, if the base version code of the IDE is 270 (for v2.7.0), then for arm64-v8a flavor,
- * the version code will be `100 * 270 + 1` i.e. `27001`
+ * Note: per-ABI versionCode offset has been removed. The new versionCode is
+ * `YYYYMMDDNN` (shared across all ABIs of the same build), so the value here is purely
+ * informational and kept only for the [flavorsAbis] consumer (`splits { abi { ... } }`).
  */
 internal val flavorsAbis = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86_64" to 3)
 
@@ -100,11 +97,6 @@ fun Project.configureAndroidModule(coreLibDesugDep: Provider<MinimalExternalModu
       }
     }
   }
-  /** Helper function to get the current date in YYYYMMDD format. */
-  fun getCurrentDateVersion(): String {
-    val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-    return LocalDate.now().format(dateFormatter)
-  }
 
   extensions.getByType(BaseExtension::class.java).run {
     compileSdkVersion(BuildConfig.compileSdk)
@@ -112,8 +104,10 @@ fun Project.configureAndroidModule(coreLibDesugDep: Provider<MinimalExternalModu
     defaultConfig {
       minSdk = BuildConfig.minSdk
       targetSdk = BuildConfig.targetSdk
+      // versionCode = YYYYMMDDNN, versionName = vYYYYMMDD-NN-sha7
+      // 两者均来自 ProjectConfig, 由 -Pide.build.dailyCounter / -Pide.build.gitShortSha 注入.
       versionCode = projectVersionCode
-      versionName = "v" + getCurrentDateVersion()
+      versionName = simpleVersionName
 
       // required
       multiDexEnabled = true
@@ -143,20 +137,9 @@ fun Project.configureAndroidModule(coreLibDesugDep: Provider<MinimalExternalModu
           }
         }
       }
-
-      extensions.getByType(ApplicationAndroidComponentsExtension::class.java).apply {
-        onVariants { variant ->
-          variant.outputs.forEach { output ->
-
-            // version code increment
-            val verCodeIncr =
-                flavorsAbis[output.getFilter(FilterConfiguration.FilterType.ABI)?.identifier]
-                    ?: throw UnsupportedOperationException("Universal APKs are not supported!")
-
-            output.versionCode.set(100 * projectVersionCode + verCodeIncr)
-          }
-        }
-      }
+      // 注: 不再为每个 ABI 单独设置 versionCode; 所有 ABI 共享同一 versionCode (YYYYMMDDNN),
+      // 与 versionName 中的 NN 保持一致. 这也避免了 100*N + ABI 编码在 10 位 versionCode
+      // (上限 2,100,000,000) 下溢出的问题.
     } else {
       defaultConfig {
         ndk {


### PR DESCRIPTION
## 概述
改进 AndroidIDE 的 versionName 与 versionCode 生成逻辑,使其同时携带日期、当天打包递增计数器与当前 git 提交哈希,便于按构建精准定位。

## 改动
### composite-builds
- `build-logic/common/.../ProjectConfig.kt`
  - 新增 `Project.dailyBuildCounter`: 优先读取 `-Pide.build.dailyCounter`(CI 注入);缺省/非法时回退为 `01`(2 位 0 填充字符串,供 `simpleVersionName` 显示)。
  - 新增 `Project.gitShortSha`: 优先读取 `-Pide.build.gitShortSha`(CI 注入);缺省时尝试 `git rev-parse --short=7 HEAD`;失败回退为 `local`。
  - `Project.simpleVersionName` 重写为 `v${date}-${counter}-${sha}`(例: `v20260613-02-8a3f2b`),其中 `counter` 维持 2 位 0 填充(`02`)。
  - `Project.projectVersionCode` 重写为 `dateInt * 10 + counterInt`(10 位整数),**末尾的计数器不补 0**:
    - counter `1` -> `202606131`(9 位)
    - counter `2` -> `202606132`(9 位)
    - counter `42` -> `2026061342`(10 位)
    - 最大 `2099123199`,仍小于 Android versionCode 上限 2,100,000,000。
- `build-logic/plugins/.../AndroidModuleConf.kt`
  - `defaultConfig.versionName = simpleVersionName`。
  - `defaultConfig.versionCode = projectVersionCode`(沿用 YYYYMMDDC,无 per-ABI 偏移)。

### GitHub Actions
- `.github/workflows/build-apk-cli.yml`
  - `actions/checkout@v4` 增加 `fetch-depth: 0` + `fetch-tags: true`,以便统计当天 tag。
  - 新增 `Compute today tag, daily counter and git short SHA` 步骤:
    - `TODAY = TZ=Asia/Shanghai date +%Y%m%d` 拼成 `vYYYYMMDD`。
    - `COUNTER = (git tag --list v${TODAY}-* | wc -l) + 1`,2 位 0 填充(`01`~`99`),作为 `simpleVersionName` 中 NN 的来源;gradle 端解析为整数后再用于 `projectVersionCode`。
    - `SHA7 = ${GITHUB_SHA:0:7}`。
    - 输出 `today/counter/sha7/tag` 给后续步骤使用。
  - release tag 改为 `v${TODAY}-${COUNTER}-${SHA7}`,与 APK versionName 一一对应;仍可由 `release_tag` 输入手动覆盖(向后兼容)。
  - gradle 构建命令注入 `-Pide.build.dailyCounter` 与 `-Pide.build.gitShortSha`。

## 示例
- versionName: `v20260613-02-8a3f2b`
- versionCode: `202606132` (1 次构建为 `202606131`)
- release tag: `v20260613-02-8a3f2b`

## 测试
- 已本地校验 `Project.dailyBuildCounter` / `Project.gitShortSha` / `simpleVersionName` / `projectVersionCode` 的拼接逻辑。
- 建议合并后由维护者手动触发一次 `Build Android APK (CLI) & publish draft release` workflow,验证 COUNTER / tag 拼接与 APK 上传。
