### PR TITLE
docs(compose-preview): v2.1 详细设计与 TODO 重写

### DIFF
--- a/modules/compose-preview/DESIGN.md
+++ b/modules/compose-preview/DESIGN.md
@@ -1,65 +1,107 @@
-# Compose Preview 重构与升级方案
+# Compose Preview v2.1 重构与升级方案
 
 > 模块：`modules/compose-preview/`
-> 状态：v2 重构规划（PR 拆分中）
-> 目标：**100% 资产化自包含、零 Maven 依赖、K2JVMCompiler 进程内调用、对标 IDEA / Android Studio Compose 预览插件**
+> 版本：v2.1（基于 v2 的设计补全：真实设备模拟、字节码加速、可视化编辑）
+> 状态：详细设计 + 待办事项（PR #N 中执行 P0；后续 PR #N+1 ~ #N+5 分批落地）
+> 目标：**100% 资产自包含 · 零 Maven · 进程内 K2JVMCompiler · 真实设备模拟（涵盖刘海 / 针孔 / 瀑布 / 折叠） · ASM 字节码加速 · 对标 IDEA / AS Compose Preview**
+
+---
+
+## 目录
+
+1. [背景与现状问题](#1-背景与现状问题)
+2. [目标与非目标](#2-目标与非目标)
+3. [v2 现状评估（已落地但需补全的部分）](#3-v2-现状评估已落地但需补全的部分)
+4. [v2.1 关键增量](#4-v21-关键增量)
+5. [新架构（v2.1 全景）](#5-新架构v21-全景)
+6. [真实设备模拟子系统](#6-真实设备模拟子系统)
+7. [系统状态栏子系统](#7-系统状态栏子系统)
+8. [字节码加速子系统（ASM）](#8-字节码加速子系统asm)
+9. [Build Phase](#9-build-phase)
+10. [Runtime 优化](#10-runtime-优化)
+11. [可视化编辑工具箱](#11-可视化编辑工具箱)
+12. [调试与可观测性](#12-调试与可观测性)
+13. [新功能矩阵](#13-新功能矩阵)
+14. [详细文件改动表](#14-详细文件改动表)
+15. [风险与缓解](#15-风险与缓解)
+16. [与 IDEA / AS 对标](#16-与-idea--as-对标)
+17. [测试 / 验收](#17-测试--验收)
+18. [PR 拆分计划](#18-pr-拆分计划)
+19. [引用](#19-引用)
 
 ---
 
 ## 1. 背景与现状问题
 
-### 1.1 模块当前结构
+### 1.1 模块当前结构（v2 落地后）
 
 ```
 modules/compose-preview/
-├── build.gradle.kts                  // 依赖 + 把 compose runtime 打进 assets
-├── src/main/AndroidManifest.xml
-├── src/main/assets/compose/          // compose-jars.zip + compose-runtime.dex
-├── src/main/java/.../compose/preview/
-│   ├── ComposePreviewViewModel.kt    // StateFlow 状态机
-│   ├── ComposePreviewFragment.kt     // UI 容器
-│   ├── ComposePreviewActivity.kt
-│   ├── PreviewConfig.kt              // data class
-│   ├── PreviewState.kt               // sealed class（与 VM 同一文件）
-│   ├── compiler/
-│   │   ├── ComposeCompiler.kt        // 调用 K2JVMCompiler
-│   │   ├── ComposeDexCompiler.kt     // 调用 d8.jar（来自 SDK build-tools）
-│   │   ├── CompilerDaemon.kt         // 试图维护 Kotlin 编译守护进程（不稳定）
-│   │   ├── ComposeClasspathManager.kt// 试图从 .m2 / IDE 路径获取 jar
-│   │   └── DexCache.kt               // 源码 hash -> .dex 缓存
-│   ├── data/
-│   │   ├── source/ProjectContextSource.kt   // 解析项目 module / classpath
-│   │   └── repository/ComposePreviewRepository*.kt
-│   ├── domain/
-│   │   ├── PreviewSourceParser.kt    // 正则解析 @Preview / @Composable
-│   │   └── model/ParsedPreviewSource.kt
-│   ├── runtime/
-│   │   ├── ComposeClassLoader.kt     // DexClassLoader 缓存
-│   │   └── ComposableRenderer.kt     // Method.invoke 反射调用
-│   └── ui/BoundedComposeView.kt
+├── build.gradle.kts                         // 自包含打包: kotlin-compiler-embeddable + r8 + compose runtime
+├── DESIGN.md                                // 本文件
+├── TODO.md                                  // 任务清单
+└── src/main/
+    ├── AndroidManifest.xml
+    ├── assets/compose/                      // 由 build 时打包 (compose-jars.zip, compose-runtime.dex)
+    ├── res/                                 // 布局 / 菜单 / 资源
+    └── java/com/itsaky/androidide/compose/preview/
+        ├── ComposePreviewActivity.kt        // 入口 Activity (XML-based 旧 UI)
+        ├── ComposePreviewFragment.kt        // Fragment 版入口 (ComposeView based)
+        ├── ComposePreviewViewModel.kt       // 状态机 (StateFlow)
+        ├── PreviewConfig.kt + PreviewState.kt
+        ├── compiler/
+        │   ├── AssetsComposeBundles.kt      // 资产自包含 SDK (解压 + 校验)
+        │   ├── BundledComposeCompiler.kt    // 进程内 K2JVMCompiler
+        │   ├── BundledD8Dexer.kt            // 进程内 D8
+        │   ├── CompileModels.kt             // CompileResult / DexResult / Diagnostic
+        │   └── DexCache.kt                  // 源 hash -> dex 缓存
+        ├── data/
+        │   ├── source/ProjectContextSource.kt
+        │   └── repository/ComposePreviewRepository(Impl).kt
+        ├── domain/
+        │   ├── PreviewSourceParser.kt       // 正则解析 @Preview
+        │   └── model/ParsedPreviewSource.kt
+        ├── runtime/
+        │   ├── ComposeClassLoader.kt        // DexClassLoader 池化
+        │   ├── ComposableRenderer.kt        // 反射 + MethodHandle 渲染
+        │   └── MethodHandleResolver.kt      // 反射 -> MethodHandle 缓存
+        └── ui/
+            ├── BoundedComposeView.kt        // ComposeView 容器
+            ├── ComponentInspector.kt        // 组件检查器 (UI 骨架)
+            ├── DeviceFrame.kt               // 设备外壳 (圆角 / 刘海 / 状态栏)
+            ├── DeviceProfile.kt             // 设备配置 + 内置 Pixel/Tablet/Watch
+            ├── DeviceProfileSheet.kt        // 设备选择 Sheet
+            ├── RecompositionCounter.kt      // recompose 计数
+            ├── ResolutionEditor.kt          // 自定义分辨率
+            ├── ThemeSelector.kt             // Light / Dark / Custom
+            └── ZoomController.kt            // 缩放 + pan
 ```
 
-### 1.2 已观测到的故障模式
+### 1.2 已观测到的故障模式（v2 已经修了大部分，但需补全）
 
-| 现象 | 根因 |
-| --- | --- |
-| 编译无限循环、无法取消 | `CompilerDaemon` 维护一个常驻进程，IPC 协议（`kotlin-daemon-embeddable`）版本与项目内 K2 不一致，wait/poll 死锁 |
-| 无法初始化 / 同步 | `ComposeClasspathManager` 引用 `Environment.KOTLIN_COMPILER_CLASSPATH_JAR_RELATIVE_PATH` 等 IDE 私有路径，沙箱 / 设备上不存在 |
-| 编译失败但无清晰错误 | `ComposeCompiler.compile()` 走的是 IDE 内部 K2，但 `K2JVMCompilerArguments.pluginClasspaths` 路径在 IDE 上下文之外为空 |
-| D8 阶段崩 | `ComposeDexCompiler` 调用 `Build-tools/d8.jar`，要求 SDK 已就绪；沙箱构建机常有 `d8` 缺失或版本不匹配 |
-| `.m2` 强依赖 | 早期版本通过 `~/.m2/repository/.../kotlin-compiler-embeddable-*.jar` 直接拉 jar，跨用户 / 跨设备不可移植 |
-| 守护进程与编译挂在本项目不存在的 SDK / jar 上 | `KotlinCompilerDaemonConfig` 中的 `classpathRoots` 引用 IDE 私有目录 |
+| 现象 | v2 处理 | v2.1 还要做 |
+| --- | --- | --- |
+| 编译无限循环 / 守护进程死锁 | 已删除 `CompilerDaemon`，K2 进程内调用 | — |
+| `ComposeClasspathManager` 引用 IDE 私有路径 | 删除，由 `AssetsComposeBundles` 替代 | — |
+| D8 强依赖 SDK build-tools | 改用 R8 fat jar 自带 D8 入口 | — |
+| `.m2` 强依赖 | 全部资产化 | — |
+| 反射渲染慢 | `MethodHandle` 替代 `Method.invoke` | **P2：ASM 字节码改写，跳过反射** |
+| 设备模拟太简化（只有圆角 + 简单刘海） | — | **v2.1 P0：真实设备 + 针孔 / 瀑布 / 折叠** |
+| 状态栏是单条黑色 Canvas | — | **v2.1 P0：可换主题的 SystemBar（电池 / 信号 / 时钟 / 通知）** |
+| 无可视化编辑工具箱 | — | **v2.1 P0：拖动 / Resize / 颜色拾取 / 实时 padding / gap** |
+| 缩放 / Pan / 适配 未接入 Activity | — | **v2.1 P0：完整接入 ComposePreviewActivity** |
+| 预览解析只识别 `@Preview` height/width | — | **v2.1 P1：支持 `@PreviewParameter` / `@PreviewFontScale` / `@PreviewLightDark`** |
+| 反射 / MethodHandle 仍有少量 boxing | — | **v2.1 P2：ASM 生成 binder，零反射** |
+| 性能埋点 | 仅有 `LOG.info` | **v2.1 P3：结构化阶段耗时 + Trace** |
+| `ComposePreviewActivity` 与 `ComposePreviewFragment` 两套入口 | 同时存在 | **v2.1 P1：统一为 Activity + 内嵌 Compose UI 层** |
 
-### 1.3 反射 / 渲染层现状
+### 1.3 核心结论
 
-- `ComposeClassLoader`：用 `DexClassLoader` 加载 `.dex`，有缓存（path + lastModified），逻辑基本可用。
-- `ComposableRenderer`：直接 `Method.invoke`，无预热、每次都做 `declaredMethods` 全扫。
-- 渲染层对 `compose-runtime.dex`（已在 assets 中）依赖 OK，**只要构建产物能产出 dex 即可工作**。
-
-### 1.4 核心结论
-
-> **构建阶段必须彻底重写为「资产自包含 + 进程内 K2JVMCompiler + 进程内 D8」，运行时仅做轻量优化与功能增强。**
-> Maven、本地仓库、IDE 私有路径、守护进程 **一律移除**。
+> **v2 已经把构建链从「不可用」变成「可用」，但 v2.1 要把它从「可用」变成「对标 AS 的生产力工具」**：
+>
+> 1. 设备模拟必须真实到能看出 Pixel 7 Pro / 华为 Mate 60 Pro / Galaxy Z Fold 5 的区别
+> 2. 字节码层要 ASM 加速，避免反射热路径
+> 3. 可视化编辑必须支持拖动、resize、color picker 等「所见即所得」能力
 
 ---
 
@@ -67,113 +109,489 @@ modules/compose-preview/
 
 ### 2.1 目标
 
-1. **构建阶段零外部依赖**：所有编译器、Compose 插件、D8 都从 `assets/compose/sdk/` 解压。
+#### 2.1.1 构建
+
+1. **构建阶段零外部依赖**：Kotlin 编译器、Compose 插件、D8 全部来自 `assets/compose/compose-jars.zip`。
 2. **首次构建 < 8s、增量构建 < 2s**：源码 hash 命中缓存时立即返回。
-3. **预览功能对标 IDEA / AS**：
-   - 设备模拟（Pixel 4/5/6/7、Tablet、折叠屏）
-   - 分辨率模拟（自定义 width × height、DPI）
-   - 缩放（pinch、双指、Ctrl+Wheel、Fit）
-   - 可视化编辑工具箱（拖动、resize、颜色拾取、padding/gap 实时编辑）
-   - 调试工具（recomposition 计数、布局框、属性面板、日志面板）
-   - 主题切换（Light/Dark/Custom）
-   - 多 Preview 网格展示（AS 风格）
-4. **运行时效率**：
-   - 反射 → `MethodHandle`，减少 boxing
-   - `DexClassLoader` 复用，DEX 文件 mmap 友好
-   - Compose 渲染首帧 < 500ms
+3. **无守护进程**：每次编译独立起 `URLClassLoader`，编译完即销毁。
+4. **可取消**：`compiler.cancel()` 在 K2 分析阶段前响应。
+
+#### 2.1.2 真实设备模拟（v2.1 重点）
+
+1. **支持以下形态（每种至少 2 个 Profile）**：
+   - **传统 16:9 / 19.5:9 / 20:9 / 21:9 全面屏手机**（Pixel 4/5/6/7/8、华为 P40 / Mate 60 Pro、小米 14 Pro）
+   - **刘海屏**（iPhone 13/14/15 风格，刘海深度 30dp / 35dp / 47dp）
+   - **针孔屏 / 挖孔屏**（居中 / 左上角 / 右上角，孔径 4dp~6dp）
+   - **瀑布屏**（华为 Mate 30 Pro / 荣耀 Magic，88° 曲边 + 侧边显示区域）
+   - **折叠屏**（Galaxy Z Fold 5 内屏 + 外屏；Pixel Fold；OPPO Find N 外屏 / 内屏）
+   - **平板**（Pixel Tablet 11"、iPad Pro 12.9"）
+   - **桌面 / 自由窗口**（Android 14 桌面模式）
+   - **Wear OS**（小 / 大 圆表 / 方形表）
+2. **设备外壳 (Hardware Chassis)**：
+   - 上 / 下 / 左 / 右 边框宽度（按真实手机测量）
+   - 圆角（按设备）
+   - 物理按键位置（电源 / 音量 ±，按设备）
+   - 摄像头凸起（部分机型）
+   - 颜色（钛黑 / 雪白 / 银 / 暗紫等）
+3. **系统状态栏模拟**：
+   - 时间（跟随系统时区）
+   - 信号 / Wi-Fi / 电池 图标
+   - 通知小红点
+   - 浅色 / 深色 / 透明 三种模式
+   - 状态栏高度（按设备不同：24dp~50dp）
+
+#### 2.1.3 可视化编辑工具箱
+
+1. 拖动 Composable
+2. Resize Composable（角 / 边控制点）
+3. 实时 padding / gap 修改
+4. 颜色拾取（截图采样像素）
+5. Layout Bounds 显示
+6. 缩放 / Fit / 100% / 双击切换
+
+#### 2.1.4 调试
+
+1. Recomposition 计数 + 高亮
+2. Component Inspector（边界框 + 属性面板）
+3. Logcat 面板（拦截 `println` / `Log.d`）
+4. 性能埋点（编译 / 编译耗时统计）
+
+#### 2.1.5 字节码加速（v2.1 P2）
+
+1. **ASM 字节码改写**：在 dex 落地之前，对 K2 产物做轻量级变换
+2. **生成静态 binder**：把 `@Composable fun Foo(...)` 包成 `staticInvoke$Foo(c, c0, 0)`，反射直接命中
+3. **dead code strip**：去掉 `@Preview` 之外的非引用代码
+4. **常量折叠**：UI 默认值可在编译期折叠
+5. **DexLayoutOptimizer**：调整 dex method order 提升 ICache 命中
 
 ### 2.2 非目标
 
-- 不实现完整 IDEA Live Edit / Hot Reload（区别于「预览」场景）
-- 不集成 ProGuard / R8 优化
-- 不支持 multi-module 项目的跨模块实时 preview（仍走 `gradle-dex` 备选路径，但只走最少必要路径）
+- 不实现完整 IDEA Live Edit / Hot Reload
+- 不集成 ProGuard / R8 优化（v2.1 之后再说）
+- 不支持 multi-module 项目的跨模块实时 preview（保留 `useGradleDex` 兜底）
 
 ---
 
-## 3. 新架构
+## 3. v2 现状评估（已落地但需补全的部分）
 
-### 3.1 分层
+### 3.1 已经工作的（v2 落地清单）
+
+| 模块 | 现状 | 评价 |
+| --- | --- | --- |
+| `AssetsComposeBundles` | assets 自包含解压 + SHA-256 校验 | ✅ 可用 |
+| `BundledComposeCompiler` | 进程内 K2JVMCompiler 反射调用 | ✅ 可用，但反射路径有性能损耗 |
+| `BundledD8Dexer` | fork 子进程跑 R8 内置 D8 | ✅ 可用 |
+| `DexCache` | 源 hash -> dex + SDK version 校验 | ✅ 可用 |
+| `ComposeClassLoader` | DexClassLoader 池化 | ✅ 可用 |
+| `MethodHandleResolver` | 反射 -> MethodHandle 缓存 | ✅ 可用，但首次反射查找仍 cold |
+| `DeviceProfile` + `DeviceFrame` | 圆角 / 简单刘海 / 简单状态栏 | ⚠️ 太简陋，不算「真实设备」 |
+| `ZoomController` | pinch / pan | ⚠️ 已实现但未接入 Activity |
+| `DeviceProfileSheet` / `ResolutionEditor` / `ThemeSelector` | 底部弹窗 / Dialog / Chip | ⚠️ UI 在但未在 Activity 调用 |
+| `ComposePreviewActivity` | XML + 旧 View 体系 | ⚠️ UI 集成不完整：没有设备框、没有工具栏 chip、没有调试面板 |
+| `ComposePreviewFragment` | ComposeView 容器 | ⚠️ 存在但与 Activity 重叠 |
+| `RecompositionCounter` | remember + counter | ⚠️ 单文件，未挂到 RenderComposable |
+| `ComponentInspector` | 选中状态 + 占位 UI | ⚠️ 没有真的反射读 `LayoutNode` |
+
+### 3.2 v2.1 要补的核心空白
+
+1. **`ComposePreviewActivity` 的 UI 升级**：从 XML View 切到 Compose 层；顶栏放设备 / 主题 / 缩放 / 调试 chip；中间用 `DeviceFrame` 套住 `ComposeView`；底部放 Inspector / Logcat 抽屉
+2. **真实设备数据**：把 `DeviceProfile` 扩到含 bezels、cutout 几何、physical key 位置、机身色
+3. **系统状态栏 Composable**：用 `Canvas` 画图标 + 时间，支持 light/dark/translucent
+4. **Cutout 几何系统**：用 `CutoutGeometry` sealed class 描述：刘海 / 针孔 / 瀑布 / 圆角盲区
+5. **Foldable 铰链模拟**：中间画一条 4dp 阴影 + 60dp 的「折叠状态」状态条
+6. **ASM 工具栈**：在 dex 阶段前加一道 pass，输出 `*_optimized.dex`
+7. **统一 Bind 入口**：让 `ComposableRenderer` 不再 `MethodHandle.invokeWithArguments(...)`，而是从生成代码里直接调
+8. **可观测性**：每次 compile/render 写一行结构化日志（含阶段耗时）
+
+---
+
+## 4. v2.1 关键增量
+
+### 4.1 新增 / 重写文件
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│  UI 层（ComposePreviewFragment / Activity）                       │
-│    └── BoundedComposeView（支持 zoom / pan / device frame）        │
-├──────────────────────────────────────────────────────────────────┤
-│  ViewModel 层（ComposePreviewViewModel）                          │
-│    ├── StateFlow<PreviewState> 状态机                             │
-│    ├── DisplayMode: ALL / SINGLE                                  │
-│    ├── DeviceProfile: 设备 / 分辨率 / DPI                         │
-│    └── ZoomController / RecompositionCounter / ComponentInspector│
-├──────────────────────────────────────────────────────────────────┤
-│  Repository 层（ComposePreviewRepository）                        │
-│    ├── compile(source) -> CompilationResult                       │
-│    └── buildContext(filePath) -> ProjectContext                   │
-├──────────────────────────────────────────────────────────────────┤
-│  Build Phase（核心重写）                                          │
-│    ├── AssetsComposeBundles       从 assets 解压 / 校验            │
-│    ├── BundledComposeCompiler     进程内 K2JVMCompiler 调用        │
-│    ├── BundledD8Dexer             进程内 D8 调用                   │
-│    ├── ComposePreviewCache        sourceHash + version -> dex     │
-│    └── Fallback: GradleDexRunner  极端 fallback（不修，留口）      │
-├──────────────────────────────────────────────────────────────────┤
-│  Runtime 层（轻量优化）                                            │
-│    ├── ComposeClassLoader         DexClassLoader 池化              │
-│    ├── MethodHandleRenderer       反射 -> MethodHandle            │
-│    └── PrewarmService             预热常用 class                  │
-└──────────────────────────────────────────────────────────────────┘
+ui/
+├── DeviceFrame.kt             # 重写: 真实设备 + cutout 几何
+├── DeviceProfile.kt           # 重写: 含 bezel / cutout / 机身色 / 物理键
+├── DeviceProfileSheet.kt      # 重写: 分组 (Phone / Foldable / Tablet / Watch)
+├── SystemBarsOverlay.kt       # 新增: 状态栏 + 导航栏
+├── CutoutOverlay.kt           # 新增: 刘海 / 针孔 / 瀑布曲线
+├── FoldableHingeOverlay.kt    # 新增: 折叠屏铰链
+├── ResolutionEditor.kt        # 保留
+├── ThemeSelector.kt           # 保留
+├── ZoomController.kt          # 保留
+├── RecompositionCounter.kt    # 增强: 真实挂到 RenderComposable
+├── ComponentInspector.kt      # 重写: 反射读 LayoutNode
+├── PreviewToolbar.kt          # 新增: 顶栏 Compose 工具栏
+├── DebugDrawer.kt             # 新增: 底部抽屉
+├── ColorPickerOverlay.kt      # 新增: 颜色拾取
+├── LayoutBoundsOverlay.kt     # 新增: 布局边界
+├── LogcatPanel.kt             # 新增: 日志面板
+├── PreviewGridLayout.kt       # 新增: 多 Preview 网格
+├── ModifierInspector.kt       # 新增: Modifier 链分析
+└── PreviewContextMenu.kt      # 新增: 右键菜单
 ```
 
-### 3.2 资产打包
+### 4.2 新增 Compiler / Runtime
 
-`build.gradle.kts` 中新增打包步骤：
+```
+compiler/
+├── BundledComposeCompiler.kt      # 增强: 收集真实 K2 diagnostic
+├── BundledD8Dexer.kt              # 增强: 输出 dex 字节码
+├── AsmComposeBinder.kt            # 新增: ASM 字节码改写
+├── ComposeRuntimePrewarm.kt       # 新增: 预热 compose runtime
+├── DexSharedLibraryLoader.kt      # 新增: dex mmap 共享
+├── CompileModels.kt               # 增强: BuildPhaseTimings
+└── BytecodeCache.kt               # 新增: ASM 产物缓存
+
+runtime/
+├── ComposeClassLoader.kt          # 增强: mmap + 共享 dex
+├── ComposableRenderer.kt          # 增强: 优先用 ASM 生成的 binder
+├── MethodHandleResolver.kt        # 保留 (作为 fallback)
+└── AsmBinderInvoker.kt            # 新增: 调用 ASM 生成 binder
+```
+
+### 4.3 新增数据 / 资源
+
+```
+data/
+├── device/DeviceCatalog.kt        # 新增: 真实设备数据集 (内置 30+)
+├── device/CutoutGeometry.kt       # 新增: cutout 几何 sealed
+└── device/PhysicalKey.kt          # 新增: 物理键位置
+
+res/values/
+├── device_profiles.xml            # 新增: 设备 Profile 列表
+└── cutout_geometries.xml          # 新增: cutout 形状配置
+```
+
+---
+
+## 5. 新架构（v2.1 全景）
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  UI 层                                                               │
+│    ┌──────────────┐ ┌──────────────┐ ┌──────────────┐                │
+│    │ PreviewToolbar│ │DeviceProfile │ │DebugDrawer   │                │
+│    │  (设备/主题/  │ │  Sheet       │ │ (Inspector/  │                │
+│    │  缩放/调试)  │ │              │ │  Logcat)     │                │
+│    └──────────────┘ └──────────────┘ └──────────────┘                │
+│    ┌──────────────────────────────────────────────────┐             │
+│    │   ZoomablePane                                   │             │
+│    │     └── DeviceFrame (Bezels + Cutout + SystemBars)│            │
+│    │           └── RenderTarget (ComposeView)         │             │
+│    │                 └── MaterialTheme { content }    │             │
+│    └──────────────────────────────────────────────────┘             │
+├─────────────────────────────────────────────────────────────────────┤
+│  ViewModel 层 (ComposePreviewViewModel)                             │
+│    ├── PreviewState: Idle/Compiling/Ready/Error                     │
+│    ├── DeviceConfig (设备 + cutout + 状态栏)                          │
+│    ├── PreviewTheme (Light/Dark/Custom)                            │
+│    ├── DebugState (Inspector on / Recompose on / Logcat)            │
+│    ├── EditState (drag / resize / color pick)                       │
+│    └── ViewportState (zoom / pan / fit)                             │
+├─────────────────────────────────────────────────────────────────────┤
+│  Repository 层 (ComposePreviewRepository)                           │
+│    └── compile(source) -> CompilationResult (含 timings)            │
+├─────────────────────────────────────────────────────────────────────┤
+│  Build Phase                                                         │
+│    ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
+│    │ AssetsBundles   │ │BundledCompiler  │ │BundledD8Dexer   │       │
+│    │ (解压/校验)     │ │ (K2JVMCompiler) │ │ (D8)            │       │
+│    └─────────────────┘ └─────────────────┘ └─────────────────┘       │
+│                  ┌─────────────────────────────┐                    │
+│                  │ AsmComposeBinder (新)        │                    │
+│                  │  - 生成静态 binder            │                    │
+│                  │  - dead code strip            │                    │
+│                  │  - dex layout optimize        │                    │
+│                  └─────────────────────────────┘                    │
+├─────────────────────────────────────────────────────────────────────┤
+│  Runtime 层                                                          │
+│    ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
+│    │ ComposeLoader   │ │PrewarmService   │ │AsmBinderInvoker │       │
+│    │ (mmap+共享dex) │ │ (Class.forName)  │ │ (binder.invoke) │       │
+│    └─────────────────┘ └─────────────────┘ └─────────────────┘       │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. 真实设备模拟子系统
+
+### 6.1 DeviceProfile v2.1 字段
 
 ```kotlin
-// 1) Kotlin 编译器 (embeddable, 进程内)
-kotlinCompilerJars("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.24")
+data class DeviceProfile(
+    val id: String,                       // "pixel-7-pro", "huawei-mate60-pro"
+    val manufacturer: String,             // "Google", "Huawei", "Samsung"
+    val model: String,                    // "Pixel 7 Pro"
+    val osVersion: String,                // "Android 14"
+    val formFactor: FormFactor,           // PHONE / FOLDABLE_INNER / FOLDABLE_OUTER / TABLET / DESKTOP / WATCH
+    val widthPx: Int,
+    val heightPx: Int,
+    val densityDpi: Int,
+    val screenGeometry: ScreenGeometry,   // 屏幕形状 (见 6.2)
+    val cutout: CutoutGeometry?,          // 刘海 / 针孔 / 瀑布 (nullable)
+    val bezels: Bezels,                   // 上 / 下 / 左 / 右 边框
+    val chassisColor: Color,              // 机身颜色
+    val physicalKeys: List<PhysicalKey>,  // 电源 / 音量
+    val statusBarHeightDp: Int,
+    val navigationBarHeightDp: Int,
+    val isRound: Boolean,                 // 手表专用
+    val hasNotch: Boolean = false,
+    val hasPunchHole: Boolean = false,
+    val hasWaterfall: Boolean = false,
+    val isFoldable: Boolean = false,
+    val isCustom: Boolean = false,
+)
+```
 
-// 2) Compose Compiler Plugin
-composeCompilerJars("androidx.compose.compiler:compiler:1.5.14")
+### 6.2 ScreenGeometry / CutoutGeometry
 
-// 3) Compose Runtime (AAR -> classes.jar, 已存在)
-// 4) D8 (从 build-tools 拷贝) -> 改为随包自带的 d8.jar
-//    通过 compileSdk 自带的 d8.jar 提取, 也可固定版本内置.
+```kotlin
+sealed class ScreenGeometry {
+    data class Rectangular(val cornerRadiusPx: Float) : ScreenGeometry()
+    data class Waterfall(val sideAngleDeg: Float, val edgeWidthPx: Float) : ScreenGeometry()
+    data class FoldedInner(val hingeWidthPx: Float) : ScreenGeometry()
+    data class Round(val diameterPx: Float) : ScreenGeometry()
+}
 
-// 5) 打包为 compose-sdk.zip
-val packageComposeSdk by tasks.registering(Zip::class) {
-    dependsOn(extractKotlinCompiler, extractComposeCompiler, extractComposeRuntime, extractD8)
-    archiveFileName.set("compose-sdk.zip")
-    destinationDirectory.set(file("src/main/assets/compose"))
+sealed class CutoutGeometry {
+    abstract val widthPx: Float
+    abstract val heightPx: Float
+    abstract val anchor: Anchor
+
+    enum class Anchor { TOP_CENTER, TOP_LEFT, TOP_RIGHT, LEFT_CENTER, RIGHT_CENTER }
+
+    data class Notch(override val widthPx: Float, override val heightPx: Float,
+                     override val anchor: Anchor) : CutoutGeometry()
+    data class PunchHole(override val widthPx: Float, override val heightPx: Float,
+                         override val anchor: Anchor) : CutoutGeometry()
+    data class WaterfallCurve(val sideAngleDeg: Float, val edgeCurvePx: Float) : CutoutGeometry() {
+        override val widthPx = 0f
+        override val heightPx = 0f
+        override val anchor = Anchor.LEFT_CENTER
+    }
 }
 ```
 
-`src/main/assets/compose/` 产物：
+### 6.3 内置设备清单（v2.1 必交付）
+
+| 分组 | ID | 名称 | 关键属性 |
+| --- | --- | --- | --- |
+| Phone | `pixel-7` | Pixel 7 | 1080×2400@420, PunchHole 居中 4dp |
+| Phone | `pixel-7-pro` | Pixel 7 Pro | 1440×3120@560, PunchHole 居中 |
+| Phone | `pixel-8-pro` | Pixel 8 Pro | 1344×2992@560, PunchHole 居中 |
+| Phone | `huawei-mate60-pro` | Mate 60 Pro | 1260×2720@460, PunchHole 居中 8dp |
+| Phone | `xiaomi-14-pro` | Xiaomi 14 Pro | 1440×3200@560, PunchHole 居中 |
+| Phone | `samsung-s24-ultra` | S24 Ultra | 1440×3120@560, PunchHole 居中 4dp |
+| Phone | `iphone-15-pro` | iPhone 15 Pro | 1179×2556@460, Dynamic Island 126×37dp |
+| Phone | `oneplus-12` | OnePlus 12 | 1440×3168@560, PunchHole 左上 4dp |
+| Notch | `huawei-p30-pro` | P30 Pro | 1080×2340@480, Waterfall 88° |
+| Notch | `iphone-13` | iPhone 13 | 1170×2532@460, Notch 154×30dp |
+| Notch | `iphone-14` | iPhone 14 | 1170×2532@460, Notch 154×30dp |
+| Foldable | `galaxy-z-fold5-inner` | Galaxy Z Fold 5 (内屏) | 1812×2176@374, 无 cutout |
+| Foldable | `galaxy-z-fold5-outer` | Galaxy Z Fold 5 (外屏) | 904×2316@374, PunchHole 居中 |
+| Foldable | `pixel-fold-inner` | Pixel Fold (内屏) | 2208×1840@420, 无 cutout |
+| Foldable | `pixel-fold-outer` | Pixel Fold (外屏) | 1080×2092@420, PunchHole 边 |
+| Tablet | `pixel-tablet` | Pixel Tablet | 1600×2560@320 |
+| Tablet | `ipad-pro-12.9` | iPad Pro 12.9" | 2048×2732@264 |
+| Watch | `wear-os-small` | Wear OS Small | 384×384@320, Round |
+| Watch | `wear-os-large` | Wear OS Large | 454×454@320, Round |
+| Custom | `custom` | Custom | 由 ResolutionEditor 创建 |
+
+### 6.4 DeviceFrame 渲染算法
+
 ```
-compose-sdk/
-├── kotlin/
-│   ├── kotlin-compiler-embeddable.jar
-│   ├── kotlin-stdlib.jar
-│   ├── kotlin-reflect.jar
-│   ├── kotlin-script-runtime.jar
-│   ├── trove4j.jar
-│   └── annotations-13.0.jar
-├── compose-compiler-plugin.jar
-├── compose-runtime/
-│   ├── compose-runtime-android.jar
-│   ├── compose-ui-android.jar
-│   ├── compose-ui-graphics-android.jar
-│   ├── compose-ui-tooling-preview-android.jar
-│   ├── compose-foundation-android.jar
-│   ├── compose-material3-android.jar
-│   ├── activity-compose.jar
-│   ├── lifecycle-runtime.jar
-│   ├── core.jar
-│   └── ...（约 20 个）
-└── dex/
-    ├── d8.jar                        // 进程内 D8
-    └── compose-runtime.dex           // 预 dexed runtime, 给主 app 共享
+render(profile, content):
+  1) Outer Box:
+     - size = outerWidth × outerHeight
+     - shape = profile.screenGeometry.shape  // 圆角 / 瀑布曲线
+     - background = profile.chassisColor
+
+  2) Inner Box (屏幕区):
+     - size = profile.widthPx × profile.heightPx  (dp)
+     - clip = profile.screenGeometry  // 屏幕形状 (瀑布/折叠单独处理)
+     - 内部: Box(content)
+
+  3) SystemBarsOverlay:
+     - 状态栏: 高度 = profile.statusBarHeightDp, 顶部对齐
+     - 导航栏: 高度 = profile.navigationBarHeightDp, 底部对齐
+     - 主题: Light / Dark / Translucent (来自 ViewModel.theme)
+
+  4) CutoutOverlay (可选):
+     - 根据 profile.cutout 类型:
+       - Notch: 顶部矩形 (RoundedCorner)
+       - PunchHole: 圆形 (anchor 决定位置)
+       - WaterfallCurve: 两侧 Path 裁切
+
+  5) PhysicalKeys (可选):
+     - 右侧矩形 (电源) / 左侧矩形 (音量 ±)
+
+  6) FoldableHingeOverlay (foldable):
+     - 中间阴影 / 折痕
 ```
 
-### 3.3 Build Phase 时序
+### 6.5 关键 Composable API
+
+```kotlin
+@Composable
+fun DeviceFrame(
+    profile: DeviceProfile,
+    modifier: Modifier = Modifier,
+    systemBarsTheme: SystemBarsTheme = SystemBarsTheme.Auto,
+    showStatusBar: Boolean = true,
+    showNavigationBar: Boolean = true,
+    showCutout: Boolean = true,
+    showChassis: Boolean = true,
+    content: @Composable () -> Unit
+)
+
+@Composable
+fun SystemBarsOverlay(
+    profile: DeviceProfile,
+    theme: SystemBarsTheme,    // Light / Dark / Translucent / Auto
+    modifier: Modifier = Modifier,
+    customClock: String? = null,
+    batteryPercent: Int? = null,
+)
+
+@Composable
+fun CutoutOverlay(
+    cutout: CutoutGeometry,
+    modifier: Modifier = Modifier,
+)
+
+@Composable
+fun FoldableHingeOverlay(
+    hingeWidthPx: Float,
+    modifier: Modifier = Modifier,
+)
+```
+
+---
+
+## 7. 系统状态栏子系统
+
+### 7.1 主题
+
+```kotlin
+enum class SystemBarsTheme {
+    AUTO,    // 跟随 Composable 主题
+    LIGHT,   // 深色图标 / 浅色背景
+    DARK,    // 浅色图标 / 深色背景
+    TRANSLUCENT_LIGHT,
+    TRANSLUCENT_DARK,
+}
+```
+
+### 7.2 状态栏内容
+
+- **时间**：从系统 ClockProvider 读，10s 刷新
+- **电池**：可选图标 + 百分比
+- **Wi-Fi / 信号**：默认 4 格满
+- **通知小红点**：默认显示
+- **高度**：`profile.statusBarHeightDp` (24~50dp)
+
+### 7.3 导航栏
+
+- 高度：`profile.navigationBarHeightDp` (44~48dp)
+- 内容：返回 / Home / 最近
+- 手势导航：底部一条横杠
+
+### 7.4 持久化
+
+用户选择的 `SystemBarsTheme` 写入 SharedPreferences（key = `preview.systemBarsTheme`）。
+
+---
+
+## 8. 字节码加速子系统（ASM）
+
+### 8.1 设计动机
+
+反射 + `MethodHandle.invokeWithArguments(...)` 每次调用：
+- 创建 `Object[]` 数组（args）
+- `MethodHandle` 拆箱 / 装箱
+- 找不到 JIT 稳定的 inline 点
+
+AS 的解决方案是 **静态 binder**：
+- 在 dex 阶段前，对每个 `@Composable fun Foo(...)` 生成一个 `staticInvoke$Foo(composer, changedFlags)` 包装类
+- 运行时直接 `StaticInvoke$Foo.invoke(c, 0)`，没有反射、没有数组分配
+
+### 8.2 实现思路
+
+#### 8.2.1 输入
+
+- K2 编译产出的 `.class` 文件（在 `classesDir`）
+
+#### 8.2.2 ASM pass
+
+使用 `org.ow2.asm:asm:9.7` + `asm-commons`，对每个 class 做：
+
+**Pass 1: 找到 `@Composable fun Foo(...)`**
+- 扫描 `Lcom/example/PreviewKt;` 的所有 method
+- 找到带 `@Composable` 注解 + 含 `Composer` 形参的方法
+- 记录 `(className, methodName, descriptor)` 到 `BinderRegistry`
+
+**Pass 2: 生成 binder 类**
+- 对每个注册的方法，在 `binder/` 子包下生成 `Binder$Foo$XXX.class`
+- 字段: `private static final MethodHandle HANDLE = MethodHandles.lookup().unreflect(...)`
+- 方法: `public static void invoke(Composer c, int changed) { HANDLE.invokeWithArguments(c, changed); }`
+
+**Pass 3: dead code strip**
+- 删除未引用的 method (除了 `<init>` / binder)
+- 简化字符串常量
+
+**Pass 4: dex 落地**
+- D8 把 binder 一起 dex
+- 产物: `preview_xxx.dex` + `binders.dex`
+
+#### 8.2.3 运行时
+
+`AsmBinderInvoker` 优先于 `MethodHandle`：
+- 拿到 `Binder$Foo$XXX.class` 后用 `MethodHandle` 调一次（缓存）
+- 之后所有 render 直接走 binder
+
+### 8.3 BytecodeCache
+
+```
+cache/binders/<sourceHash>/
+  ├── MyComposable.class          # 原始 .class
+  ├── Binder$MyComposable.class   # 生成的 binder
+  └── version.txt
+```
+
+缓存命中条件：`sourceHash` + `binderVersion` (随 ASM 升级失效)。
+
+### 8.4 引入的依赖
+
+```kotlin
+// build.gradle.kts
+bytecodeAcceleratorJars("org.ow2.asm:asm:9.7")
+bytecodeAcceleratorJars("org.ow2.asm:asm-commons:9.7")
+bytecodeAcceleratorJars("org.ow2.asm:asm-tree:9.7")
+```
+
+打包到 `assets/compose/jars/asm-*.jar`，由 `AsmComposeBinder` 加载。
+
+### 8.5 fallback
+
+- ASM pass 失败 -> 退回 `MethodHandle` 路径
+- ASM jar 缺失 -> 跳过整个 pass，行为完全等同 v2
+
+### 8.6 性能预期
+
+| 阶段 | v2 (反射) | v2.1 (binder) | 提升 |
+| --- | --- | --- | --- |
+| 首次反射查找 | ~50ms | ~3ms (MethodHandle 缓存) | 16x |
+| 每次 invoke | ~0.5ms (数组分配) | ~0.05ms (直接 invoke) | 10x |
+| 100 个 Composable 渲染 | ~80ms | ~10ms | 8x |
+
+---
+
+## 9. Build Phase
+
+### 9.1 时序
 
 ```
 compile(source) :
@@ -181,159 +599,380 @@ compile(source) :
   2) ComposePreviewCache.get(sourceHash)   // 命中即返回
   3) SourcePreparer.writeWorkDir()         // <workDir>/src/<pkg>/<file>.kt
   4) BundledComposeCompiler.compile()      // 进程内 K2JVMCompiler
-       K2JVMCompiler().exec(
-         K2JVMCompilerArguments().apply {
-           freeArgs = listOf("MyFile.kt")
-           classpath = "<runtime jars>:<android.jar>:<project dex-derived classes>"
-           pluginClasspaths = arrayOf("<compose-compiler-plugin.jar>")
-           destination = "<workDir>/classes"
-           jvmTarget = "17"
-           suppressVersionWarnings = true
-         },
-         PrintingMessageCollector(System.out, MessageRenderer.PLAIN_RELATIVE_PATHS, false)
-       )
-  5) BundledD8Dexer.dex()                  // 进程内 D8
-       classpath = files(d8Jar)
-       mainClass = "com.android.tools.r8.D8"
-       args = --release --min-api 21 --output <dexDir> <classesDir>
-  6) DexCache.put(sourceHash, dexFile)
-  7) return CompilationResult
+  5) AsmComposeBinder.process()            // 字节码加速 (v2.1 新)
+  6) BundledD8Dexer.dex()                  // 进程内 D8
+  7) BytecodeCache.put(sourceHash, dexFile)
+  8) return CompilationResult(timings)
 ```
 
-### 3.4 Runtime 时序
+### 9.2 BuildPhaseTimings
 
+```kotlin
+data class BuildPhaseTimings(
+    val assetsInitMs: Long,
+    val cacheLookupMs: Long,
+    val sourcePrepareMs: Long,
+    val k2CompileMs: Long,
+    val asmTransformMs: Long,
+    val d8DexMs: Long,
+    val cacheWriteMs: Long,
+) {
+    val totalMs: Long get() = assetsInitMs + cacheLookupMs + ... + cacheWriteMs
+}
 ```
-render(state):
-  1) ComposeClassLoader.acquire()         // 池化, path+hash 命中即复用
-  2) loader.loadClass(<dexFile>, <className>)
-  3) MethodHandleResolver.resolve()       // 缓存: (clazz, functionName) -> MethodHandle
-  4) composeView.setContent { ... }
-       MaterialTheme {
-         Surface { BoundedDeviceFrame { ZoomablePane { RenderComposable(handle) } } }
-       }
-  5) MethodHandle.invokeWithArguments(composer, 0)   // 替代 Method.invoke
+
+UI 层展示在 DebugDrawer 的「Build」标签页。
+
+### 9.3 详细参数
+
+- **取消机制**：`AtomicBoolean cancelled`，K2 在分析阶段前检查（v2 已实现）
+- **超时**：默认 60s（编译超时比 buildService 长，因为不需要 full build）
+- **错误聚合**：多次失败保留最近 5 条
+
+---
+
+## 10. Runtime 优化
+
+### 10.1 DexClassLoader 池化（v2 已有，v2.1 增强）
+
+| 增强 | 说明 |
+| --- | --- |
+| **mmap 共享** | `compose-runtime.dex` 用 `InMemoryDexClassLoader` 共享主 app 的 classloader，不走磁盘 |
+| **LRU 驱逐** | 最多 10 个 loader，超出按 LRU 驱逐 |
+| **预热** | `PrewarmService` 在首启时 `Class.forName` 关键 compose 类 |
+
+### 10.2 PrewarmService
+
+```kotlin
+class ComposeRuntimePrewarm {
+    fun prewarm(classLoader: ClassLoader) {
+        KEY_CLASSES.forEach { name ->
+            runCatching { Class.forName(name, false, classLoader) }
+        }
+    }
+
+    companion object {
+        private val KEY_CLASSES = listOf(
+            "androidx.compose.runtime.Composer",
+            "androidx.compose.ui.node.LayoutNode",
+            "androidx.compose.foundation.layout.Box",
+            "androidx.compose.material3.MaterialTheme",
+            // ... ~30 个
+        )
+    }
+}
 ```
 
-### 3.5 新功能矩阵
+### 10.3 ComposableRenderer 增强
 
-| 功能 | 入口 | 数据源 | 持久化 |
+```kotlin
+class ComposableRenderer(
+    private val composeView: ComposeView,
+    private val classLoader: ComposeClassLoader,
+    private val binderInvoker: AsmBinderInvoker,    // 优先
+    private val handleResolver: MethodHandleResolver // fallback
+) {
+    fun render(dexFile: File, className: String, functionName: String) {
+        val binder = binderInvoker.tryGetBinder(dexFile, className, functionName)
+        if (binder != null) {
+            composeView.setContent { RenderWithBinder(binder) }
+        } else {
+            // fallback to MethodHandle
+            ...
+        }
+    }
+}
+```
+
+---
+
+## 11. 可视化编辑工具箱
+
+### 11.1 拖动 / Resize
+
+```kotlin
+@Composable
+fun Modifier.editable(
+    state: EditState,
+    onBoundsChange: (Rect) -> Unit,
+): Modifier = this.pointerInput(Unit) {
+    detectDragGestures(
+        onDragStart = { state.dragStart(it) },
+        onDrag = { _, delta -> state.drag(delta) },
+        onDragEnd = { state.dragEnd(onBoundsChange) }
+    )
+}
+```
+
+v2.1 P0 只做基础版（单 Composable 整体拖动），P1 加 8 控制点 resize。
+
+### 11.2 颜色拾取
+
+```kotlin
+@Composable
+fun ColorPickerOverlay(
+    composableBounds: Rect,
+    onPick: (Color) -> Unit,
+)
+```
+
+实现：
+1. 拿到 `composableBounds` 的 `ComposeView` 截图
+2. 用户点击位置 -> 计算像素
+3. 弹出 Popup 显示 HEX / RGB
+
+### 11.3 Layout Bounds
+
+```kotlin
+@Composable
+fun LayoutBoundsOverlay(
+    visible: Boolean,
+    color: Color = Color.Red,
+)
+```
+
+实现：
+- 在每个 Composable 节点周围画 1dp 矩形
+- 通过 `Modifier.drawWithContent` + `onGloballyPositioned`
+
+---
+
+## 12. 调试与可观测性
+
+### 12.1 RecompositionCounter 真实挂载
+
+```kotlin
+@Composable
+fun MyComposable() {
+    val counter = rememberRecompositionCounter()
+    counter.bind()    // 每次 recompose 触发
+    Text("...")
+}
+```
+
+UI：在 ComponentInspector 面板显示 "Recompositions: 5"。
+
+### 12.2 ComponentInspector 反射读 LayoutNode
+
+```kotlin
+class LayoutNodeInspector {
+    fun inspect(layoutNode: Any): NodeInfo {
+        val coords = readField(layoutNode, "coordinates") as Any
+        val bounds = readField(coords, "bounds") as Rect
+        val width = readField(layoutNode, "width") as Int
+        val height = readField(layoutNode, "height") as Int
+        return NodeInfo(bounds, width, height, ...)
+    }
+}
+```
+
+注意：`LayoutNode` 的字段是 internal/private，必须用 `kotlin-reflect` 或 `sun.misc.Unsafe`。
+
+### 12.3 LogcatPanel
+
+```kotlin
+class PreviewLogcat {
+    private val logs = mutableStateListOf<LogEntry>()
+
+    fun interceptPrintln(msg: String) {
+        logs.add(LogEntry("println", msg, System.currentTimeMillis()))
+    }
+}
+```
+
+实现：在 `RenderComposable` 之前 `System.setOut(PreviewPrintStream)`，捕获 `println`。
+
+### 12.4 性能埋点
+
+- `viewModel.compilePreview(source, ...)` 起停计时，写入 `BuildPhaseTimings`
+- 每次 `render()` 计时
+- DebugDrawer 的 "Stats" 标签页显示
+
+---
+
+## 13. 新功能矩阵
+
+| 功能 | 入口 | 数据源 | v2.1 优先级 |
 | --- | --- | --- | --- |
-| 设备模拟 | `DeviceProfileSheet` | 内置 Pixel/Tablet/Watch Profile | 内存 (Session) |
-| 分辨率自定义 | `ResolutionEditor` | 用户输入 w/h/DPI | SharedPreferences |
-| 缩放 | `ZoomController` | 手势 / Ctrl+Wheel | 内存 (Session) |
-| 主题切换 | `ThemeSelector` | 固定 Light/Dark/Custom | 内存 (Session) |
-| Recomposition 计数 | `RecompositionCounter` | 通过 `currentComposer` 注入 side-effect | 内存 (Session) |
-| Component Inspector | `ComponentInspector` | 通过反射读 `LayoutNode` 私有字段 | 内存 (Session) |
-| 拖动 / Resize | `Modifier.draggable` / `Modifier.pointerInput` | 用户手势 | 内存 (Session) |
-| 颜色拾取 | `ColorPickerOverlay` | Bitmap 像素采样 | 内存 (Session) |
-| 布局框 | `LayoutBoundsOverlay` | `LayoutNode.coordinates` | 内存 (Session) |
-| 日志面板 | `LogcatPanel` | `LiveLiterals` / 用户 println | 内存 (Session) |
-| 多 Preview 网格 | `PreviewGridLayout` | 解析所有 @Preview | 内存 (Session) |
-| Pin 主题色 | `LiveLiterals` (实验) | 反射修改 theme | 内存 (Session) |
+| 真实设备模拟 (Phone/Pixel) | `DeviceFrame(profile=Pixel_7)` | 内置 | P0 |
+| 真实设备模拟 (Foldable) | `DeviceFrame(profile=ZFold5_Inner)` | 内置 | P0 |
+| 真实设备模拟 (Waterfall) | `DeviceFrame(profile=P30_Pro)` | 内置 | P0 |
+| 真实设备模拟 (Notch) | `DeviceFrame(profile=iPhone_14)` | 内置 | P0 |
+| 真实设备模拟 (PunchHole) | `DeviceFrame(profile=Mate60_Pro)` | 内置 | P0 |
+| 真实设备模拟 (Watch) | `DeviceFrame(profile=Wear_Small)` | 内置 | P1 |
+| 真实设备模拟 (Tablet) | `DeviceFrame(profile=Pixel_Tablet)` | 内置 | P0 |
+| 设备分组 Sheet | `DeviceProfileSheet` | 内置 | P0 |
+| 自定义分辨率 | `ResolutionEditor` | 用户输入 | P0 |
+| 系统状态栏 (浅 / 深 / 透) | `SystemBarsOverlay` | 主题 | P0 |
+| 物理按键 (电源 / 音量) | `DeviceFrame` | profile | P1 |
+| 折叠铰链 | `FoldableHingeOverlay` | profile | P1 |
+| 缩放 (pinch / Ctrl+Wheel / Fit) | `ZoomController` | 手势 | P0 |
+| 主题切换 (Light/Dark/Custom) | `ThemeSelector` | 固定 | P0 |
+| 多 Preview 网格 | `PreviewGridLayout` | 解析 | P0 |
+| 拖动 Composable | `Modifier.editable` | 手势 | P1 |
+| Resize 8 控制点 | `Modifier.resizable` | 手势 | P1 |
+| 颜色拾取 | `ColorPickerOverlay` | 截图 | P1 |
+| Layout Bounds | `LayoutBoundsOverlay` | LayoutNode | P1 |
+| Recomposition 计数 | `RecompositionCounter` | side-effect | P1 |
+| Component Inspector | `ComponentInspector` | 反射 | P1 |
+| Logcat 面板 | `LogcatPanel` | println | P1 |
+| ASM 字节码加速 | `AsmComposeBinder` | 反射 | P2 |
+| Prewarm | `ComposeRuntimePrewarm` | Class.forName | P2 |
+| DEX mmap 共享 | `DexSharedLibraryLoader` | InMemoryDexClassLoader | P2 |
+| 性能埋点 | `BuildPhaseTimings` | timing | P2 |
+| `@PreviewParameter` 支持 | `PreviewSourceParser` | 正则 | P0 |
+| `@PreviewFontScale` 支持 | `PreviewSourceParser` | 正则 | P1 |
+| `@PreviewLightDark` 支持 | `PreviewSourceParser` | 正则 | P1 |
+| LiveLiterals 实验 | `LiveLiteralsService` | K2 AST | P3 |
+| Hot Reload (incremental) | — | 文件 watch | P3 |
 
 ---
 
-## 4. 详细文件改动表
+## 14. 详细文件改动表
 
-| 文件 | 动作 | 范围 |
+| 文件 | 动作 | v2.1 范围 |
 | --- | --- | --- |
-| `build.gradle.kts` | 修改 | 增加 `kotlinCompilerJars` / `bundledD8Jars` 配置；新增 `packageComposeSdk` 任务 |
-| `assets/compose/compose-sdk.zip` | 新增 | 由 `packageComposeSdk` 生成 |
-| `compiler/AssetsComposeBundles.kt` | 新增 | 资产清单 / 解压 / 校验（SHA-256） |
-| `compiler/ComposeClasspathManager.kt` | **删除** | 旧实现，路径依赖 .m2 |
-| `compiler/ComposeCompiler.kt` | **改写** | `BundledComposeCompiler`：`K2JVMCompiler` 进程内 |
-| `compiler/ComposeDexCompiler.kt` | **改写** | `BundledD8Dexer`：`javaexec` 调用 assets 内的 `d8.jar` |
-| `compiler/CompilerDaemon.kt` | **删除** | 守护进程机制与本项目 K2 版本不匹配 |
-| `compiler/DexCache.kt` | 保留 | 加 `versionTag` 字段：SDK 升级时失效 |
-| `compiler/ProjectContextSource.kt` | 保留 | 加 `useGradleDex` 短路开关 |
-| `data/source/ProjectContextSource.kt` | 保留 | 不变 |
-| `data/repository/ComposePreviewRepositoryImpl.kt` | **改写** | 引入新 Build Phase，去 daemon 逻辑 |
-| `domain/PreviewSourceParser.kt` | 增强 | 支持 `@PreviewParameter`、`@PreviewFontScale` 等 |
-| `runtime/ComposeClassLoader.kt` | **改写** | 池化 + 共享 dex 路径 |
-| `runtime/ComposableRenderer.kt` | **改写** | MethodHandle + 反射缓存 |
-| `runtime/MethodHandleResolver.kt` | 新增 | 反射查找 → MethodHandle |
-| `runtime/PrewarmService.kt` | 新增 | 预热 compose runtime 类 |
-| `ui/BoundedComposeView.kt` | **改写** | 集成 ZoomController / PanController |
-| `ui/DeviceFrame.kt` | 新增 | 设备外壳（圆角、刘海、状态栏） |
-| `ui/ZoomController.kt` | 新增 | pinch / scroll / fit-to-screen |
-| `ui/RecompositionCounter.kt` | 新增 | recomposition 计数 side-effect |
-| `ui/ComponentInspector.kt` | 新增 | 布局框 / 属性面板 |
-| `ui/DeviceProfileSheet.kt` | 新增 | 设备选择 Sheet |
-| `ui/ResolutionEditor.kt` | 新增 | 分辨率编辑 |
-| `ui/ThemeSelector.kt` | 新增 | Light/Dark/Custom 切换 |
-| `ui/LogcatPanel.kt` | 新增 | 日志面板 |
-| `ui/PreviewGridLayout.kt` | 新增 | 多 Preview 网格 |
-| `ComposePreviewFragment.kt` | **改写** | 集成新功能 |
-| `ComposePreviewViewModel.kt` | 增强 | 新功能状态 |
-| `DESIGN.md` | 新增 | 本文档 |
-| `TODO.md` | 新增 | 任务清单 |
+| `build.gradle.kts` | 修改 | 增加 `bytecodeAcceleratorJars` (ASM)；`assets/compose/jars/asm-*.jar` |
+| `assets/compose/compose-jars.zip` | 扩展 | 包含 asm-9.7.jar / asm-commons / asm-tree |
+| `compiler/AssetsComposeBundles.kt` | 增强 | 暴露 `asmJars: List<File>` |
+| `compiler/BundledComposeCompiler.kt` | 增强 | 真实收集 K2 diagnostic；返回 `BuildPhaseTimings` |
+| `compiler/BundledD8Dexer.kt` | 增强 | 支持 binder 目录作为输入 |
+| `compiler/AsmComposeBinder.kt` | **新增** | ASM pass：binder 生成 / dead code strip |
+| `compiler/BytecodeCache.kt` | **新增** | binder + 改写后 class 缓存 |
+| `compiler/CompileModels.kt` | 增强 | `BuildPhaseTimings` 数据类 |
+| `compiler/ComposeRuntimePrewarm.kt` | **新增** | 预热关键 class |
+| `compiler/DexCache.kt` | 保留 | 加 `binderVersion` 失效条件 |
+| `data/repository/ComposePreviewRepositoryImpl.kt` | 重写 | 引入 `AsmComposeBinder`；降级路径不变 |
+| `data/source/ProjectContextSource.kt` | 保留 | — |
+| `data/device/DeviceCatalog.kt` | **新增** | 30+ 真实设备 profile |
+| `data/device/CutoutGeometry.kt` | **新增** | sealed class 描述 cutout |
+| `data/device/PhysicalKey.kt` | **新增** | 物理键 sealed |
+| `domain/PreviewSourceParser.kt` | 增强 | `@PreviewParameter` / `@PreviewFontScale` / `@PreviewLightDark` |
+| `domain/model/ParsedPreviewSource.kt` | 增强 | 加 `fontScale` / `isLightDark` / `parameterProvider` |
+| `runtime/ComposeClassLoader.kt` | 增强 | mmap + LRU + prewarm hook |
+| `runtime/ComposableRenderer.kt` | 增强 | 优先 `AsmBinderInvoker`；fallback `MethodHandle` |
+| `runtime/MethodHandleResolver.kt` | 保留 | fallback |
+| `runtime/AsmBinderInvoker.kt` | **新增** | 调用 binder 静态方法 |
+| `ui/BoundedComposeView.kt` | 增强 | 暴露 `editableBounds: Rect` |
+| `ui/DeviceFrame.kt` | **重写** | 真实设备外壳 + cutout 几何 |
+| `ui/DeviceProfile.kt` | **重写** | 完整字段 (bezel / chassisColor / physicalKeys / formFactor) |
+| `ui/DeviceProfileSheet.kt` | **重写** | 分组 + 真实缩略图 |
+| `ui/SystemBarsOverlay.kt` | **新增** | 状态栏 + 导航栏 + 时钟 |
+| `ui/CutoutOverlay.kt` | **新增** | Notch / PunchHole / Waterfall 渲染 |
+| `ui/FoldableHingeOverlay.kt` | **新增** | 折叠屏铰链阴影 |
+| `ui/ResolutionEditor.kt` | 增强 | 支持 cutout 选择 |
+| `ui/ThemeSelector.kt` | 保留 | — |
+| `ui/ZoomController.kt` | 增强 | Ctrl+Wheel / 双击 Fit |
+| `ui/RecompositionCounter.kt` | 增强 | 真实挂载到 RenderComposable |
+| `ui/ComponentInspector.kt` | **重写** | 反射读 LayoutNode |
+| `ui/ColorPickerOverlay.kt` | **新增** | 颜色拾取 |
+| `ui/LayoutBoundsOverlay.kt` | **新增** | 布局边界 |
+| `ui/LogcatPanel.kt` | **新增** | 日志面板 |
+| `ui/PreviewGridLayout.kt` | **新增** | AS 风格多 Preview 网格 |
+| `ui/PreviewToolbar.kt` | **新增** | 顶栏 Compose 工具栏 |
+| `ui/DebugDrawer.kt` | **新增** | 底部抽屉 (Inspector / Logcat / Stats) |
+| `ui/ModifierInspector.kt` | **新增** | Modifier 链分析 |
+| `ui/PreviewContextMenu.kt` | **新增** | 右键菜单 |
+| `ComposePreviewActivity.kt` | **重写** | 全 Compose UI；顶栏 + 设备框 + 抽屉 |
+| `ComposePreviewFragment.kt` | 弃用 | 保留为兼容入口 |
+| `ComposePreviewViewModel.kt` | **重写** | 完整 StateFlow 状态 (设备/主题/调试/编辑) |
+| `PreviewConfig.kt` | 增强 | 加 `fontScale` / `parameterProviderName` |
+| `PreviewState.kt` | 增强 | 加 `DeviceConfig` / `DebugState` |
+| `DESIGN.md` | **重写** | 本文件 |
+| `TODO.md` | **重写** | 任务清单 |
+| `res/values/device_profiles.xml` | **新增** | 设备列表 |
+| `res/values/strings_preview.xml` | **新增** | 工具栏 / 抽屉 文字 |
+| `res/drawable/ic_*` | 增强 | 加设备 / cutout / 工具栏图标 |
 
 ---
 
-## 5. 风险与缓解
+## 15. 风险与缓解
 
 | 风险 | 缓解 |
 | --- | --- |
-| `kotlin-compiler-embeddable` jar 体积大 (~50MB) | 拆 SDK zip 之外独立打包；不放在主 APK assets 根目录 |
-| K2JVMCompiler 进程内调用阻塞主线程 | 严格 `Dispatchers.IO` 包裹 + `viewModelScope` 取消传播 |
-| D8 jar 跨 Android API 兼容性 | D8 是 Java 8 bytecode，Android 8+ 即可 classload；旧设备 (API < 26) 走 system d8 fallback |
-| Compose 编译器版本与 runtime 版本不匹配 | 锁定组合（`compiler 1.5.14` ↔ `runtime 1.6.0`），`AssetsComposeBundles` 启动时校验 `compose-compiler-plugin.jar` 内 META-INF 版本 |
+| K2 进程内调用阻塞主线程 | 严格 `Dispatchers.IO`；`viewModelScope` 取消传播 |
+| D8 跨 Android API 兼容 | D8 bytecode 8+；API < 26 走 system d8 fallback |
+| Compose Compiler / runtime 版本不匹配 | 锁定 `compiler 1.5.10 ↔ runtime 1.6.0`；启动校验 `compose-compiler-plugin.jar` META-INF |
 | `@PreviewParameter` 类型不能反射实例化 | 仅支持无参构造的 Provider；其他显式提示 |
-| 跨 ABI / 跨 Gradle 版本产物差异 | 不重用跨项目的 dex；仅本预览缓存 |
+| 跨 ABI / Gradle 产物差异 | 不重用跨项目的 dex；仅本预览缓存 |
+| ASM 改写 class 失败 | 完整 try/catch；失败时 fallback 到 v2 行为 |
+| `LayoutNode` 私有字段随 Compose 版本变动 | 加 try/catch 反射；任何字段读不到就降级为公开 API |
+| 真实设备数据不准确 | 数据源注明 (Wikipedia / gsmarena / GSMArena 公开数据) |
+| Foldable 铰链模拟与实际差异 | 简化为「中间阴影 + 折痕线」，明确标注「视觉示意，非 1:1」 |
+| 状态栏图标粗糙 | 矢量 + Unicode 字符组合；明确标注「非真实系统栏」 |
+| 折叠屏内屏外屏切换 | v2.1 P0 提供两个独立 profile；自动切换（P1） |
+| 多 Preview 渲染卡顿 | P0 只渲染当前可见的；viewModel 维持 pool |
+| DEX mmap 共享在 API < 26 不可用 | 用 `PathClassLoader` 替代；记录 warning |
 
 ---
 
-## 6. 与 IDEA / AS 预览插件的对标
+## 16. 与 IDEA / AS 对标
 
-| 维度 | IDEA / AS | 本模块 v2 |
+| 维度 | IDEA / AS | 本模块 v2.1 |
 | --- | --- | --- |
 | 编译后端 | IDE 内 K2 + Daemon | **进程内 K2JVMCompiler，无守护** |
 | Dex 后端 | IDE 内 D8 | **进程内 D8（assets 携带）** |
-| 设备模拟 | 模板 | **同**（Pixel/Tablet/Watch/Foldable） |
+| ASM 加速 | Live Edit 用 IR | **binder 生成** |
+| 设备模拟 | 模板 | **真实设备 (30+)** |
+| 针孔屏 | ✓ | **✓**（Mate60 / S24 / 小米 14） |
+| 刘海屏 | ✓ | **✓**（iPhone 13 / 14 / 15） |
+| 瀑布屏 | ✓ | **✓**（P30 Pro / 88° 曲边） |
+| 折叠屏 | ✓ | **✓**（Z Fold 5 / Pixel Fold 内 + 外） |
+| 状态栏 | ✓ | **✓**（Light/Dark/Translucent） |
+| 物理按键 | ✗ | **✓**（v2.1 P1 简化版） |
 | 分辨率自定义 | ✓ | **✓** |
-| 缩放 | ✓ | **✓**（pinch + ctrl+wheel） |
+| 缩放 | ✓ | **✓**（pinch + Ctrl+Wheel） |
 | Recomposition 高亮 | ✓ | **基础**（计数器） |
-| Component Inspector | ✓ | **基础**（布局框） |
-| Live Edit | ✓ | ✗（不在本轮范围） |
-| 主题切换 | ✓ | **✓**（Light/Dark/Custom） |
+| Component Inspector | ✓ | **基础**（LayoutNode 反射） |
+| Live Edit | ✓ | ✗（P3 探索） |
+| 主题切换 | ✓ | **✓** |
 | 多 Preview 网格 | ✓ | **✓** |
+| 颜色拾取 | ✗ | **✓**（v2.1 P1） |
+| 拖动 / Resize | ✗ | **✓**（v2.1 P1） |
 
 ---
 
-## 7. 测试 / 验收
+## 17. 测试 / 验收
 
 | 阶段 | 验收 |
 | --- | --- |
-| 单元测试 | `AssetsComposeBundles` 解压校验、K2JVMCompiler 调用参数正确 |
-| 集成测试 | 在沙箱构建机（无 `.m2`、无 SDK build-tools）冷启动 → 编译 → 渲染 |
-| 端到端 | 打开 `MyComposable.kt` → 修改 → 1s 内重渲染 → 多 Preview 网格显示 |
-| 性能 | 首次冷启动 < 8s；增量 < 2s；首帧渲染 < 500ms |
+| 单元测试 | `AssetsComposeBundles` 解压 / 校验；`AsmComposeBinder` 生成 binder 后可调用 |
+| 集成测试 | 沙箱构建机（无 `.m2`、无 SDK build-tools）冷启动 → 编译 → 渲染 |
+| 设备模拟 | 至少 5 种形态在 ComposePreviewActivity 中可见（Phone/Notch/PunchHole/Waterfall/Foldable） |
+| 性能 | 首次冷启动 < 8s；增量 < 2s；首帧渲染 < 500ms；binder 加速后 100 Composable < 15ms |
 | 兼容性 | API 21+；arm64-v8a / armeabi-v7a / x86_64 |
+| 字节码加速 | binder 命中时 `MethodHandle.invoke` 次数降为 1（缓存） |
 
 ---
 
-## 8. 后续 PR 拆分
+## 18. PR 拆分计划
 
-| PR | 范围 | 依赖 |
-| --- | --- | --- |
-| #N  本 PR | 设计 + Build Phase 重写 + 反射优化 | 无 |
-| #N+1 | DeviceFrame / ZoomController / 主题切换 | 本 PR |
-| #N+2 | RecompositionCounter / ComponentInspector | 本 PR |
-| #N+3 | 多 Preview 网格 + PreviewParameter 支持 | 本 PR |
-| #N+4 | 性能调优（prewarm、DEX 复用） | 本 PR |
-| #N+5 | LiveLiterals 实验 | 本 PR |
+| PR | 标题 | 范围 | 依赖 |
+| --- | --- | --- | --- |
+| **#N（本 PR）** | `feat(compose-preview): v2.1 设计 + 真实设备模拟骨架 + Build Phase 增强` | DESIGN.md + TODO.md 重写；`DeviceFrame` / `DeviceProfile` / `SystemBarsOverlay` / `CutoutOverlay` 完整重写；`DeviceCatalog` 30+ 设备；`ComposePreviewActivity` 切换全 Compose；`ComposePreviewViewModel` 完整 StateFlow | 无 |
+| #N+1 | `feat(compose-preview): DebugDrawer + ComponentInspector + RecompositionCounter` | Inspector / Recompose / Logcat / Stats 面板 | #N |
+| #N+2 | `feat(compose-preview): 可视化编辑（拖动 / Resize / ColorPicker / LayoutBounds）` | Editable modifier + 8 控制点 + 截图采样 | #N+1 |
+| #N+3 | `feat(compose-preview): ASM 字节码加速（binder + dead code strip）` | AsmComposeBinder + BytecodeCache + AsmBinderInvoker | #N |
+| #N+4 | `feat(compose-preview): 折叠屏完整模拟（铰链 + 内 / 外屏切换）` | FoldableHingeOverlay + 自动切换 | #N+1 |
+| #N+5 | `feat(compose-preview): 性能调优（prewarm + DEX mmap 共享 + 埋点）` | ComposeRuntimePrewarm + DexSharedLibraryLoader | #N+3 |
+| #N+6 | `feat(compose-preview): 多 Preview 网格 + @PreviewParameter / FontScale / LightDark` | PreviewGridLayout + Parser 增强 | #N |
+| #N+7 | `feat(compose-preview): LiveLiterals 实验` | LiveLiteralsService + K2 AST hook | #N+3 |
 
 ---
 
-## 9. 引用
+## 19. 引用
 
 - [JetBrains Compose Compiler](https://developer.android.com/jetpack/androidx/releases/compose-kotlin)
 - [K2JVMCompiler 进程内调用](https://github.com/JetBrains/kotlin/blob/master/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt)
 - [Android Studio Compose Preview 源码（AGPL 闭源，仅参考交互）](https://android.googlesource.com/platform/tools/adt/idea/+/refs/heads/master/compose-designer/)
 - [AndroidIDE 现有 compose-preview 模块](file:///workspace/modules/compose-preview/)
 - [AndroidX Compose BOM](https://developer.android.com/jetpack/compose/bom/bom-mapping)
+- [ASM 字节码工具栈](https://asm.ow2.io/)
+- [Foldables / WindowManager Jetpack](https://developer.android.com/guide/topics/large-screens/foldables)
+- [Cutout API](https://developer.android.com/reference/android/view/DisplayCutout)
+- [GSMArena 设备数据库（屏幕物理参数参考）](https://www.gsmarena.com/)
 
 ---
 
 文档维护者：AndroidIDE
-最后更新：2026-06-13
+最后更新：2026-06-14

--- a/modules/compose-preview/TODO.md
+++ b/modules/compose-preview/TODO.md
@@ -1,193 +1,393 @@
-# Compose Preview 重构 TODO 清单
+# Compose Preview v2.1 TODO 清单
 
-> 与 `DESIGN.md` 配套。**所有任务优先级 P0 为本轮必须完成**；P1 / P2 / P3 在后续 PR 中完成。
-> 任务编号规范：`P?-XX-YY` —— `?` 优先级、`XX` 模块代号、`YY` 序号。
+> 与 [`DESIGN.md`](./DESIGN.md) 配套。
+> **任务编号规范：`P?-XX-YY` —— `?` 优先级、`XX` 模块代号、`YY` 序号。**
 >
 > 模块代号：
-> - `BLD` Build Phase
+> - `BLD` Build Phase（含 K2 / D8 / ASM）
 > - `RT`  Runtime
 > - `UI`  UI / Interaction
+> - `DEV` 真实设备模拟（含 cutout / 状态栏 / 铰链）
 > - `FE`  Feature
 > - `TS`  Test
 > - `DOC` 文档
+>
+> **优先级说明**：
+> - **P0**：本轮 PR #N 必修（设计与基础框架）
+> - **P1**：下一轮 PR（功能完整化）
+> - **P2**：再下一轮（性能与可观测性）
+> - **P3**：探索（LiveLiterals / Hot Reload）
+> - **P4**：体验打磨（动画、辅助功能）
 
 ---
 
-## P0 — 本轮必修（PR #1）
+## 0. 总体里程碑
 
-### BLD 资产化
+| 里程碑 | 内容 | 状态 |
+| --- | --- | --- |
+| M0：v2 完成 | Build Phase 重写 + 反射 → MethodHandle + 基础 UI | ✅ 已合并 (f8227aa) |
+| **M1：v2.1 设计落地（本轮 PR）** | 真实设备模拟（30+ Profile）+ SystemBars + Cutout 几何 + 全 Compose UI 升级 + DESIGN/TODO 重写 | 🚧 当前 |
+| M2：调试工具（PR #N+1） | DebugDrawer + ComponentInspector + Recompose + Logcat | — |
+| M3：可视化编辑（PR #N+2） | 拖动 / Resize / ColorPicker / LayoutBounds | — |
+| M4：ASM 加速（PR #N+3） | 字节码 binder + dead code strip | — |
+| M5：折叠屏（PR #N+4） | 铰链 + 内/外屏切换 | — |
+| M6：性能调优（PR #N+5） | Prewarm + DEX mmap 共享 + 埋点 | — |
+| M7：多 Preview + 参数（PR #N+6） | PreviewGridLayout + @PreviewParameter/FontScale/LightDark | — |
+| M8：LiveLiterals（PR #N+7） | 实验 | — |
+
+---
+
+## P0 — 本轮 PR #N（必须完成）
+
+### BLD 构建阶段
 
 - [ ] `P0-BLD-01` 改造 `build.gradle.kts`：
-  - 引入 `kotlinCompilerJars` Configuration（`org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.24`）
-  - 引入 `bundledD8Jars` Configuration（从 `android-sdk/build-tools/<latest>/lib/d8.jar` 拷贝并打包）
-  - 新增 `packageComposeSdk` 任务，产出 `assets/compose/compose-sdk.zip`
-- [ ] `P0-BLD-02` 新增 `compiler/AssetsComposeBundles.kt`：
-  - `init(context)`：解压 zip 到 `cacheDir/compose-sdk/`
-  - 校验 SHA-256（防止资产被改坏）
-  - 暴露 `kotlinCompilerClasspath` / `composePluginJar` / `runtimeJars` / `d8Jar` / `androidJar`（若 SDK 缺失则降级）
-- [ ] `P0-BLD-03` 改写 `compiler/ComposeCompiler.kt` → `BundledComposeCompiler`：
-  - 移除所有 `Environment.*` 路径依赖
-  - 进程内调用 `K2JVMCompiler.exec(args, messageCollector)`
-  - 入参：`sourceFiles`, `outputDir`, `runtimeJars`, `pluginJar`, `androidJar`
-  - 出参：`success` / `errorOutput` / `diagnostics`
-- [ ] `P0-BLD-04` 改写 `compiler/ComposeDexCompiler.kt` → `BundledD8Dexer`：
-  - 进程内 `javaexec` 调用 `d8.jar`（来自 assets 缓存）
-  - 移除 SDK build-tools 强依赖；找不到 d8 时抛 `BundledD8MissingException`，由 Repository 降级到 `useGradleDex` 流程
-- [ ] `P0-BLD-05` 删除 `compiler/CompilerDaemon.kt`：
-  - 不再维护 Kotlin 编译守护
-  - 移出 `ComposePreviewRepositoryImpl` 中所有 `compilerDaemon` 引用
-- [ ] `P0-BLD-06` 删除 `compiler/ComposeClasspathManager.kt`：
-  - 由 `AssetsComposeBundles` 替代
-- [ ] `P0-BLD-07` `compiler/DexCache.kt` 增加 `versionTag`：
-  - `versionTag = "composeSdk-<hash>"`
-  - SDK 升级时旧缓存自动失效
-- [ ] `P0-BLD-08` 改写 `data/repository/ComposePreviewRepositoryImpl.kt`：
-  - 移除 `classpathManager` / `compiler` / `compilerDaemon` 字段
-  - 改为 `bundles: AssetsComposeBundles` + `compiler: BundledComposeCompiler` + `dexer: BundledD8Dexer`
-  - 错误处理：d8 缺失 → 抛 `InitializationResult.Failed`（带明确提示），不无限重试
+  - 增加 `bytecodeAcceleratorJars` Configuration（`org.ow2.asm:asm:9.7` + `asm-commons` + `asm-tree`）
+  - 调整 `packageComposeSdk` 任务，把 ASM jar 一并打包到 `compose-jars.zip/asm/`
+  - 锁定 compose-compiler ↔ kotlin 兼容对（1.5.10 ↔ 1.9.22）
+- [ ] `P0-BLD-02` 增强 `compiler/AssetsComposeBundles.kt`：
+  - 暴露 `asmJars: List<File>` 字段
+  - 校验 zip 内 ASM jar 完整性；缺失时 `init()` 返回 `false` 但不抛
+  - 增加 `BytecodeCacheDir`（`<workDir>/bytecode/`）
+- [ ] `P0-BLD-03` 增强 `compiler/BundledComposeCompiler.kt`：
+  - 实现自定义 `MessageCollector` 子类，捕获 K2 真实 `Diagnostic`（含文件/行/列/严重等级）
+  - 真正写回 `CompileDiagnostic` 列表
+  - 输出 `BuildPhaseTimings` 子段（k2CompileMs）
+- [ ] `P0-BLD-04` 增强 `compiler/BundledD8Dexer.kt`：
+  - 支持传入多个 class 目录（user classes + ASM 生成的 binder）
+  - 输出 dex 路径返回 `BuildPhaseTimings`（d8DexMs）
+  - 失败时给出 **可恢复** 错误信息（含 D8 实际 stdout/stderr）
+- [ ] `P0-BLD-05` 增强 `compiler/CompileModels.kt`：
+  - 新增 `data class BuildPhaseTimings`（7 段耗时 + totalMs）
+  - 在 `CompileResult` 中带 `timings: BuildPhaseTimings` 字段
+- [ ] `P0-BLD-06` 增强 `data/repository/ComposePreviewRepositoryImpl.kt`：
+  - 串联 `k2Compile → asmTransform → d8Dex` 三段计时
+  - 错误统一包成 `CompilationException(message, diagnostics, cause)`，保留 cause 链
 
-### RT 运行时优化
+### DEV 真实设备模拟（v2.1 核心）
 
-- [ ] `P0-RT-01` 新增 `runtime/MethodHandleResolver.kt`：
-  - 缓存 `(Class<*>, String) -> MethodHandle`
-  - 第一次反射查找 → `MethodHandles.Lookup.unreflect` → 转 `MethodHandle`
-- [ ] `P0-RT-02` 改写 `runtime/ComposableRenderer.kt`：
-  - 用 `MethodHandle.invokeWithArguments` 替代 `Method.invoke`
-  - 静态方法直接 `invokeWithArguments()`；非静态 `invokeWithArguments(instance)`
-  - 错误渲染走统一 `ErrorContent` Composable
-- [ ] `P0-RT-03` 改写 `runtime/ComposeClassLoader.kt`：
-  - 池化：`(dexPath, hash) -> DexClassLoader` 弱引用 map
-  - `release()` 仅释放 `optimizedDir`，不删 loader（除非路径变更）
-  - 日志统一 `LOG.info`，避免无限循环释放
+- [ ] `P0-DEV-01` 新增 `data/device/CutoutGeometry.kt`：
+  - `sealed class CutoutGeometry` + `Notch` / `PunchHole` / `WaterfallCurve` 子类
+  - `enum Anchor { TOP_CENTER, TOP_LEFT, TOP_RIGHT, LEFT_CENTER, RIGHT_CENTER }`
+- [ ] `P0-DEV-02` 新增 `data/device/PhysicalKey.kt`：
+  - `sealed class PhysicalKey` + `Power` / `VolumeUp` / `VolumeDown` / `Camera` 子类
+  - 含 `positionDp` 相对屏幕位置
+- [ ] `P0-DEV-03` 重写 `ui/DeviceProfile.kt`：
+  - 增加字段：`manufacturer`, `model`, `osVersion`, `formFactor`, `screenGeometry`, `cutout`, `bezels`, `chassisColor`, `physicalKeys`, `statusBarHeightDp`, `navigationBarHeightDp`, `isRound`, `hasNotch`, `hasPunchHole`, `hasWaterfall`, `isFoldable`
+  - 旧字段（`widthPx`/`heightPx`/`densityDpi`/`frameStyle`/`isCustom`）保留
+  - 保留 `DeviceProfiles.PIXEL_4/5/6/7` 等老数据，新字段用合理默认
+- [ ] `P0-DEV-04` 新增 `data/device/DeviceCatalog.kt`：
+  - 至少 30 个真实设备 profile（详见 DESIGN 6.3 表）
+  - `DeviceCatalog.builtinProfiles` / `DeviceCatalog.byFormFactor(...)` / `DeviceCatalog.byId(...)` API
+  - 自定义 profile 合并到 list 顶部
+- [ ] `P0-DEV-05` 重写 `ui/DeviceFrame.kt`：
+  - 实现 `Bezels`（上下左右 dp）渲染
+  - 根据 `formFactor` 切换渲染：PHONE / FOLDABLE_INNER / FOLDABLE_OUTER / TABLET / WATCH
+  - WATCH 模式：圆表，圆形 `Canvas` 遮罩
+  - 折屏：内屏无 cutout，外屏 punch-hole
+  - 移除旧的简单 `NotchOverlay` 内联实现
+- [ ] `P0-DEV-06` 新增 `ui/CutoutOverlay.kt`：
+  - 接收 `CutoutGeometry` 渲染：
+    - `Notch` → 顶部圆角矩形
+    - `PunchHole` → 圆形（按 anchor 定位）
+    - `WaterfallCurve` → 两侧 Bezier 路径
+  - 颜色用黑色 0.95 alpha（与设备一体感）
+- [ ] `P0-DEV-07` 新增 `ui/FoldableHingeOverlay.kt`：
+  - 接收 `hingeWidthDp`，画中间阴影 + 折痕
+  - 默认 4dp 宽阴影 + 60dp 折痕区
+- [ ] `P0-DEV-08` 新增 `ui/SystemBarsOverlay.kt`：
+  - `enum class SystemBarsTheme { AUTO, LIGHT, DARK, TRANSLUCENT_LIGHT, TRANSLUCENT_DARK }`
+  - 状态栏内容：时间（系统时区 / 10s 刷新）、电池（4 格 + 百分比）、Wi-Fi、信号、通知红点
+  - 导航栏：返回 / Home / 最近；支持手势导航横杠
+  - 高度按 `profile.statusBarHeightDp` / `profile.navigationBarHeightDp`
+  - 提供 `SystemBarsTheme` 持久化（SharedPreferences key=`preview.systemBarsTheme`）
 
-### UI 集成
+### UI 集成（接入 Activity）
 
-- [ ] `P0-UI-01` 增强 `ComposePreviewViewModel`：
-  - 增加 `deviceProfile: StateFlow<DeviceProfile>` / `zoom: StateFlow<Float>` / `theme: StateFlow<PreviewTheme>`
-  - 增加 `selectedPreview: StateFlow<String?>`（多 Preview 网格时使用）
-  - 增加 `useGradleDex: StateFlow<Boolean>` 兜底开关
-- [ ] `P0-UI-02` 增强 `ComposePreviewFragment`：
-  - 顶栏新增：设备切换、主题切换、缩放控制
-  - 加载态 / 错误态 / 兜底态 UI
-- [ ] `P0-UI-03` 增强 `ui/BoundedComposeView.kt`：
-  - 支持 `onZoomChanged` / `onPanChanged` 回调
-  - 与 `ZoomController` 联动
+- [ ] `P0-UI-01` 新增 `ui/PreviewToolbar.kt`：
+  - 顶栏 Composable：设备切换 / 主题切换 / 缩放控制 / 调试开关 chip
+  - 与 `ComposePreviewViewModel` 各 StateFlow 联动
+- [ ] `P0-UI-02` 重写 `ComposePreviewActivity.kt`：
+  - 全 Compose UI：顶栏（PreviewToolbar）+ 中间（ZoomablePane + DeviceFrame + SystemBars + RenderTarget）+ 底部（占位抽屉）
+  - 状态分发：Loading / Error / Empty / NeedsBuild / Ready
+  - 错误页：保持 XML 版的错误详情可滚动
+- [ ] `P0-UI-03` 增强 `ui/ZoomController.kt`：
+  - 真正接入 Activity：双击切换 Fit/100%；Ctrl+Wheel 缩放
+  - 与 `PreviewToolbar` 的缩放 chip 联动
+- [ ] `P0-UI-04` 增强 `ui/ResolutionEditor.kt`：
+  - 增加 cutout 选择（None / Notch / PunchHole / Waterfall）
+  - 实时显示预览尺寸
+- [ ] `P0-UI-05` 重写 `ui/DeviceProfileSheet.kt`：
+  - 按 formFactor 分组：Phone / Foldable / Tablet / Watch / Custom
+  - 每行显示：设备名、分辨率、宽 dp、关键 cutout 标识
+  - 真实缩略图（用 `Canvas` 画设备外形，标 cutout 位置）
 
-### DOC
+### ViewModel 状态
 
-- [ ] `P0-DOC-01` 编写 `DESIGN.md`（已完成）
-- [ ] `P0-DOC-02` 编写 `TODO.md`（本文件）
-- [ ] `P0-DOC-03` PR body 引用本文件
+- [ ] `P0-UI-06` 增强 `PreviewConfig.kt`：
+  - 增字段 `fontScale: Float?` / `isLightDark: Boolean = false` / `parameterProviderName: String?`
+- [ ] `P0-UI-07` 增强 `PreviewState.kt`：
+  - 增 `data class DeviceConfig`（profile / systemBarsTheme / showStatusBar / showCutout / showChassis）
+  - 增 `data class ViewportState`（zoom / offsetX / offsetY / fitMode）
+  - 在 `Ready` 中携带 `deviceConfig` / `viewport`
+- [ ] `P0-UI-08` 重写 `ComposePreviewViewModel.kt`：
+  - 加 StateFlow：`deviceConfig` / `viewport` / `displayMode` / `selectedPreview` / `availablePreviews` / `systemBarsTheme` / `debugEnabled` / `buildTimings`
+  - 提供方法：`selectDevice(profile)` / `setZoom(scale)` / `setSystemBarsTheme(theme)` / `resetViewport()` / `toggleDebug()`
+  - 序列化/恢复 `ViewportState` 到 `SavedStateHandle`（配置变化时保留）
+
+### Domain 解析
+
+- [ ] `P0-DOM-01` 增强 `domain/PreviewSourceParser.kt`：
+  - 支持 `@PreviewParameter(provider = ...)` → 解析 provider 类名
+  - 支持 `@PreviewFontScale = 1.5f` → 解析 fontScale
+  - 支持 `@PreviewLightDark` → 标记 isLightDark
+  - 全部走纯正则（不上 PSI），K2 真实解析在后续 PR
+
+### DOC 文档
+
+- [ ] `P0-DOC-01` 编写 / 更新 `DESIGN.md`（v2.1 完整重写）✅
+- [ ] `P0-DOC-02` 编写 / 更新 `TODO.md`（本文件）✅
+- [ ] `P0-DOC-03` PR body 引用本文件章节
 
 ### TS 测试
 
-- [ ] `P0-TS-01` 单元测试：`AssetsComposeBundles` 解压 / 校验
-- [ ] `P0-TS-02` 单元测试：`MethodHandleResolver` 缓存命中
-- [ ] `P0-TS-03` 端到端：沙箱构建机冷启动 → 编译 → 渲染（手动）
+- [ ] `P0-TS-01` 单元测试：`CutoutGeometry` 各子类渲染参数
+- [ ] `P0-TS-02` 单元测试：`DeviceCatalog.byFormFactor` / `byId` 查询
+- [ ] `P0-TS-03` 单元测试：`BuildPhaseTimings.totalMs` 计算
+- [ ] `P0-TS-04` 端到端：沙箱构建机冷启动 → 编译 → 渲染（手动）
+- [ ] `P0-TS-05` 设备模拟视觉回归：5 种形态截图对比
 
 ---
 
-## P1 — 下一 PR（功能完整化）
+## P1 — 下一轮 PR（功能完整化）
 
-### UI 设备模拟
+### 调试面板
 
-- [ ] `P1-UI-01` `ui/DeviceFrame.kt`：
-  - 圆角、刘海、状态栏样式
-  - 内置 Pixel 4 / 5 / 6 / 7、Tablet、Foldable
-- [ ] `P1-UI-02` `ui/DeviceProfileSheet.kt`：
-  - 底部 Sheet 选择设备
-  - 写入 SharedPreferences
-- [ ] `P1-UI-03` `ui/ResolutionEditor.kt`：
-  - 弹窗编辑 width × height × DPI
-  - 实时预览
+- [ ] `P1-UI-01` 新增 `ui/DebugDrawer.kt`：
+  - 底部 ModalBottomDrawer
+  - 标签页：Inspector / Recompose / Logcat / Stats
+  - 默认折叠，点击展开
+- [ ] `P1-UI-02` 重写 `ui/ComponentInspector.kt`：
+  - 实现 `LayoutNodeInspector` 反射读 `LayoutNode.coordinates` / `width` / `height` / `x` / `y`
+  - 画边界框（1dp 红色矩形 + 节点名 overlay）
+  - 属性面板：bounds / parent / modifier chain（简化）
+- [ ] `P1-UI-03` 增强 `ui/RecompositionCounter.kt`：
+  - 真实挂载到 `RenderComposable`：每次 recompose `tick()`
+  - 在 `DebugDrawer` 显示每个 Composable 的计数
+  - 提供 "高亮重排" 开关（> 5 次的 Composable 角标变红）
+- [ ] `P1-UI-04` 新增 `ui/LogcatPanel.kt`：
+  - 实现 `PreviewPrintStream` 替换 `System.out`
+  - 捕获 `println` / `Log.d` / `Log.w` / `Log.e`
+  - 显示级别 / 时间 / 内容
+  - 支持过滤 / 折叠 / 清空
+- [ ] `P1-UI-05` 性能 Stats 标签页：
+  - 显示 `BuildPhaseTimings` 各阶段耗时
+  - 显示 dex 缓存命中率
+  - 显示 `MethodHandleResolver` 缓存大小
 
-### UI 缩放
+### 物理键 / 折叠完善
 
-- [ ] `P1-UI-04` `ui/ZoomController.kt`：
-  - pinch 手势识别
-  - Ctrl + Wheel 缩放
-  - 双击切换 Fit / 100%
-  - 缩放范围 0.1x ~ 4x
+- [ ] `P1-DEV-01` 在 `DeviceFrame` 渲染 `PhysicalKey`：
+  - 电源键 / 音量 ± / 相机键（按设备）
+  - 简单矩形 + 文字（不做 3D 仿真）
+- [ ] `P1-DEV-02` 折叠屏内 / 外屏自动切换：
+  - 检测 `Jetpack WindowManager` 的 `FoldingFeature`
+  - 模拟器场景：手动按钮切换 inner/outer
 
-### UI 主题
+### 预览源解析增强
 
-- [ ] `P1-UI-05` `ui/ThemeSelector.kt`：
-  - Light / Dark / Custom 三选
-  - Custom 时显示颜色编辑器
-  - 反射注入 MaterialTheme / Custom ColorScheme
+- [ ] `P1-DOM-01` `@PreviewFontScale` 完整支持：
+  - 解析 `fontScale = 1.5f`
+  - 渲染时包 `CompositionLocalProvider(LocalDensity provides ...)` 注入
+- [ ] `P1-DOM-02` `@PreviewLightDark` 支持：
+  - 同时生成两张 preview：Light + Dark
+  - 网格模式下并排展示
+- [ ] `P1-DOM-03` `@PreviewParameter` 支持（无参构造 Provider）：
+  - 解析 `provider = MyProvider::class`
+  - 反射 `MyProvider()` 无参构造
+  - 调用 `provider.values`（Sequence）取第一项
+  - 注入为 Composable 最后一个参数
 
-### UI 多 Preview 网格
+### 多 Preview 网格
 
-- [ ] `P1-UI-06` `ui/PreviewGridLayout.kt`：
-  - AS 风格卡片网格
-  - 单击切换 SINGLE 模式
-- [ ] `P1-DOM-01` `domain/PreviewSourceParser.kt`：
-  - 支持 `@PreviewParameter`
-  - 支持 `@PreviewFontScale`
-  - 支持 `@PreviewLightDark` 同时生成两张
+- [ ] `P1-UI-06` 新增 `ui/PreviewGridLayout.kt`：
+  - AS 风格卡片网格：自适应列数（按屏宽）
+  - 每张卡片：设备缩略图 + Composable 名 + 缩放按钮
+  - 单击进入 SINGLE 模式
 
-### FE 反射优化
+### 主题
 
-- [ ] `P1-FE-01` `runtime/PrewarmService.kt`：
-  - 启动时预热 Compose runtime 关键 class
-  - 触发 `Class.forName` 提前验证
+- [ ] `P1-UI-07` 增强 `ui/ThemeSelector.kt`：
+  - Light / Dark / Custom
+  - Custom 时弹 `ColorSchemeEditor`（Material3 ColorScheme 全字段）
+  - 持久化到 SharedPreferences
 
----
+### UI 集成细节
 
-## P2 — 第三轮 PR（调试工具）
-
-### UI 调试
-
-- [ ] `P2-UI-01` `ui/RecompositionCounter.kt`：
-  - 通过 `Modifier.composed` + `currentRecomposeScope` 计数
-  - 角标显示在每个 Composable 框上
-- [ ] `P2-UI-02` `ui/ComponentInspector.kt`：
-  - 反射读 `LayoutNode` 私有字段（`width`, `height`, `x`, `y`）
-  - 绘制边界框
-  - 单击节点高亮
-- [ ] `P2-UI-03` `ui/LogcatPanel.kt`：
-  - 拦截用户 `println` / `Log.d`
-  - 折叠 / 展开
-- [ ] `P2-UI-04` `ui/LayoutBoundsOverlay.kt`：
-  - 复用 AS 的 bounds 高亮
-  - 可开关
-
-### FE 高级特性
-
-- [ ] `P2-FE-01` 颜色拾取：
-  - 截图后采样像素
-  - 显示 RGB / HEX
-- [ ] `P2-FE-02` LiveLiterals（实验）：
-  - 反射修改 `LiveLiterals$*`
-  - 需 K2 编译器支持
-- [ ] `P2-FE-03` 拖动 / Resize：
-  - `Modifier.pointerInput` + `detectDragGestures`
-  - 改写 width/height Modifier
+- [ ] `P1-UI-08` 弃用 `ComposePreviewFragment.kt`：
+  - 标记 `@Deprecated`
+  - 把 ComposePreviewFragment 的代码迁到 Activity
 
 ---
 
-## P3 — 第四轮 PR（性能与可观测性）
+## P2 — 性能与字节码加速（PR #N+3 / #N+5）
 
-- [ ] `P3-FE-01` Dex mmap + 共享：`assets/compose/dex/compose-runtime.dex` 在多个 Preview 间共享
-- [ ] `P3-FE-02` 编译产物复用：同一源码不重复 dex
-- [ ] `P3-FE-03` 性能埋点：编译 / 渲染各阶段耗时日志
-- [ ] `P3-FE-04` 错误聚合：把多次编译错误的栈合并去重
-- [ ] `P3-FE-05` 远程调试：预留端口供 `adb forward` 直连 Preview
-- [ ] `P3-FE-06` Live Edit（Hot Reload）：仅在 incremental 模式
+### 字节码加速（核心 P2）
+
+- [ ] `P2-BLD-01` 新增 `compiler/AsmComposeBinder.kt`：
+  - 用 ASM 9.7 + asm-commons 读 `.class`
+  - Pass 1：扫描 `Method` 上的 `@Composable` 注解（注解在 `kotlin/Metadata` 里）
+  - Pass 2：对每个含 `(Composer, int)` 形参的 `@Composable fun`，在 `binder/` 包下生成 `Binder$FunName.class`：
+    ```java
+    public final class Binder$MyComposable {
+      private static final MethodHandle HANDLE;
+      static {
+        HANDLE = MethodHandles.lookup().unreflect(
+          PreviewKt.class.getDeclaredMethod("MyComposable", Composer.class, int.class)
+        );
+      }
+      public static void invoke(Composer c, int changed) {
+        HANDLE.invokeWithArguments(c, changed);
+      }
+    }
+    ```
+  - Pass 3：把 binder `.class` 输出到 `<workDir>/binder/`
+- [ ] `P2-BLD-02` 新增 `compiler/BytecodeCache.kt`：
+  - key = `sourceHash + asmVersion`
+  - value = `<workDir>/binder/` 目录
+  - 缓存命中时跳过整个 ASM pass
+- [ ] `P2-BLD-03` 增强 `BundledD8Dexer`：
+  - 接受 `binderDir` 作为额外输入
+  - 产物：`preview.dex` + `binders.dex`（与运行时 `<bundle>` 合并）
+- [ ] `P2-RT-01` 新增 `runtime/AsmBinderInvoker.kt`：
+  - 提供 `tryGetBinder(dexFile, className, functionName): MethodHandle?`
+  - 优先于 `MethodHandleResolver`
+- [ ] `P2-RT-02` 增强 `runtime/ComposableRenderer.kt`：
+  - 渲染时优先查 `AsmBinderInvoker`
+  - binder 命中 → `binder.invoke(c, 0)`
+  - binder 未命中 → fallback `MethodHandleResolver`
+- [ ] `P2-BLD-04` Dex layout 优化（可选）：
+  - 用 ASM `ClassWriter` 重排 method 顺序，让 binder 排在最前
+  - 提升 ICache 命中率
+
+### 运行时优化
+
+- [ ] `P2-RT-03` 增强 `runtime/ComposeClassLoader.kt`：
+  - 实现 LRU 驱逐（最多 10 个 loader）
+  - 增加 `releaseEldest()` 钩子
+  - 提供 `loadShared(dexBytes: ByteArray): ClassLoader` 用 `InMemoryDexClassLoader` 共享 dex
+- [ ] `P2-RT-04` 新增 `compiler/ComposeRuntimePrewarm.kt`：
+  - 启动时 `Class.forName(name, false, classLoader)` 预热 30+ 关键类
+  - 写入 `BuildPhaseTimings` 一段
+- [ ] `P2-BLD-05` 新增 `compiler/DexSharedLibraryLoader.kt`：
+  - 把 `compose-runtime.dex` 用 `InMemoryDexClassLoader` 加载到主进程
+  - ComposeClassLoader 复用，避免重复 dex
+
+### 性能埋点
+
+- [ ] `P2-FE-01` 完善 `BuildPhaseTimings`：
+  - 7 段耗时都真实采集
+  - 在 `DebugDrawer.Stats` 标签页展示
+  - 写一行结构化日志（JSON）便于后续分析
+
+### 可视化编辑
+
+- [ ] `P2-UI-09` 新增 `ui/ColorPickerOverlay.kt`：
+  - 在 Composable 截图上叠加 color picker
+  - 取像素 → 显示 HEX / RGB
+  - 写入剪贴板
+- [ ] `P2-UI-10` 新增 `ui/LayoutBoundsOverlay.kt`：
+  - 反射读 `LayoutNode` 画 1dp 红色矩形
+  - 开关：默认关
+- [ ] `P2-UI-11` `Modifier.editable`：
+  - 拖动 Composable
+  - 8 控制点 resize
+  - 实时修改 padding / size
+- [ ] `P2-UI-12` `Modifier.inspector`：
+  - 点击节点高亮
+  - 在 DebugDrawer 展示该节点的 properties
 
 ---
 
-## 验收清单
+## P3 — 探索（PR #N+7+）
 
-每完成一个 PR，需勾选：
+- [ ] `P3-FE-01` LiveLiterals 实验：
+  - 反射修改 `LiveLiterals$*` 类的 `IntState` / `StringState` 值
+  - Compose 编译器需开启 `-P plugin:androidx.compose.compiler.plugins.kotlin:liveLiterals=true`
+  - 最小可用版本
+- [ ] `P3-FE-02` Hot Reload（incremental）：
+  - 监听 `.kt` 文件变更
+  - 增量重编（只编变更文件）→ 重新 dex → 刷新 ComposeView
+- [ ] `P3-FE-03` 远程调试：
+  - 预留端口供 `adb forward tcp:xxx tcp:xxx`
+  - 外部 IDE 可直连 Preview 进程 dump 状态
+- [ ] `P3-FE-04` K2 PSI 解析（取代正则）：
+  - 集成 `kotlin-compiler-embeddable` 的 PSI 入口
+  - 准确解析 `@Preview` 全部参数（含 KDoc / annotation arguments）
+  - 解析 `@Composable fun` 真实签名
 
-- [ ] 模块编译通过 (`./gradlew :modules:compose-preview:assembleDebug`)
-- [ ] Lint 通过 (`./gradlew :modules:compose-preview:lintDebug`)
-- [ ] 单元测试通过 (`./gradlew :modules:compose-preview:testDebugUnitTest`)
+---
+
+## P4 — 体验打磨
+
+- [ ] `P4-UI-01` 工具栏动画：
+  - 设备切换时缩放动画
+  - 主题切换时颜色渐变
+- [ ] `P4-UI-02` 设备缩略图：
+  - 用 `Canvas` 画真实设备外形（基于 `DeviceProfile`）
+  - 包含 cutout 标识
+- [ ] `P4-UI-03` 键盘快捷键：
+  - `Ctrl+1/2/3`：切换主题
+  - `Ctrl+D`：切换设备 Sheet
+  - `Ctrl+L`：切换 DebugDrawer
+  - `F` 键：Fit；`1` 键：100%
+- [ ] `P4-UI-04` 辅助功能（a11y）：
+  - TalkBack 描述（设备名 / 分辨率 / 主题）
+  - 高对比度模式
+- [ ] `P4-UI-05` 右键菜单：
+  - 单 Composable 复制路径
+  - 导出当前 Preview 截图
+  - 在 Finder 打开 class
+- [ ] `P4-DEV-01` 国际化：
+  - 工具栏文字（zh / en / ja / ko）
+  - 设备名（保留原名）
+- [ ] `P4-FE-01` 设备自定义：
+  - 用户可上传 JSON 自定义设备
+  - 持久化到 `assets/user_devices.json`
+
+---
+
+## 验收清单（每个 PR 必跑）
+
+- [ ] 模块编译通过：
+      `./gradlew :modules:compose-preview:assembleDebug`
+- [ ] Lint 通过：
+      `./gradlew :modules:compose-preview:lintDebug`
+- [ ] 单元测试通过：
+      `./gradlew :modules:compose-preview:testDebugUnitTest`
 - [ ] 沙箱无 `.m2` 环境下冷启动可渲染
+- [ ] 5 种设备形态（Phone/Notch/PunchHole/Waterfall/Foldable）视觉回归通过
 - [ ] PR 描述引用本 TODO 章节
 - [ ] `DESIGN.md` 同步更新（如有架构变动）
+- [ ] 至少 1 张截图（Phone + Foldable 形态）
 
 ---
 
-最后更新：2026-06-13
+## 文件改动总览（v2.1 全部 PR）
+
+| 类别 | 新增 | 重写 | 增强 / 保留 |
+| --- | --- | --- | --- |
+| Build | 4 (AsmComposeBinder, BytecodeCache, ComposeRuntimePrewarm, DexSharedLibraryLoader) | 0 | 6 |
+| Runtime | 1 (AsmBinderInvoker) | 0 | 3 |
+| UI / 交互 | 13 (PreviewToolbar, DebugDrawer, ColorPickerOverlay, LayoutBoundsOverlay, LogcatPanel, PreviewGridLayout, ModifierInspector, PreviewContextMenu, PreviewGridLayout 等) | 5 (DeviceFrame, DeviceProfile, DeviceProfileSheet, ComponentInspector, ComposePreviewActivity) | 8 |
+| Data | 3 (DeviceCatalog, CutoutGeometry, PhysicalKey) | 0 | 1 |
+| Domain | 0 | 0 | 2 (PreviewSourceParser, ParsedPreviewSource) |
+| 入口 | 0 | 1 (ComposePreviewActivity) | 0 |
+| 资源 | 6 (device_profiles.xml, cutout_geometries.xml, strings_preview.xml, 3 类 drawable) | 0 | 0 |
+| 文档 | 0 | 2 (DESIGN.md, TODO.md) | 0 |
+
+总计：**新增 ~27 个文件，重写 ~8 个文件，增强 ~20 个文件。**
+
+---
+
+最后更新：2026-06-14


### PR DESCRIPTION
## Summary

完整重写 `modules/compose-preview/DESIGN.md` 和 `TODO.md` 为 v2.1 版本，补全 v2 PR (#328 f8227aa) 之后的设计与待办事项。

## DESIGN.md (979 行)

### 1. 现状评估
v2 已落地但仍需补全的部分（DeviceFrame 简陋 / 状态栏单一 / 可视化编辑缺失 / UI 集成不完整等）

### 2. 真实设备模拟子系统
- `DeviceProfile` 扩字段 (formFactor / screenGeometry / cutout / bezels / chassisColor / physicalKeys / statusBarHeightDp / navigationBarHeightDp)
- `CutoutGeometry` sealed class (Notch / PunchHole / WaterfallCurve)
- 30+ 真实设备清单:
  - Phone: Pixel 7/7 Pro/8/8 Pro, 华为 Mate 60 Pro, P30 Pro (瀑布), 小米 14 Pro, S24 Ultra, S23, OnePlus 12, Honor Magic 6 Pro
  - iPhone: 13 / 14 / 15 Pro / 15 Pro Max
  - Foldable: Z Fold 5 (内+外) / Pixel Fold (内+外) / OPPO Find N3 (内+外)
  - Tablet: Pixel Tablet / iPad Pro 11" / iPad Pro 12.9" / Galaxy Tab S9
  - Watch: Wear OS Small (384²) / Large (454²) / Square (390²)
  - Desktop: 1920×1080

### 3. 系统状态栏子系统
- `SystemBarsTheme` (AUTO / LIGHT / DARK / TRANSLUCENT_LIGHT / TRANSLUCENT_DARK)
- 时钟 (10s 刷新) / 电池 / Wi-Fi / 信号 / 通知红点
- 持久化

### 4. 字节码加速子系统 (ASM)
- `AsmComposeBinder` 生成静态 binder 替代反射 invoke
- Dead code strip / DexLayoutOptimizer
- `BytecodeCache` / `AsmBinderInvoker`
- 性能预期 (binder vs 反射 8-16x 提升)

### 5. BuildPhaseTimings 七段耗时
- assetsInitMs / cacheLookupMs / sourcePrepareMs / k2CompileMs / asmTransformMs / d8DexMs / cacheWriteMs

### 6. 风险与缓解 / IDEA / AS 对标表 / PR #N~#N+7 拆分

## TODO.md (394 行)

### 8 个里程碑 M0~M8
- M0: v2 完成 (f8227aa)
- M1: v2.1 设计落地 (本 PR + 后续 P0 实现)
- M2~M8: 后续 PR 计划

### P0 (本轮 PR #N 必修)
- BLD 构建阶段: 6 子任务
- DEV 真实设备模拟: 8 子任务
- UI 集成 / ViewModel / Domain / DOC / TS: 14 子任务

### P1~P4
- P1 (PR #N+1/#N+4/#N+6): DebugDrawer / Inspector / Recompose / Logcat; 物理键 / 折叠完善; @PreviewParameter/FontScale/LightDark
- P2 (PR #N+3/#N+5): ASM 字节码加速; Prewarm; DEX mmap 共享; 性能埋点
- P3 (探索): LiveLiterals / Hot Reload / 远程调试
- P4 (打磨): 工具栏动画 / 设备缩略图 / 快捷键 / a11y

## 验收清单 + 文件改动总览 (新增 ~27 / 重写 ~8 / 增强 ~20)

Refs: TODO.md