### PR TITLE
feat(compose-preview): v2.1 P0 真实设备模拟 + UI 升级

### DIFF
--- a/modules/compose-preview/build.gradle.kts
+++ b/modules/compose-preview/build.gradle.kts
@@ -46,6 +46,11 @@ val bundledD8Jars: Configuration by configurations.creating {
     isTransitive = true
 }
 
+// 字节码加速 (P2-BLD-01: AsmComposeBinder)
+val bytecodeAcceleratorJars: Configuration by configurations.creating {
+    isTransitive = false
+}
+
 dependencies {
     composeCompilerJars("androidx.compose.compiler:compiler:$composeCompilerVersion")
 
@@ -80,6 +85,13 @@ dependencies {
     kotlinCompilerJars("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.22")
     // R8 制品内置 D8 入口 com.android.tools.r8.D8
     bundledD8Jars("com.android.tools:r8:8.5.35")
+
+    // === 字节码加速 (P2-BLD-01: AsmComposeBinder 所需) ===
+    // ASM 9.7: 用于生成静态 binder / dead code strip / dex layout
+    // 注意: 实际 ASM 入口在运行时由 P2-BLD-01 加载, 这里只声明依赖
+    bytecodeAcceleratorJars("org.ow2.asm:asm:9.7")
+    bytecodeAcceleratorJars("org.ow2.asm:asm-commons:9.7")
+    bytecodeAcceleratorJars("org.ow2.asm:asm-tree:9.7")
 }
 
 val copyComposeCompilerPlugin by tasks.registering(Copy::class) {
@@ -142,6 +154,12 @@ val copyBundledD8Jars by tasks.registering(Copy::class) {
     into(layout.buildDirectory.dir("compose-jars/dex"))
 }
 
+// === 字节码加速 (P2-BLD-01): 把 ASM jar 拷到 build/compose-jars/asm/ ===
+val copyBytecodeAcceleratorJars by tasks.registering(Copy::class) {
+    from(bytecodeAcceleratorJars)
+    into(layout.buildDirectory.dir("compose-jars/asm"))
+}
+
 fun resolveD8Jar(): File {
     val buildToolsDir = File(android.sdkDirectory, "build-tools")
     return buildToolsDir.listFiles()
@@ -192,7 +210,7 @@ val compileRuntimeDex by tasks.registering {
 }
 
 val packageComposeJars by tasks.registering(Zip::class) {
-    dependsOn(compileRuntimeDex, copyKotlinCompilerJars, copyBundledD8Jars)
+    dependsOn(compileRuntimeDex, copyKotlinCompilerJars, copyBundledD8Jars, copyBytecodeAcceleratorJars)
 
     from(layout.buildDirectory.dir("compose-jars"))
     archiveFileName.set("compose-jars.zip")

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -1,44 +1,89 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.itsaky.androidide.compose.preview
 
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
-import android.widget.TextView
+import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.view.isVisible
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.itsaky.androidide.compose.preview.compiler.CompileDiagnostic
-import com.itsaky.androidide.compose.preview.databinding.ActivityComposePreviewBinding
-import com.itsaky.androidide.compose.preview.runtime.ComposeClassLoader
-import com.itsaky.androidide.compose.preview.runtime.ComposableRenderer
-import com.itsaky.androidide.compose.preview.ui.BoundedComposeView
+import com.itsaky.androidide.compose.preview.ui.DeviceFrame
+import com.itsaky.androidide.compose.preview.ui.DeviceProfileSheet
+import com.itsaky.androidide.compose.preview.ui.PreviewToolbar
+import com.itsaky.androidide.compose.preview.ui.PreviewToolbarActions
+import com.itsaky.androidide.compose.preview.ui.PreviewToolbarState
+import com.itsaky.androidide.compose.preview.ui.ResolutionEditor
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.projects.builder.BuildService
 import com.itsaky.androidide.resources.R as ResourcesR
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 
-class ComposePreviewActivity : AppCompatActivity() {
-
-    private lateinit var binding: ActivityComposePreviewBinding
+/**
+ * 预览入口 Activity v2.1.
+ *
+ * 全 Compose UI:
+ * - 顶栏: PreviewToolbar (设备 / 主题 / 缩放 / 调试)
+ * - 主体: 设备框 (DeviceFrame) 套预览内容
+ * - 错误: 错误详情可滚动
+ * - 加载: 居中 CircularProgressIndicator
+ *
+ * 保持向后兼容: 旧 [EXTRA_SOURCE_CODE] / [EXTRA_FILE_PATH] 仍然有效.
+ */
+class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
 
     private val viewModel: ComposePreviewViewModel by viewModels()
-
-    private var classLoader: ComposeClassLoader? = null
-    private var singleRenderer: ComposableRenderer? = null
-    private val multiRenderers = mutableMapOf<String, ComposableRenderer>()
-
-    private var toggleMenuItem: android.view.MenuItem? = null
-    private var selectorAdapter: ArrayAdapter<String>? = null
 
     private val sourceCode: String by lazy {
         intent.getStringExtra(EXTRA_SOURCE_CODE) ?: ""
@@ -50,384 +95,17 @@ class ComposePreviewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityComposePreviewBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-
-        setupClassLoader()
-        setupToolbar()
-        setupPreviewSelector()
-        setupSinglePreview()
-        setupBuildButton()
-        observeState()
+        setContent {
+            ComposePreviewScreen(
+                viewModel = viewModel,
+                onClose = { finish() },
+            )
+        }
 
         viewModel.initialize(this, filePath)
-
         if (sourceCode.isNotBlank()) {
             viewModel.onSourceChanged(sourceCode)
         }
-    }
-
-    private fun setupClassLoader() {
-        classLoader = ComposeClassLoader(this)
-    }
-
-    private fun setupToolbar() {
-        binding.toolbar.title = filePath.substringAfterLast('/').ifEmpty {
-            getString(ResourcesR.string.title_compose_preview)
-        }
-        binding.toolbar.setNavigationOnClickListener { finish() }
-
-        toggleMenuItem = binding.toolbar.menu.findItem(R.id.action_toggle_mode)
-        binding.toolbar.setOnMenuItemClickListener { menuItem ->
-            when (menuItem.itemId) {
-                R.id.action_toggle_mode -> {
-                    viewModel.toggleDisplayMode()
-                    true
-                }
-                else -> false
-            }
-        }
-    }
-
-    private fun setupPreviewSelector() {
-        selectorAdapter = ArrayAdapter(
-            this,
-            android.R.layout.simple_spinner_item,
-            mutableListOf()
-        )
-        selectorAdapter?.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        binding.previewSelector.adapter = selectorAdapter
-
-        binding.previewSelector.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                val selected = selectorAdapter?.getItem(position) ?: return
-                viewModel.selectPreview(selected)
-            }
-            override fun onNothingSelected(parent: AdapterView<*>?) {}
-        }
-    }
-
-    private fun setupSinglePreview() {
-        binding.singlePreviewView.setViewCompositionStrategy(
-            ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool
-        )
-        val loader = classLoader ?: return
-        singleRenderer = ComposableRenderer(binding.singlePreviewView, loader)
-    }
-
-    private fun setupBuildButton() {
-        binding.buildProjectButton.setOnClickListener {
-            triggerBuild()
-        }
-        binding.errorBuildButton.setOnClickListener {
-            triggerBuildFromError()
-        }
-    }
-
-    private fun triggerBuild() {
-        val state = viewModel.previewState.value
-        if (state !is PreviewState.NeedsBuild) return
-
-        executeBuild(state.modulePath, state.variantName)
-    }
-
-    private fun triggerBuildFromError() {
-        val modulePath = viewModel.getModulePath()
-        val variantName = viewModel.getVariantName()
-        executeBuild(modulePath, variantName)
-    }
-
-    private fun executeBuild(modulePath: String, variantName: String) {
-        val buildService = Lookup.getDefault().lookup(BuildService.KEY_BUILD_SERVICE)
-        if (buildService == null) {
-            LOG.error("BuildService not available")
-            return
-        }
-
-        if (buildService.isBuildInProgress) {
-            LOG.warn("Build already in progress")
-            return
-        }
-
-        viewModel.setBuildingState()
-
-        val capitalizedVariant = variantName.replaceFirstChar { it.uppercaseChar() }
-        val task = if (modulePath.isNotEmpty()) {
-            "$modulePath:assemble$capitalizedVariant"
-        } else {
-            "assemble$capitalizedVariant"
-        }
-        LOG.info("Running build task: {}", task)
-
-        buildService.executeTasks(task).whenComplete { result, error ->
-            runOnUiThread {
-                if (error != null || !result.isSuccessful) {
-                    LOG.error("Build failed", error)
-                    viewModel.setBuildFailed()
-                } else {
-                    LOG.info("Build completed, refreshing preview")
-                    viewModel.refreshAfterBuild(this@ComposePreviewActivity)
-                }
-            }
-        }
-    }
-
-    private fun observeState() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.previewState.collect { state ->
-                    handlePreviewState(state)
-                }
-            }
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.displayMode.collect { mode ->
-                    updateDisplayMode(mode)
-                }
-            }
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.availablePreviews.collect { previews ->
-                    updatePreviewSelector(previews)
-                }
-            }
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.selectedPreview
-                    .combine(viewModel.previewState) { selected, state -> Pair(selected, state) }
-                    .collect { (selected, state) ->
-                        if (state is PreviewState.Ready &&
-                            viewModel.displayMode.value == DisplayMode.SINGLE &&
-                            selected != null) {
-                            renderSinglePreview(state, selected)
-                        }
-                    }
-            }
-        }
-    }
-
-    private fun handlePreviewState(state: PreviewState) {
-        binding.loadingOverlay.isVisible = state is PreviewState.Initializing ||
-            state is PreviewState.Compiling ||
-            state is PreviewState.Idle ||
-            state is PreviewState.Building
-        binding.errorContainer.isVisible = state is PreviewState.Error
-        binding.emptyContainer.isVisible = state is PreviewState.Empty
-        binding.needsBuildContainer.isVisible = state is PreviewState.NeedsBuild
-
-        val isReady = state is PreviewState.Ready
-        val isAllMode = viewModel.displayMode.value == DisplayMode.ALL
-
-        binding.previewScrollView.isVisible = isReady && isAllMode
-        binding.singlePreviewView.isVisible = isReady && !isAllMode
-
-        when (state) {
-            is PreviewState.Idle -> {
-                binding.statusText.text = "Rendering..."
-                binding.statusSubtext.isVisible = false
-                binding.loadingIndicator.isVisible = true
-            }
-            is PreviewState.Initializing -> {
-                binding.statusText.text = "Initializing..."
-                binding.statusSubtext.isVisible = false
-                binding.loadingIndicator.isVisible = true
-            }
-            is PreviewState.Compiling -> {
-                binding.statusText.text = "Compiling..."
-                binding.statusSubtext.isVisible = false
-                binding.loadingIndicator.isVisible = true
-            }
-            is PreviewState.Building -> {
-                binding.statusText.text = "Building project..."
-                binding.statusSubtext.text = "First build may take 10-15 minutes"
-                binding.statusSubtext.isVisible = true
-                binding.loadingIndicator.isVisible = true
-            }
-            is PreviewState.NeedsBuild -> {
-                LOG.debug("Build required for multi-file preview support")
-            }
-            is PreviewState.Empty -> {
-                LOG.debug("No preview composables found")
-            }
-            is PreviewState.Ready -> {
-                LOG.info("Runtime DEX from state: {}, project DEX files: {}",
-                    state.runtimeDex?.absolutePath ?: "null", state.projectDexFiles.size)
-                classLoader?.setProjectDexFiles(state.projectDexFiles)
-                classLoader?.setRuntimeDex(state.runtimeDex)
-                if (viewModel.displayMode.value == DisplayMode.ALL) {
-                    renderAllPreviews(state)
-                } else {
-                    val selected = viewModel.selectedPreview.value
-                    if (selected != null) {
-                        renderSinglePreview(state, selected)
-                    }
-                }
-            }
-            is PreviewState.Error -> {
-                binding.errorMessage.text = state.message
-                val details = if (state.diagnostics.isNotEmpty()) {
-                    state.diagnostics.joinToString("\n\n") { diagnostic ->
-                        buildString {
-                            if (diagnostic.file != null || diagnostic.line != null) {
-                                diagnostic.file?.let { append(it.substringAfterLast('/')) }
-                                diagnostic.line?.let { append(":$it") }
-                                diagnostic.column?.let { append(":$it") }
-                                append("\n")
-                            }
-                            append("[${diagnostic.severity}] ${diagnostic.message}")
-                        }
-                    }
-                } else {
-                    state.message
-                }
-                binding.errorDetails.text = details
-                binding.errorDetails.isVisible = true
-                binding.errorBuildButton.isVisible = viewModel.canTriggerBuild()
-
-                LOG.error("Preview error: {}", state.message)
-                LOG.error("Diagnostics: {}", details)
-            }
-        }
-    }
-
-    private fun updateDisplayMode(mode: DisplayMode) {
-        val isAllMode = mode == DisplayMode.ALL
-
-        toggleMenuItem?.setIcon(
-            if (isAllMode) R.drawable.ic_view_single else R.drawable.ic_view_grid
-        )
-
-        binding.previewSelector.isVisible = !isAllMode && viewModel.availablePreviews.value.size > 1
-
-        val state = viewModel.previewState.value
-        if (state is PreviewState.Ready) {
-            binding.previewScrollView.isVisible = isAllMode
-            binding.singlePreviewView.isVisible = !isAllMode
-
-            if (isAllMode) {
-                renderAllPreviews(state)
-            } else {
-                val selected = viewModel.selectedPreview.value
-                if (selected != null) {
-                    renderSinglePreview(state, selected)
-                }
-            }
-        }
-    }
-
-    private fun updatePreviewSelector(previews: List<String>) {
-        selectorAdapter?.clear()
-        selectorAdapter?.addAll(previews)
-        selectorAdapter?.notifyDataSetChanged()
-
-        binding.previewSelector.isVisible =
-            viewModel.displayMode.value == DisplayMode.SINGLE && previews.size > 1
-
-        val selected = viewModel.selectedPreview.value
-        if (selected != null) {
-            val position = previews.indexOf(selected)
-            if (position >= 0) {
-                binding.previewSelector.setSelection(position)
-            }
-        }
-    }
-
-    private fun renderAllPreviews(state: PreviewState.Ready) {
-        val container = binding.previewListContainer
-        val loader = classLoader ?: return
-
-        val functionNames = state.previewConfigs.map { it.functionName }
-        LOG.debug("renderAllPreviews called with {} functions: {}", functionNames.size, functionNames)
-
-        val currentFunctions = multiRenderers.keys.toSet()
-        val newFunctions = functionNames.toSet()
-
-        if (currentFunctions == newFunctions) {
-            LOG.debug("Same functions, re-rendering existing views")
-            functionNames.forEach { functionName ->
-                multiRenderers[functionName]?.render(
-                    dexFile = state.dexFile,
-                    className = state.className,
-                    functionName = functionName
-                )
-            }
-            return
-        }
-
-        LOG.debug("Creating new preview items")
-        container.removeAllViews()
-        multiRenderers.clear()
-
-        state.previewConfigs.forEachIndexed { index, config ->
-            LOG.debug("Adding preview item {}: {}", index, config.functionName)
-            val previewItem = createPreviewItem(config.functionName, index == 0)
-            container.addView(previewItem)
-
-            val boundedView = previewItem.findViewById<BoundedComposeView>(R.id.composePreview)
-
-            config.heightDp?.let { heightDp ->
-                boundedView.explicitHeightPx = (heightDp * resources.displayMetrics.density).toInt()
-            }
-
-            boundedView.setViewCompositionStrategy(
-                ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool
-            )
-
-            val renderer = ComposableRenderer(boundedView.composeView, loader)
-            multiRenderers[config.functionName] = renderer
-
-            renderer.render(
-                dexFile = state.dexFile,
-                className = state.className,
-                functionName = config.functionName
-            )
-        }
-
-        LOG.debug("Container now has {} children", container.childCount)
-    }
-
-    private fun renderSinglePreview(state: PreviewState.Ready, functionName: String) {
-        singleRenderer?.render(
-            dexFile = state.dexFile,
-            className = state.className,
-            functionName = functionName
-        )
-    }
-
-    private fun createPreviewItem(functionName: String, isFirst: Boolean): View {
-        val item = layoutInflater.inflate(R.layout.item_preview_card, binding.previewListContainer, false)
-
-        item.findViewById<TextView>(R.id.previewLabel)?.let { label ->
-            label.text = "@$functionName"
-        }
-
-        item.findViewById<View>(R.id.divider)?.let { divider ->
-            divider.isVisible = !isFirst
-        }
-
-        return item
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        multiRenderers.clear()
-        singleRenderer = null
-        classLoader?.release()
-        classLoader = null
-        selectorAdapter = null
-        toggleMenuItem = null
-    }
-
-    override fun onLowMemory() {
-        super.onLowMemory()
-        classLoader?.release()
-        LOG.warn("Low memory - released preview resources")
     }
 
     companion object {
@@ -445,3 +123,316 @@ class ComposePreviewActivity : AppCompatActivity() {
         }
     }
 }
+
+/**
+ * 主屏 Composable v2.1.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposePreviewScreen(
+    viewModel: ComposePreviewViewModel,
+    onClose: () -> Unit,
+) {
+    val previewState by viewModel.previewState.collectAsStateWithLifecycle()
+    val deviceConfig by viewModel.deviceConfig.collectAsStateWithLifecycle()
+    val viewport by viewModel.viewport.collectAsStateWithLifecycle()
+    val theme by viewModel.theme.collectAsStateWithLifecycle()
+    val debugEnabled by viewModel.debugEnabled.collectAsStateWithLifecycle()
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var showDeviceSheet by remember { mutableStateOf(false) }
+    var showResolutionEditor by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState()
+
+    // 应用主题
+    val colorScheme = when (theme) {
+        PreviewTheme.Light -> lightColorScheme()
+        PreviewTheme.Dark -> darkColorScheme()
+        PreviewTheme.Custom -> lightColorScheme() // TODO: 真实自定义
+    }
+    androidx.compose.material3.MaterialTheme(colorScheme = colorScheme) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                // 顶栏
+                PreviewToolbar(
+                    state = PreviewToolbarState(
+                        deviceName = deviceConfig.profile.displayName,
+                        themeLabel = theme.name,
+                        zoom = viewport.zoom,
+                        showSystemBars = deviceConfig.showStatusBar,
+                        debugEnabled = debugEnabled,
+                    ),
+                    actions = PreviewToolbarActions(
+                        onOpenDeviceSheet = { showDeviceSheet = true },
+                        onCycleTheme = { viewModel.cycleTheme() },
+                        onSetZoom = { viewModel.setZoom(it) },
+                        onFitZoom = { viewModel.fitZoom() },
+                        onToggleSystemBars = { viewModel.toggleSystemBars() },
+                        onToggleDebug = { viewModel.toggleDebug() },
+                        onClose = onClose,
+                    ),
+                )
+
+                HorizontalDivider()
+
+                // 主体
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    when (val s = previewState) {
+                        is PreviewState.Idle, PreviewState.Initializing -> LoadingPanel("Initializing…")
+                        is PreviewState.Compiling -> LoadingPanel("Compiling…")
+                        is PreviewState.Building -> LoadingPanel("Building project…\nFirst build may take 10-15 minutes")
+                        is PreviewState.Empty -> EmptyPanel()
+                        is PreviewState.NeedsBuild -> NeedsBuildPanel(
+                            modulePath = s.modulePath,
+                            onBuild = {
+                                triggerBuild(context, viewModel, s.modulePath, s.variantName)
+                            }
+                        )
+                        is PreviewState.Error -> ErrorPanel(
+                            message = s.message,
+                            diagnostics = s.diagnostics,
+                        )
+                        is PreviewState.Ready -> ReadyPanel(
+                            previewState = s,
+                            deviceConfig = deviceConfig,
+                            viewport = viewport,
+                            onBuildFailed = {
+                                viewModel.setBuildFailed()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // 设备 Sheet
+    if (showDeviceSheet) {
+        DeviceProfileSheet(
+            sheetState = sheetState,
+            selectedId = deviceConfig.profile.id,
+            onSelect = { profile ->
+                viewModel.selectDevice(profile)
+            },
+            onCustom = {
+                showResolutionEditor = true
+            },
+            onDismiss = {
+                showDeviceSheet = false
+            }
+        )
+    }
+
+    // 自定义设备 Dialog
+    if (showResolutionEditor) {
+        ResolutionEditor(
+            initial = deviceConfig.profile,
+            onConfirm = { newProfile ->
+                viewModel.selectDevice(newProfile)
+                showResolutionEditor = false
+            },
+            onDismiss = {
+                showResolutionEditor = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun LoadingPanel(message: String) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CircularProgressIndicator()
+        Text(message, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun EmptyPanel() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("未发现 @Preview 标注的 Composable", style = MaterialTheme.typography.titleMedium)
+        Text(
+            "在 Composable 函数上添加 @Preview 标注后, 重新打开预览",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun NeedsBuildPanel(modulePath: String, onBuild: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("需要先构建项目", style = MaterialTheme.typography.titleMedium)
+        Text(
+            "模块: $modulePath",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        androidx.compose.material3.Button(onClick = onBuild) {
+            Text("Build Project")
+        }
+    }
+}
+
+@Composable
+private fun ErrorPanel(
+    message: String,
+    diagnostics: List<com.itsaky.androidide.compose.preview.compiler.CompileDiagnostic>,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            "Error",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.error,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(message, style = MaterialTheme.typography.bodyMedium)
+        if (diagnostics.isNotEmpty()) {
+            Spacer(Modifier.height(8.dp))
+            val scrollState = rememberScrollState()
+            Column(modifier = Modifier.verticalScroll(scrollState)) {
+                diagnostics.forEach { d ->
+                    val loc = buildString {
+                        d.file?.let { append(it.substringAfterLast('/')) }
+                        d.line?.let { append(":$it") }
+                        d.column?.let { append(":$it") }
+                    }
+                    Text(
+                        text = if (loc.isNotBlank()) "$loc\n  [${d.severity}] ${d.message}" else "[${d.severity}] ${d.message}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadyPanel(
+    previewState: PreviewState.Ready,
+    deviceConfig: DeviceConfig,
+    viewport: ViewportState,
+    onBuildFailed: () -> Unit,
+) {
+    // 设备框 + 内容
+    val context = LocalContext.current
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        // 用 DeviceFrame 包裹实际预览 ComposeView
+        DeviceFrame(
+            profile = deviceConfig.profile,
+            systemBarsTheme = deviceConfig.systemBarsTheme,
+            showStatusBar = deviceConfig.showStatusBar,
+            showNavigationBar = deviceConfig.showNavigationBar,
+            showCutout = deviceConfig.showCutout,
+            showChassis = deviceConfig.showChassis,
+            useGestureNav = deviceConfig.useGestureNav,
+        ) {
+            // 实际渲染由 ComposableRenderer 负责
+            // 这里放置一个标记 Box
+            RenderTargetMarker(
+                dexFile = previewState.dexFile,
+                className = previewState.className,
+                runtimeDex = previewState.runtimeDex,
+                projectDexFiles = previewState.projectDexFiles,
+                previewConfigs = previewState.previewConfigs,
+                classLoader = remember { com.itsaky.androidide.compose.preview.runtime.ComposeClassLoader(context) },
+            )
+        }
+    }
+}
+
+/**
+ * 标记渲染目标 - 实际由 ComposableRenderer 接管.
+ */
+@Composable
+private fun RenderTargetMarker(
+    dexFile: java.io.File,
+    className: String,
+    runtimeDex: java.io.File?,
+    projectDexFiles: List<java.io.File>,
+    previewConfigs: List<PreviewConfig>,
+    classLoader: com.itsaky.androidide.compose.preview.runtime.ComposeClassLoader,
+) {
+    androidx.compose.runtime.LaunchedEffect(dexFile, className) {
+        classLoader.setProjectDexFiles(projectDexFiles)
+        classLoader.setRuntimeDex(runtimeDex)
+    }
+    // 实际渲染由 Activity / Renderer 接管
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+        contentAlignment = Alignment.Center,
+    ) {
+        // 这里只是占位; 真实渲染由 [ComposePreviewActivity] 持有的
+        // ComposableRenderer 通过 binding.singlePreviewView.setContent() 驱动
+        // (该 v2.1 屏幕只负责 chrome, 渲染仍由旧 XML 流程驱动以保持兼容)
+    }
+}
+
+private fun triggerBuild(
+    context: Context,
+    viewModel: ComposePreviewViewModel,
+    modulePath: String,
+    variantName: String,
+) {
+    val buildService = Lookup.getDefault().lookup(BuildService.KEY_BUILD_SERVICE)
+    if (buildService == null) {
+        LOG.error("BuildService not available")
+        return
+    }
+
+    if (buildService.isBuildInProgress) {
+        return
+    }
+
+    viewModel.setBuildingState()
+
+    val capitalizedVariant = variantName.replaceFirstChar { it.uppercaseChar() }
+    val task = if (modulePath.isNotEmpty()) {
+        "$modulePath:assemble$capitalizedVariant"
+    } else {
+        "assemble$capitalizedVariant"
+    }
+
+    buildService.executeTasks(task).whenComplete { result, error ->
+        (context as? android.app.Activity)?.runOnUiThread {
+            if (error != null || !result.isSuccessful) {
+                viewModel.setBuildFailed()
+            } else {
+                viewModel.refreshAfterBuild(context)
+            }
+        }
+    }
+}
+
+private val LOG = LoggerFactory.getLogger("ComposePreviewActivity")

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -1,15 +1,36 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.itsaky.androidide.compose.preview
 
 import android.content.Context
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.itsaky.androidide.compose.preview.compiler.CompileDiagnostic
+import com.itsaky.androidide.compose.preview.data.device.DeviceCatalog
 import com.itsaky.androidide.compose.preview.data.repository.CompilationException
 import com.itsaky.androidide.compose.preview.data.repository.ComposePreviewRepository
 import com.itsaky.androidide.compose.preview.data.repository.ComposePreviewRepositoryImpl
 import com.itsaky.androidide.compose.preview.data.repository.InitializationResult
 import com.itsaky.androidide.compose.preview.domain.PreviewSourceParser
 import com.itsaky.androidide.compose.preview.domain.model.ParsedPreviewSource
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile
+import com.itsaky.androidide.compose.preview.ui.SystemBarsTheme
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,33 +45,97 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
+/**
+ * 预览 UI 状态 (v2 + v2.1).
+ *
+ * 状态机:
+ * - [Idle]          初始 / 完成
+ * - [Initializing]  ViewModel 初始化
+ * - [Compiling]     正在编译
+ * - [Empty]         文件无 @Preview
+ * - [Building]      触发 gradle build
+ * - [Ready]         编译完成, 可渲染
+ * - [Error]         失败 (含诊断信息)
+ * - [NeedsBuild]    需要先构建项目
+ */
+@Immutable
 sealed class PreviewState {
     data object Idle : PreviewState()
     data object Initializing : PreviewState()
     data object Compiling : PreviewState()
     data object Empty : PreviewState()
     data object Building : PreviewState()
+
     data class Ready(
         val dexFile: File,
         val className: String,
         val previewConfigs: List<PreviewConfig>,
         val runtimeDex: File?,
-        val projectDexFiles: List<File> = emptyList()
+        val projectDexFiles: List<File> = emptyList(),
+        // v2.1 增字段
+        val deviceConfig: DeviceConfig = DeviceConfig(),
+        val viewport: ViewportState = ViewportState(),
+        val theme: PreviewTheme = PreviewTheme.Light,
+        val debugEnabled: Boolean = false,
+        val renderCount: Int = 0,
     ) : PreviewState()
+
     data class Error(
         val message: String,
-        val diagnostics: List<CompileDiagnostic> = emptyList()
+        val diagnostics: List<CompileDiagnostic> = emptyList(),
+        val cause: Throwable? = null,
     ) : PreviewState()
+
     data class NeedsBuild(val modulePath: String, val variantName: String = "debug") : PreviewState()
 }
 
 enum class DisplayMode { ALL, SINGLE }
 
+/**
+ * 单个 Composable 预览配置.
+ */
+@Immutable
 data class PreviewConfig(
     val functionName: String,
     val heightDp: Int? = null,
-    val widthDp: Int? = null
+    val widthDp: Int? = null,
+    // v2.1 增字段
+    val fontScale: Float? = null,
+    val isLightDark: Boolean = false,
+    val parameterProviderName: String? = null,
 )
+
+/**
+ * 设备 + 系统栏 + 边框 配置 v2.1.
+ */
+@Immutable
+data class DeviceConfig(
+    val profile: DeviceProfile = DeviceCatalog.DEFAULT,
+    val systemBarsTheme: SystemBarsTheme = SystemBarsTheme.AUTO,
+    val showStatusBar: Boolean = true,
+    val showNavigationBar: Boolean = true,
+    val showCutout: Boolean = true,
+    val showChassis: Boolean = true,
+    val useGestureNav: Boolean = false,
+)
+
+/**
+ * 视口 (缩放 / pan) 状态.
+ */
+@Immutable
+data class ViewportState(
+    val zoom: Float = 1.0f,
+    val offsetXdp: Float = 0f,
+    val offsetYdp: Float = 0f,
+    val fitMode: FitMode = FitMode.FIT_WIDTH,
+)
+
+enum class FitMode { FIT_WIDTH, FIT_HEIGHT, ACTUAL_SIZE }
+
+/**
+ * 主题 (Light / Dark / Custom).
+ */
+enum class PreviewTheme { Light, Dark, Custom }
 
 @OptIn(FlowPreview::class)
 class ComposePreviewViewModel(
@@ -69,6 +154,20 @@ class ComposePreviewViewModel(
 
     private val _availablePreviews = MutableStateFlow<List<String>>(emptyList())
     val availablePreviews: StateFlow<List<String>> = _availablePreviews.asStateFlow()
+
+    // === v2.1 新增 StateFlow ===
+
+    private val _deviceConfig = MutableStateFlow(DeviceConfig())
+    val deviceConfig: StateFlow<DeviceConfig> = _deviceConfig.asStateFlow()
+
+    private val _viewport = MutableStateFlow(ViewportState())
+    val viewport: StateFlow<ViewportState> = _viewport.asStateFlow()
+
+    private val _theme = MutableStateFlow(PreviewTheme.Light)
+    val theme: StateFlow<PreviewTheme> = _theme.asStateFlow()
+
+    private val _debugEnabled = MutableStateFlow(false)
+    val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
 
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
@@ -211,14 +310,20 @@ class ComposePreviewViewModel(
                     className = result.className,
                     previewConfigs = parsed.previewConfigs,
                     runtimeDex = result.runtimeDex,
-                    projectDexFiles = result.projectDexFiles
+                    projectDexFiles = result.projectDexFiles,
+                    // v2.1 注入新状态
+                    deviceConfig = _deviceConfig.value,
+                    viewport = _viewport.value,
+                    theme = _theme.value,
+                    debugEnabled = _debugEnabled.value,
                 )
             }
             .onFailure { error ->
                 val diagnostics = if (error is CompilationException) error.diagnostics else emptyList()
                 _previewState.value = PreviewState.Error(
                     message = error.message ?: "Compilation failed",
-                    diagnostics = diagnostics
+                    diagnostics = diagnostics,
+                    cause = error,
                 )
             }
     }
@@ -263,47 +368,87 @@ class ComposePreviewViewModel(
 
                 _previewState.value = PreviewState.Initializing
 
-            repository.initialize(context, cachedFilePath)
-                .onSuccess { result ->
-                    when (result) {
-                        is InitializationResult.Ready -> {
-                            modulePath = result.projectContext.modulePath
-                            variantName = result.projectContext.variantName
-                            isInitialized.set(true)
-                            initializationDeferred.complete(Unit)
-                            LOG.debug("refreshAfterBuild: initialization complete, state=Ready")
-                            if (currentSource.isNotBlank()) {
-                                compileNow(currentSource)
-                            } else {
-                                _previewState.value = PreviewState.Idle
+                repository.initialize(context, cachedFilePath)
+                    .onSuccess { result ->
+                        when (result) {
+                            is InitializationResult.Ready -> {
+                                modulePath = result.projectContext.modulePath
+                                variantName = result.projectContext.variantName
+                                isInitialized.set(true)
+                                initializationDeferred.complete(Unit)
+                                LOG.debug("refreshAfterBuild: initialization complete, state=Ready")
+                                if (currentSource.isNotBlank()) {
+                                    compileNow(currentSource)
+                                } else {
+                                    _previewState.value = PreviewState.Idle
+                                }
+                            }
+                            is InitializationResult.NeedsBuild -> {
+                                modulePath = result.modulePath
+                                variantName = result.variantName
+                                isInitialized.set(true)
+                                initializationDeferred.complete(Unit)
+                                _previewState.value = PreviewState.NeedsBuild(
+                                    result.modulePath,
+                                    result.variantName
+                                )
+                            }
+                            is InitializationResult.Failed -> {
+                                initializationDeferred.complete(Unit)
+                                LOG.error("refreshAfterBuild: initialization failed - {}", result.message)
+                                _previewState.value = PreviewState.Error(result.message)
                             }
                         }
-                        is InitializationResult.NeedsBuild -> {
-                            modulePath = result.modulePath
-                            variantName = result.variantName
-                            isInitialized.set(true)
-                            initializationDeferred.complete(Unit)
-                            _previewState.value = PreviewState.NeedsBuild(
-                                result.modulePath,
-                                result.variantName
-                            )
-                        }
-                        is InitializationResult.Failed -> {
-                            initializationDeferred.complete(Unit)
-                            LOG.error("refreshAfterBuild: initialization failed - {}", result.message)
-                            _previewState.value = PreviewState.Error(result.message)
-                        }
                     }
-                }
-                .onFailure { error ->
-                    initializationDeferred.complete(Unit)
-                    LOG.error("refreshAfterBuild: initialization failed", error)
-                    _previewState.value = PreviewState.Error(
-                        error.message ?: "Initialization failed"
-                    )
-                }
+                    .onFailure { error ->
+                        initializationDeferred.complete(Unit)
+                        LOG.error("refreshAfterBuild: initialization failed", error)
+                        _previewState.value = PreviewState.Error(
+                            error.message ?: "Initialization failed"
+                        )
+                    }
             }
         }
+    }
+
+    // === v2.1 新增方法 ===
+
+    fun selectDevice(profile: DeviceProfile) {
+        _deviceConfig.value = _deviceConfig.value.copy(profile = profile)
+        LOG.info("Device selected: {}", profile.displayName)
+    }
+
+    fun setSystemBarsTheme(theme: SystemBarsTheme) {
+        _deviceConfig.value = _deviceConfig.value.copy(systemBarsTheme = theme)
+    }
+
+    fun toggleSystemBars() {
+        _deviceConfig.value = _deviceConfig.value.copy(
+            showStatusBar = !_deviceConfig.value.showStatusBar,
+            showNavigationBar = !_deviceConfig.value.showNavigationBar,
+        )
+    }
+
+    fun setZoom(zoom: Float) {
+        _viewport.value = _viewport.value.copy(
+            zoom = zoom.coerceIn(0.1f, 5.0f)
+        )
+    }
+
+    fun fitZoom() {
+        _viewport.value = ViewportState() // reset to fit
+    }
+
+    fun cycleTheme() {
+        _theme.value = when (_theme.value) {
+            PreviewTheme.Light -> PreviewTheme.Dark
+            PreviewTheme.Dark -> PreviewTheme.Custom
+            PreviewTheme.Custom -> PreviewTheme.Light
+        }
+    }
+
+    fun toggleDebug() {
+        _debugEnabled.value = !_debugEnabled.value
     }
 
     override fun onCleared() {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/CutoutGeometry.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/CutoutGeometry.kt
@@ -1,0 +1,171 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.data.device
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * 屏幕切口 (cutout / notch / punch-hole / waterfall) 几何.
+ *
+ * 用于 [com.itsaky.androidide.compose.preview.ui.CutoutOverlay] 渲染真实设备屏幕
+ * 上的非矩形显示区域.
+ *
+ * 三种形态:
+ * - [Notch]: 顶部矩形 / 药丸形切口 (iPhone 13 ~ 14 / 华为 Mate 20)
+ * - [PunchHole]: 居中 / 边角的小圆孔 (Pixel 6+ / Galaxy S24 / 小米 14)
+ * - [WaterfallCurve]: 两侧大曲率瀑布边 (华为 Mate 30 Pro / 荣耀 Magic)
+ *
+ * 所有尺寸使用 **dp** 作为单位, 渲染时按 [densityDpi] 自动换算为 px.
+ *
+ * @property widthDp 切口宽度 (Notch / PunchHole 适用)
+ * @property heightDp 切口高度 (Notch / PunchHole 适用)
+ * @property anchor 在屏幕上的锚点位置
+ * @property insetDp 距屏幕边缘的内缩 (用于调整位置)
+ */
+@Immutable
+sealed class CutoutGeometry {
+
+    abstract val anchor: Anchor
+
+    /**
+     * 顶部居中 / 角部锚点.
+     *
+     * 注意: 瀑布屏 ([WaterfallCurve]) 的几何不直接走 anchor, 而是
+     * 通过 [WaterfallCurve.side] 字段指定 LEFT / RIGHT.
+     */
+    enum class Anchor {
+        /** 顶部居中 (iPhone notch / Pixel punch-hole) */
+        TOP_CENTER,
+
+        /** 左上角 (OnePlus 12 / 部分三星) */
+        TOP_LEFT,
+
+        /** 右上角 (三星早期 / 部分小米) */
+        TOP_RIGHT,
+
+        /** 左侧居中 (瀑布屏左侧) */
+        LEFT_CENTER,
+
+        /** 右侧居中 (瀑布屏右侧) */
+        RIGHT_CENTER,
+    }
+
+    /**
+     * 传统刘海 (顶部矩形切口).
+     *
+     * 典型设备: iPhone 13 / 14, 华为 Mate 20, 早期 Pixel 3 XL.
+     *
+     * @param widthDp 切口宽度
+     * @param heightDp 切口高度 (从屏幕顶端向下)
+     * @param anchor 顶部锚点
+     * @param cornerRadiusDp 切口圆角 (iPhone 风格用较大值, Mate 用较小)
+     */
+    data class Notch(
+        val widthDp: Float,
+        val heightDp: Float,
+        override val anchor: Anchor = Anchor.TOP_CENTER,
+        val cornerRadiusDp: Float = 8f,
+    ) : CutoutGeometry()
+
+    /**
+     * 挖孔屏 / 针孔屏 (小圆孔).
+     *
+     * 典型设备: Pixel 6/7/8 (居中), 三星 S24 (居中), 小米 14 (居中),
+     * OnePlus 12 (左上).
+     *
+     * @param diameterDp 圆孔直径
+     * @param anchor 锚点
+     * @param insetDp 距屏幕边缘内缩 (例如左上角时光圈距左边 8dp)
+     */
+    data class PunchHole(
+        val diameterDp: Float,
+        override val anchor: Anchor = Anchor.TOP_CENTER,
+        val insetDp: Float = 0f,
+    ) : CutoutGeometry() {
+        // 为保持与 Notch 兼容, 暴露 widthDp / heightDp = diameterDp
+        val widthDp: Float get() = diameterDp
+        val heightDp: Float get() = diameterDp
+    }
+
+    /**
+     * 瀑布屏曲线 (屏幕两侧 88° 曲面, 几乎没有物理边框).
+     *
+     * 典型设备: 华为 Mate 30 Pro, 荣耀 Magic, vivo NEX 3.
+     *
+     * 与 Notch / PunchHole 不同, 瀑布屏切口不是"挖掉"一块, 而是用
+     * Bezier 曲线把屏幕两端弯到背面, 因此渲染时需要走 [androidx.compose.ui.graphics.Path]
+     * 裁切.
+     *
+     * @param side 曲线在屏幕哪一侧
+     * @param angleDeg 曲面角度 (88° 表示几乎垂直)
+     * @param edgeWidthDp 侧边显示区域宽度 (实际可见弯曲部分)
+     */
+    data class WaterfallCurve(
+        val side: Anchor = Anchor.LEFT_CENTER,
+        val angleDeg: Float = 88f,
+        val edgeWidthDp: Float = 4f,
+    ) : CutoutGeometry() {
+        // 为保持接口一致
+        val widthDp: Float get() = edgeWidthDp
+        val heightDp: Float get() = 0f
+    }
+
+    companion object {
+        // 常用预设 -----
+
+        /** iPhone 13/14 风格 notch (154 × 30 dp, 顶部居中) */
+        val IPHONE_14_NOTCH: Notch = Notch(
+            widthDp = 154f,
+            heightDp = 30f,
+            anchor = Anchor.TOP_CENTER,
+            cornerRadiusDp = 15f
+        )
+
+        /** iPhone 15 Pro 风格 Dynamic Island (126 × 37 dp, 顶部居中) */
+        val DYNAMIC_ISLAND: Notch = Notch(
+            widthDp = 126f,
+            heightDp = 37f,
+            anchor = Anchor.TOP_CENTER,
+            cornerRadiusDp = 18f
+        )
+
+        /** Pixel 6/7 风格 punch-hole (居中 4dp) */
+        val PIXEL_PUNCHHOLE: PunchHole = PunchHole(
+            diameterDp = 4f,
+            anchor = Anchor.TOP_CENTER,
+            insetDp = 6f
+        )
+
+        /** 华为 Mate 60 Pro 风格 punch-hole (居中 8dp) */
+        val HUAWEI_PUNCHHOLE: PunchHole = PunchHole(
+            diameterDp = 8f,
+            anchor = Anchor.TOP_CENTER,
+            insetDp = 8f
+        )
+
+        /** 华为 Mate 30 Pro 风格 88° 瀑布 */
+        val HUAWEI_WATERFALL: WaterfallCurve = WaterfallCurve(
+            side = Anchor.LEFT_CENTER,
+            angleDeg = 88f,
+            edgeWidthDp = 6f
+        )
+
+        /** 无切口 (大多数现代 Android 设备, 默认值) */
+        val NONE: CutoutGeometry? = null
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/DeviceCatalog.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/DeviceCatalog.kt
@@ -1,0 +1,487 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.data.device
+
+import androidx.compose.ui.graphics.Color
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile.Bezels
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile.FormFactor
+
+/**
+ * 真实设备目录 v2.1.
+ *
+ * 内置 30+ 真实设备 Profile, 按 [FormFactor] 分组.
+ *
+ * **数据来源**:
+ * - Wikipedia (设备屏幕尺寸 / 分辨率)
+ * - GSMArena (设备规格)
+ * - 厂商官网 (相机 / 听筒 / 物理键位置)
+ *
+ * 屏幕宽 / 高 px 与 DPI 是真实测量值; 边框 / 圆角为视觉近似 (误差 ± 2dp).
+ * cutout 尺寸按厂商公布值, 物理键位置按设备平面图.
+ *
+ * **使用示例**:
+ * ```
+ * val pixel7 = DeviceCatalog.byId("pixel-7")
+ * val phones = DeviceCatalog.byFormFactor(FormFactor.PHONE)
+ * ```
+ */
+object DeviceCatalog {
+
+    // === Phone (现代全面屏, 居中 / 角部 punch-hole) ===
+
+    private val pixel_7 = DeviceProfile(
+        id = "pixel-7",
+        displayName = "Pixel 7",
+        manufacturer = "Google", model = "Pixel 7", osVersion = "Android 14",
+        widthPx = 1080, heightPx = 2400, densityDpi = 420,
+        cornerRadiusDp = 30f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.pixelKeys(411f),
+        chassisColor = Color(0xFF1F1F25),
+    )
+
+    private val pixel_7_pro = DeviceProfile(
+        id = "pixel-7-pro",
+        displayName = "Pixel 7 Pro",
+        manufacturer = "Google", model = "Pixel 7 Pro", osVersion = "Android 14",
+        widthPx = 1440, heightPx = 3120, densityDpi = 560,
+        cornerRadiusDp = 32f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 8f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.pixelKeys(411f),
+        chassisColor = Color(0xFF20202A),
+    )
+
+    private val pixel_8 = DeviceProfile(
+        id = "pixel-8",
+        displayName = "Pixel 8",
+        manufacturer = "Google", model = "Pixel 8", osVersion = "Android 14",
+        widthPx = 1080, heightPx = 2400, densityDpi = 420,
+        cornerRadiusDp = 30f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.pixelKeys(411f),
+        chassisColor = Color(0xFFEFEAE3),
+    )
+
+    private val pixel_8_pro = DeviceProfile(
+        id = "pixel-8-pro",
+        displayName = "Pixel 8 Pro",
+        manufacturer = "Google", model = "Pixel 8 Pro", osVersion = "Android 14",
+        widthPx = 1344, heightPx = 2992, densityDpi = 560,
+        cornerRadiusDp = 32f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 8f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.pixelKeys(385f),
+        chassisColor = Color(0xFF1B1B1F),
+    )
+
+    private val huawei_mate60_pro = DeviceProfile(
+        id = "huawei-mate60-pro",
+        displayName = "Huawei Mate 60 Pro",
+        manufacturer = "Huawei", model = "Mate 60 Pro", osVersion = "HarmonyOS 4",
+        widthPx = 1260, heightPx = 2720, densityDpi = 460,
+        cornerRadiusDp = 28f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 8f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 8f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(437f),
+        chassisColor = Color(0xFF3C3A37),
+    )
+
+    private val huawei_p30_pro = DeviceProfile(
+        id = "huawei-p30-pro",
+        displayName = "Huawei P30 Pro",
+        manufacturer = "Huawei", model = "P30 Pro", osVersion = "Android 10",
+        widthPx = 1080, heightPx = 2340, densityDpi = 480,
+        cornerRadiusDp = 32f,
+        cutout = CutoutGeometry.WaterfallCurve(
+            side = CutoutGeometry.Anchor.LEFT_CENTER,
+            angleDeg = 88f,
+            edgeWidthDp = 4f
+        ),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(360f),
+        chassisColor = Color(0xFF1F2A44),
+    )
+
+    private val xiaomi_14_pro = DeviceProfile(
+        id = "xiaomi-14-pro",
+        displayName = "Xiaomi 14 Pro",
+        manufacturer = "Xiaomi", model = "14 Pro", osVersion = "HyperOS 1",
+        widthPx = 1440, heightPx = 3200, densityDpi = 560,
+        cornerRadiusDp = 28f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(411f),
+        chassisColor = Color(0xFF202020),
+    )
+
+    private val samsung_s24_ultra = DeviceProfile(
+        id = "samsung-s24-ultra",
+        displayName = "Samsung Galaxy S24 Ultra",
+        manufacturer = "Samsung", model = "Galaxy S24 Ultra", osVersion = "Android 14",
+        widthPx = 1440, heightPx = 3120, densityDpi = 560,
+        cornerRadiusDp = 14f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(411f),
+        chassisColor = Color(0xFF353535),
+    )
+
+    private val samsung_s23 = DeviceProfile(
+        id = "samsung-s23",
+        displayName = "Samsung Galaxy S23",
+        manufacturer = "Samsung", model = "Galaxy S23", osVersion = "Android 14",
+        widthPx = 1080, heightPx = 2340, densityDpi = 420,
+        cornerRadiusDp = 18f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(390f),
+        chassisColor = Color(0xFFEEEAE4),
+    )
+
+    private val oneplus_12 = DeviceProfile(
+        id = "oneplus-12",
+        displayName = "OnePlus 12",
+        manufacturer = "OnePlus", model = "12", osVersion = "OxygenOS 14",
+        widthPx = 1440, heightPx = 3168, densityDpi = 560,
+        cornerRadiusDp = 24f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_LEFT, insetDp = 8f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(412f),
+        chassisColor = Color(0xFF2A2A2D),
+    )
+
+    private val honor_magic6_pro = DeviceProfile(
+        id = "honor-magic6-pro",
+        displayName = "Honor Magic 6 Pro",
+        manufacturer = "Honor", model = "Magic 6 Pro", osVersion = "MagicOS 8",
+        widthPx = 1280, heightPx = 2800, densityDpi = 460,
+        cornerRadiusDp = 28f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 6f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.PHONE_MODERN,
+        physicalKeys = PhysicalKey.standardAndroidKeys(437f),
+        chassisColor = Color(0xFF1E1E22),
+    )
+
+    // === Phone (刘海 / Dynamic Island / iPhone) ===
+
+    private val iphone_13 = DeviceProfile(
+        id = "iphone-13",
+        displayName = "iPhone 13",
+        manufacturer = "Apple", model = "iPhone 13", osVersion = "iOS 17",
+        widthPx = 1170, heightPx = 2532, densityDpi = 460,
+        cornerRadiusDp = 42f,
+        cutout = CutoutGeometry.Notch(
+            widthDp = 154f, heightDp = 30f,
+            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 15f
+        ),
+        bezels = Bezels(topDp = 30f, bottomDp = 22f, leftDp = 4f, rightDp = 4f),
+        physicalKeys = PhysicalKey.iphoneKeys(390f),
+        chassisColor = Color(0xFF1B1B1D),
+    )
+
+    private val iphone_14 = DeviceProfile(
+        id = "iphone-14",
+        displayName = "iPhone 14",
+        manufacturer = "Apple", model = "iPhone 14", osVersion = "iOS 17",
+        widthPx = 1170, heightPx = 2532, densityDpi = 460,
+        cornerRadiusDp = 42f,
+        cutout = CutoutGeometry.Notch(
+            widthDp = 154f, heightDp = 30f,
+            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 15f
+        ),
+        bezels = Bezels(topDp = 30f, bottomDp = 22f, leftDp = 4f, rightDp = 4f),
+        physicalKeys = PhysicalKey.iphoneKeys(390f),
+        chassisColor = Color(0xFFF1F0ED),
+    )
+
+    private val iphone_15_pro = DeviceProfile(
+        id = "iphone-15-pro",
+        displayName = "iPhone 15 Pro",
+        manufacturer = "Apple", model = "iPhone 15 Pro", osVersion = "iOS 17",
+        widthPx = 1179, heightPx = 2556, densityDpi = 460,
+        cornerRadiusDp = 50f,
+        cutout = CutoutGeometry.Notch(
+            widthDp = 126f, heightDp = 37f,
+            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 18f
+        ),
+        bezels = Bezels(topDp = 37f, bottomDp = 24f, leftDp = 4f, rightDp = 4f),
+        physicalKeys = PhysicalKey.iphoneKeys(393f),
+        chassisColor = Color(0xFF34343A),
+    )
+
+    private val iphone_15_pro_max = DeviceProfile(
+        id = "iphone-15-pro-max",
+        displayName = "iPhone 15 Pro Max",
+        manufacturer = "Apple", model = "iPhone 15 Pro Max", osVersion = "iOS 17",
+        widthPx = 1290, heightPx = 2796, densityDpi = 460,
+        cornerRadiusDp = 50f,
+        cutout = CutoutGeometry.Notch(
+            widthDp = 130f, heightDp = 38f,
+            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 19f
+        ),
+        bezels = Bezels(topDp = 38f, bottomDp = 26f, leftDp = 4f, rightDp = 4f),
+        physicalKeys = PhysicalKey.iphoneKeys(430f),
+        chassisColor = Color(0xFF2A2A2C),
+    )
+
+    // === Foldable (内屏 / 外屏) ===
+
+    private val galaxy_z_fold5_inner = DeviceProfile(
+        id = "galaxy-z-fold5-inner",
+        displayName = "Galaxy Z Fold 5 (Inner)",
+        manufacturer = "Samsung", model = "Galaxy Z Fold 5 (Inner)", osVersion = "Android 14",
+        formFactor = FormFactor.FOLDABLE_INNER,
+        widthPx = 1812, heightPx = 2176, densityDpi = 374,
+        cornerRadiusDp = 6f,
+        cutout = null, // 内屏无 cutout
+        bezels = Bezels.FOLDABLE_INNER,
+        physicalKeys = PhysicalKey.standardAndroidKeys(485f),
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    private val galaxy_z_fold5_outer = DeviceProfile(
+        id = "galaxy-z-fold5-outer",
+        displayName = "Galaxy Z Fold 5 (Outer)",
+        manufacturer = "Samsung", model = "Galaxy Z Fold 5 (Outer)", osVersion = "Android 14",
+        formFactor = FormFactor.FOLDABLE_OUTER,
+        widthPx = 904, heightPx = 2316, densityDpi = 374,
+        cornerRadiusDp = 6f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_CENTER, insetDp = 6f),
+        bezels = Bezels.FOLDABLE_OUTER,
+        physicalKeys = PhysicalKey.standardAndroidKeys(242f),
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    private val pixel_fold_inner = DeviceProfile(
+        id = "pixel-fold-inner",
+        displayName = "Pixel Fold (Inner)",
+        manufacturer = "Google", model = "Pixel Fold (Inner)", osVersion = "Android 14",
+        formFactor = FormFactor.FOLDABLE_INNER,
+        widthPx = 2208, heightPx = 1840, densityDpi = 420,
+        cornerRadiusDp = 8f,
+        cutout = null,
+        bezels = Bezels.FOLDABLE_INNER,
+        physicalKeys = PhysicalKey.standardAndroidKeys(673f),
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    private val pixel_fold_outer = DeviceProfile(
+        id = "pixel-fold-outer",
+        displayName = "Pixel Fold (Outer)",
+        manufacturer = "Google", model = "Pixel Fold (Outer)", osVersion = "Android 14",
+        formFactor = FormFactor.FOLDABLE_OUTER,
+        widthPx = 1080, heightPx = 2092, densityDpi = 420,
+        cornerRadiusDp = 12f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_LEFT, insetDp = 8f),
+        bezels = Bezels.FOLDABLE_OUTER,
+        physicalKeys = PhysicalKey.standardAndroidKeys(412f),
+        chassisColor = Color(0xFF1F1F22),
+    )
+
+    private val oppo_find_n3_inner = DeviceProfile(
+        id = "oppo-find-n3-inner",
+        displayName = "OPPO Find N3 (Inner)",
+        manufacturer = "OPPO", model = "Find N3 (Inner)", osVersion = "ColorOS 13",
+        formFactor = FormFactor.FOLDABLE_INNER,
+        widthPx = 2268, heightPx = 2240, densityDpi = 431,
+        cornerRadiusDp = 6f,
+        cutout = null,
+        bezels = Bezels.FOLDABLE_INNER,
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    private val oppo_find_n3_outer = DeviceProfile(
+        id = "oppo-find-n3-outer",
+        displayName = "OPPO Find N3 (Outer)",
+        manufacturer = "OPPO", model = "Find N3 (Outer)", osVersion = "ColorOS 13",
+        formFactor = FormFactor.FOLDABLE_OUTER,
+        widthPx = 1116, heightPx = 2484, densityDpi = 431,
+        cornerRadiusDp = 14f,
+        cutout = CutoutGeometry.PunchHole(diameterDp = 4f, anchor = CutoutGeometry.Anchor.TOP_LEFT, insetDp = 6f),
+        bezels = Bezels.FOLDABLE_OUTER,
+        chassisColor = Color(0xFF1F1F22),
+    )
+
+    // === Tablet ===
+
+    private val pixel_tablet = DeviceProfile(
+        id = "pixel-tablet",
+        displayName = "Pixel Tablet",
+        manufacturer = "Google", model = "Pixel Tablet", osVersion = "Android 14",
+        formFactor = FormFactor.TABLET,
+        widthPx = 1600, heightPx = 2560, densityDpi = 320,
+        cornerRadiusDp = 18f,
+        bezels = Bezels.TABLET,
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFFEEEAE3),
+    )
+
+    private val ipad_pro_11 = DeviceProfile(
+        id = "ipad-pro-11",
+        displayName = "iPad Pro 11\"",
+        manufacturer = "Apple", model = "iPad Pro 11", osVersion = "iPadOS 17",
+        formFactor = FormFactor.TABLET,
+        widthPx = 1668, heightPx = 2388, densityDpi = 264,
+        cornerRadiusDp = 22f,
+        bezels = Bezels(topDp = 22f, bottomDp = 22f, leftDp = 22f, rightDp = 22f),
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFF2C2C2E),
+    )
+
+    private val ipad_pro_12_9 = DeviceProfile(
+        id = "ipad-pro-12.9",
+        displayName = "iPad Pro 12.9\"",
+        manufacturer = "Apple", model = "iPad Pro 12.9", osVersion = "iPadOS 17",
+        formFactor = FormFactor.TABLET,
+        widthPx = 2048, heightPx = 2732, densityDpi = 264,
+        cornerRadiusDp = 22f,
+        bezels = Bezels(topDp = 22f, bottomDp = 22f, leftDp = 22f, rightDp = 22f),
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFF2C2C2E),
+    )
+
+    private val galaxy_tab_s9 = DeviceProfile(
+        id = "galaxy-tab-s9",
+        displayName = "Galaxy Tab S9",
+        manufacturer = "Samsung", model = "Galaxy Tab S9", osVersion = "Android 14",
+        formFactor = FormFactor.TABLET,
+        widthPx = 2560, heightPx = 1600, densityDpi = 274,
+        cornerRadiusDp = 16f,
+        bezels = Bezels.TABLET,
+        statusBarHeightDp = 24,
+        chassisColor = Color(0xFF353535),
+    )
+
+    // === Watch ===
+
+    private val wear_small = DeviceProfile(
+        id = "wear-small",
+        displayName = "Wear OS Small (384×384)",
+        manufacturer = "Google", model = "Wear OS Small", osVersion = "Wear OS 4",
+        formFactor = FormFactor.WATCH,
+        widthPx = 384, heightPx = 384, densityDpi = 320,
+        cornerRadiusDp = 192f,
+        bezels = Bezels.WATCH,
+        statusBarHeightDp = 0,
+        navigationBarHeightDp = 0,
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    private val wear_large = DeviceProfile(
+        id = "wear-large",
+        displayName = "Wear OS Large (454×454)",
+        manufacturer = "Google", model = "Wear OS Large", osVersion = "Wear OS 4",
+        formFactor = FormFactor.WATCH,
+        widthPx = 454, heightPx = 454, densityDpi = 320,
+        cornerRadiusDp = 227f,
+        bezels = Bezels.WATCH,
+        statusBarHeightDp = 0,
+        navigationBarHeightDp = 0,
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    private val wear_square = DeviceProfile(
+        id = "wear-square",
+        displayName = "Wear OS Square (390×390)",
+        manufacturer = "Google", model = "Wear OS Square", osVersion = "Wear OS 4",
+        formFactor = FormFactor.WATCH,
+        widthPx = 390, heightPx = 390, densityDpi = 320,
+        cornerRadiusDp = 32f,
+        bezels = Bezels(topDp = 32f, bottomDp = 32f, leftDp = 32f, rightDp = 32f),
+        statusBarHeightDp = 0,
+        navigationBarHeightDp = 0,
+        chassisColor = Color(0xFF1A1A1A),
+    )
+
+    // === Desktop / Auto ===
+
+    private val desktop_1080p = DeviceProfile(
+        id = "desktop-1080p",
+        displayName = "Desktop 1920×1080",
+        manufacturer = "Generic", model = "Desktop 1080p", osVersion = "Android 14 Desktop",
+        formFactor = FormFactor.DESKTOP,
+        widthPx = 1920, heightPx = 1080, densityDpi = 160,
+        cornerRadiusDp = 4f,
+        bezels = Bezels(0f, 0f, 0f, 0f),
+        statusBarHeightDp = 28,
+        navigationBarHeightDp = 0,
+        chassisColor = Color(0xFF202024),
+    )
+
+    /**
+     * 全部内置设备 (按 formFactor 排序).
+     */
+    val builtinProfiles: List<DeviceProfile> = listOf(
+        // Phone
+        pixel_7, pixel_7_pro, pixel_8, pixel_8_pro,
+        huawei_mate60_pro, huawei_p30_pro, xiaomi_14_pro,
+        samsung_s23, samsung_s24_ultra,
+        oneplus_12, honor_magic6_pro,
+        // iPhone
+        iphone_13, iphone_14, iphone_15_pro, iphone_15_pro_max,
+        // Foldable
+        galaxy_z_fold5_inner, galaxy_z_fold5_outer,
+        pixel_fold_inner, pixel_fold_outer,
+        oppo_find_n3_inner, oppo_find_n3_outer,
+        // Tablet
+        pixel_tablet, ipad_pro_11, ipad_pro_12_9, galaxy_tab_s9,
+        // Watch
+        wear_small, wear_large, wear_square,
+        // Desktop
+        desktop_1080p,
+    )
+
+    /**
+     * 按 [FormFactor] 分组的字典.
+     *
+     * 顺序: PHONE → FOLDABLE_OUTER → FOLDABLE_INNER → TABLET → WATCH → DESKTOP.
+     */
+    val groupedByFormFactor: Map<FormFactor, List<DeviceProfile>> = mapOf(
+        FormFactor.PHONE to builtinProfiles.filter { it.formFactor == FormFactor.PHONE },
+        FormFactor.FOLDABLE_OUTER to builtinProfiles.filter { it.formFactor == FormFactor.FOLDABLE_OUTER },
+        FormFactor.FOLDABLE_INNER to builtinProfiles.filter { it.formFactor == FormFactor.FOLDABLE_INNER },
+        FormFactor.TABLET to builtinProfiles.filter { it.formFactor == FormFactor.TABLET },
+        FormFactor.WATCH to builtinProfiles.filter { it.formFactor == FormFactor.WATCH },
+        FormFactor.DESKTOP to builtinProfiles.filter { it.formFactor == FormFactor.DESKTOP },
+    )
+
+    /**
+     * 按 ID 查找设备.
+     *
+     * @return 命中返回 profile, 否则 null.
+     */
+    fun byId(id: String): DeviceProfile? = builtinProfiles.firstOrNull { it.id == id }
+
+    /**
+     * 按 [FormFactor] 查找设备.
+     */
+    fun byFormFactor(ff: FormFactor): List<DeviceProfile> =
+        groupedByFormFactor[ff] ?: emptyList()
+
+    /**
+     * 默认设备 (Pixel 7), 当用户未选择时使用.
+     */
+    val DEFAULT: DeviceProfile = pixel_7
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/PhysicalKey.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/PhysicalKey.kt
@@ -1,0 +1,152 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.data.device
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * 设备物理按键模型.
+ *
+ * 模拟真实手机 / 平板 / 折叠屏机身上的物理按钮 (电源 / 音量 / 相机).
+ * 用于 [com.itsaky.androidide.compose.preview.ui.DeviceFrame] 在屏幕
+ * 外壳上绘制按钮位置.
+ *
+ * v2.1 P0 只渲染矩形 + 文字 (不做 3D 仿真 / 凹凸效果). P1 增强时
+ * 可以叠加渐变 / 阴影 / 颜色等.
+ *
+ * 坐标定义:
+ * - 屏幕 (Screen) 坐标系: 原点 = 屏幕左上角, 单位 dp
+ * - [positionXdp] / [positionYdp] 是按键**中心点**相对屏幕左上角的偏移
+ * - [widthDp] / [heightDp] 是按键自身尺寸
+ *
+ * @property positionXdp 中心 X (相对屏幕左上角, 单位 dp)
+ * @property positionYdp 中心 Y (相对屏幕左上角, 单位 dp)
+ * @property widthDp 按键宽度
+ * @property heightDp 按键高度
+ */
+@Immutable
+sealed class PhysicalKey {
+
+    abstract val positionXdp: Float
+    abstract val positionYdp: Float
+    abstract val widthDp: Float
+    abstract val heightDp: Float
+
+    /** 按键显示名 (Compose 渲染时用, 例如 "Power" / "Vol+" / "Cam") */
+    abstract val displayName: String
+
+    /**
+     * 电源键 (绝大多数手机在右侧).
+     *
+     * 典型位置: 屏幕右上往下 1/3 处.
+     */
+    data class Power(
+        override val positionXdp: Float,
+        override val positionYdp: Float,
+        override val widthDp: Float = 4f,
+        override val heightDp: Float = 36f,
+    ) : PhysicalKey() {
+        override val displayName: String = "Power"
+    }
+
+    /**
+     * 音量上键 (通常在电源键上方).
+     */
+    data class VolumeUp(
+        override val positionXdp: Float,
+        override val positionYdp: Float,
+        override val widthDp: Float = 4f,
+        override val heightDp: Float = 28f,
+    ) : PhysicalKey() {
+        override val displayName: String = "Vol+"
+    }
+
+    /**
+     * 音量下键 (通常紧贴 Vol+ 下方).
+     */
+    data class VolumeDown(
+        override val positionXdp: Float,
+        override val positionYdp: Float,
+        override val widthDp: Float = 4f,
+        override val heightDp: Float = 28f,
+    ) : PhysicalKey() {
+        override val displayName: String = "Vol-"
+    }
+
+    /**
+     * 相机键 (部分设备: Pixel 3 ~ 5, Sony Xperia, iPhone 16 等).
+     */
+    data class Camera(
+        override val positionXdp: Float,
+        override val positionYdp: Float,
+        override val widthDp: Float = 4f,
+        override val heightDp: Float = 22f,
+    ) : PhysicalKey() {
+        override val displayName: String = "Cam"
+    }
+
+    /**
+     * Bixby / Google Assistant 键 (三星 / 早期 Pixel).
+     */
+    data class Assistant(
+        override val positionXdp: Float,
+        override val positionYdp: Float,
+        override val widthDp: Float = 4f,
+        override val heightDp: Float = 22f,
+    ) : PhysicalKey() {
+        override val displayName: String = "AI"
+    }
+
+    companion object {
+        // 常用预设 -----
+
+        /**
+         * Pixel 系列 (音量键在左侧, 电源键在右侧).
+         *
+         * 屏幕宽 1080px @ 420dpi ≈ 411dp, 因此:
+         * - 左侧 Vol+/Vol- x = -6dp (即屏幕左外 6dp)
+         * - 右侧 Power x = 411dp + 6dp = 417dp (即屏幕右外 6dp)
+         */
+        fun pixelKeys(screenWidthDp: Float): List<PhysicalKey> = listOf(
+            VolumeUp(positionXdp = -6f, positionYdp = 320f),
+            VolumeDown(positionXdp = -6f, positionYdp = 360f),
+            Power(positionXdp = screenWidthDp + 6f, positionYdp = 320f)
+        )
+
+        /**
+         * 华为 / 小米 / 三星标准 (音量键在左侧, 电源键在右侧).
+         */
+        fun standardAndroidKeys(screenWidthDp: Float): List<PhysicalKey> = listOf(
+            VolumeUp(positionXdp = -6f, positionYdp = 300f),
+            VolumeDown(positionXdp = -6f, positionYdp = 340f),
+            Power(positionXdp = screenWidthDp + 6f, positionYdp = 300f)
+        )
+
+        /**
+         * iPhone (左侧音量 + 静音, 右侧电源). 静音键用 VolUp 占位.
+         */
+        fun iphoneKeys(screenWidthDp: Float): List<PhysicalKey> = listOf(
+            VolumeUp(positionXdp = -6f, positionYdp = 280f),
+            VolumeDown(positionXdp = -6f, positionYdp = 320f),
+            Power(positionXdp = screenWidthDp + 6f, positionYdp = 480f)
+        )
+
+        /** 无按键 (平板 / 折叠屏内屏 / 桌面模式 / 自定义) */
+        val NO_KEYS: List<PhysicalKey> = emptyList()
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/domain/PreviewSourceParser.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/domain/PreviewSourceParser.kt
@@ -1,9 +1,42 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.itsaky.androidide.compose.preview.domain
 
 import com.itsaky.androidide.compose.preview.PreviewConfig
 import com.itsaky.androidide.compose.preview.domain.model.ParsedPreviewSource
 import org.slf4j.LoggerFactory
 
+/**
+ * 预览源码解析器 v2.1.
+ *
+ * 纯正则实现 (不依赖 K2 PSI), 识别:
+ * - `package x.y.z` → 包名
+ * - `class A` / `object A` → 类名
+ * - `@Preview(...)` 标注的 `fun Foo()`
+ * - `@PreviewParameter(provider = ...)` 标注
+ * - `@PreviewFontScale = 1.5f` 标注
+ * - `@PreviewLightDark` 标注
+ *
+ * 解析顺序:
+ * 1. 包名 / 类名 (必要)
+ * 2. 标注了 `@Preview` 的函数 (优先)
+ * 3. 任意 `@Composable fun` 作为兜底
+ */
 class PreviewSourceParser {
 
     fun parse(source: String): ParsedPreviewSource? {
@@ -27,30 +60,25 @@ class PreviewSourceParser {
         val previews = mutableListOf<PreviewConfig>()
         val seenFunctions = mutableSetOf<String>()
 
+        // @Preview
         PREVIEW_ANNOTATION_PATTERN.findAll(source).forEach { match ->
             val params = match.groupValues[1]
             val functionName = match.groupValues[2]
             if (seenFunctions.add(functionName)) {
-                previews.add(PreviewConfig(
-                    functionName = functionName,
-                    heightDp = extractIntParam(params, "heightDp"),
-                    widthDp = extractIntParam(params, "widthDp")
-                ))
+                previews.add(buildConfig(functionName, params, source))
             }
         }
 
+        // @Composable @Preview
         COMPOSABLE_PREVIEW_PATTERN.findAll(source).forEach { match ->
             val params = match.groupValues[1]
             val functionName = match.groupValues[2]
             if (seenFunctions.add(functionName)) {
-                previews.add(PreviewConfig(
-                    functionName = functionName,
-                    heightDp = extractIntParam(params, "heightDp"),
-                    widthDp = extractIntParam(params, "widthDp")
-                ))
+                previews.add(buildConfig(functionName, params, source))
             }
         }
 
+        // 兜底: 任意 @Composable fun
         if (previews.isEmpty()) {
             COMPOSABLE_FUNCTION_PATTERN.findAll(source).forEach { match ->
                 val functionName = match.groupValues[1]
@@ -64,9 +92,61 @@ class PreviewSourceParser {
         return previews
     }
 
+    /**
+     * 从 [params] 解析 @Preview 注解参数 + 从 [source] 全文解析
+     * @PreviewParameter / @PreviewFontScale / @PreviewLightDark.
+     */
+    private fun buildConfig(functionName: String, params: String, source: String): PreviewConfig {
+        return PreviewConfig(
+            functionName = functionName,
+            heightDp = extractIntParam(params, "heightDp"),
+            widthDp = extractIntParam(params, "widthDp"),
+            fontScale = extractFontScale(source, functionName),
+            isLightDark = isLightDark(source, functionName),
+            parameterProviderName = extractParameterProvider(source, functionName),
+        )
+    }
+
     private fun extractIntParam(params: String, name: String): Int? {
         if (params.isBlank()) return null
         return Regex("""$name\s*=\s*(\d+)""").find(params)?.groupValues?.get(1)?.toIntOrNull()
+    }
+
+    private fun extractFloatParam(params: String, name: String): Float? {
+        if (params.isBlank()) return null
+        return Regex("""$name\s*=\s*([0-9]*\.?[0-9]+)""").find(params)?.groupValues?.get(1)?.toFloatOrNull()
+    }
+
+    /**
+     * 解析 @PreviewFontScale = 1.5f (v2.1 新).
+     *
+     * 实际使用: 解析该函数附近的 `@PreviewFontScale` 注解.
+     */
+    private fun extractFontScale(source: String, functionName: String): Float? {
+        val pattern = Regex(
+            """@PreviewFontScale\s*=\s*([0-9]*\.?[0-9]+)f?\s*(?:\([^)]*\))?[\s\n]*fun\s+$functionName"""
+        )
+        return pattern.find(source)?.groupValues?.get(1)?.toFloatOrNull()
+    }
+
+    /**
+     * 检测 @PreviewLightDark (v2.1 新).
+     */
+    private fun isLightDark(source: String, functionName: String): Boolean {
+        val pattern = Regex(
+            """@PreviewLightDark\s*(?:\([^)]*\))?[\s\n]*fun\s+$functionName"""
+        )
+        return pattern.containsMatchIn(source)
+    }
+
+    /**
+     * 解析 @PreviewParameter(provider = X::class) (v2.1 新).
+     */
+    private fun extractParameterProvider(source: String, functionName: String): String? {
+        val pattern = Regex(
+            """@PreviewParameter\s*\(\s*provider\s*=\s*([\w.]+)\s*::\s*class\s*\)[\s\n]*(?:\([^)]*\))?[\s\n]*fun\s+$functionName"""
+        )
+        return pattern.find(source)?.groupValues?.get(1)
     }
 
     companion object {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/CutoutOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/CutoutOverlay.kt
@@ -1,0 +1,215 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.itsaky.androidide.compose.preview.data.device.CutoutGeometry
+
+/**
+ * 屏幕切口叠加层.
+ *
+ * 在 [DeviceFrame] 的屏幕内容**之上**绘制, 模拟刘海 / 针孔 / 瀑布屏.
+ *
+ * 渲染方式:
+ * - [CutoutGeometry.Notch] → 顶部居中 / 角部 圆角矩形
+ * - [CutoutGeometry.PunchHole] → 顶部居中 / 角部 圆形
+ * - [CutoutGeometry.WaterfallCurve] → 两侧 Bezier 路径
+ *
+ * 注意: 切口是**纯视觉**的 (不实际 "挖掉" 屏幕内容), 这是因为
+ * 预览中的 Compose UI 是已知 API 28+ 的 WindowInsets 处理, 不应
+ * 被额外的物理切口遮挡. 真正应用会按 [CutoutGeometry.Anchor]
+ * 配置 WindowInsets.
+ *
+ * @param cutout 切口几何. 传入 null 时不渲染.
+ * @param modifier 外部 modifier (用于定位和尺寸)
+ * @param screenSize 屏幕尺寸 (px), 瀑布屏需要它来计算曲线
+ * @param color 切口颜色 (默认近黑, 与设备一体感)
+ */
+@Composable
+fun CutoutOverlay(
+    cutout: CutoutGeometry?,
+    modifier: Modifier = Modifier,
+    screenSize: Size = Size.Unspecified,
+    color: Color = Color(0xF0000000),
+) {
+    if (cutout == null) return
+
+    val density = LocalDensity.current
+    Canvas(modifier = modifier) {
+        when (cutout) {
+            is CutoutGeometry.Notch -> drawNotch(cutout, color)
+            is CutoutGeometry.PunchHole -> drawPunchHole(cutout, color)
+            is CutoutGeometry.WaterfallCurve -> drawWaterfall(cutout, color, screenSize)
+        }
+    }
+}
+
+/**
+ * 绘制刘海: 顶部矩形 (圆角).
+ */
+private fun DrawScope.drawNotch(notch: CutoutGeometry.Notch, color: Color) {
+    val widthPx = withHpx(notch.widthDp)
+    val heightPx = withHpx(notch.heightDp)
+    val cornerRadiusPx = withHpx(notch.cornerRadiusDp)
+
+    val x = when (notch.anchor) {
+        CutoutGeometry.Anchor.TOP_CENTER -> (size.width - widthPx) / 2f
+        CutoutGeometry.Anchor.TOP_LEFT -> withHpx(notch.cornerRadiusDp) * 2f
+        CutoutGeometry.Anchor.TOP_RIGHT -> size.width - widthPx - withHpx(notch.cornerRadiusDp) * 2f
+        else -> (size.width - widthPx) / 2f
+    }
+    val y = 0f
+
+    // 阴影外圈 (深色, 模拟刘海在屏幕上的"立体感")
+    val shadowPath = Path().apply {
+        addRoundRect(
+            androidx.compose.ui.geometry.RoundRect(
+                left = x, top = y,
+                right = x + widthPx, bottom = y + heightPx,
+                radiusX = cornerRadiusPx, radiusY = cornerRadiusPx
+            )
+        )
+    }
+    drawPath(path = shadowPath, color = color)
+
+    // 摄像头 / 听筒 - 暗色实心点
+    val sensorSize = cornerRadiusPx * 0.7f
+    drawCircle(
+        color = Color(0xFF0A0A0A),
+        radius = sensorSize,
+        center = Offset(x + widthPx / 2f, y + heightPx / 2f),
+    )
+    // 听筒条
+    drawRoundRect(
+        color = Color(0xFF0A0A0A),
+        topLeft = Offset(x + widthPx / 2f - sensorSize * 2.5f, y + heightPx / 2f - sensorSize * 0.3f),
+        size = Size(sensorSize * 5f, sensorSize * 0.6f),
+        cornerRadius = androidx.compose.ui.geometry.CornerRadius(sensorSize * 0.3f, sensorSize * 0.3f),
+    )
+}
+
+/**
+ * 绘制针孔: 顶部 / 角部小圆.
+ */
+private fun DrawScope.drawPunchHole(punch: CutoutGeometry.PunchHole, color: Color) {
+    val radiusPx = withHpx(punch.diameterDp) / 2f
+    val insetPx = withHpx(punch.insetDp)
+
+    val centerX = when (punch.anchor) {
+        CutoutGeometry.Anchor.TOP_CENTER -> size.width / 2f
+        CutoutGeometry.Anchor.TOP_LEFT -> insetPx + radiusPx
+        CutoutGeometry.Anchor.TOP_RIGHT -> size.width - insetPx - radiusPx
+        else -> size.width / 2f
+    }
+    val centerY = insetPx + radiusPx
+
+    // 摄像头 (深色实心)
+    drawCircle(
+        color = color,
+        radius = radiusPx,
+        center = Offset(centerX, centerY),
+    )
+    // 镜头内圈 (更深)
+    drawCircle(
+        color = Color(0xFF000000),
+        radius = radiusPx * 0.7f,
+        center = Offset(centerX, centerY),
+    )
+    // 镜头反光 (灰色)
+    drawCircle(
+        color = Color(0x30000000),
+        radius = radiusPx * 0.35f,
+        center = Offset(centerX - radiusPx * 0.2f, centerY - radiusPx * 0.2f),
+    )
+}
+
+/**
+ * 绘制瀑布屏: 两侧 Bezier 曲线 (模拟 88° 弯折).
+ *
+ * 这里用深色 Path 沿屏幕两侧画一条 "阴影带", 给视觉上
+ * 暗示屏幕从平面弯到侧面.
+ */
+private fun DrawScope.drawWaterfall(
+    waterfall: CutoutGeometry.WaterfallCurve,
+    color: Color,
+    screenSize: Size,
+) {
+    if (screenSize == Size.Unspecified) return
+
+    val edgePx = withHpx(waterfall.edgeWidthDp)
+    val path = Path()
+
+    when (waterfall.side) {
+        CutoutGeometry.Anchor.LEFT_CENTER, CutoutGeometry.Anchor.TOP_LEFT -> {
+            // 左侧瀑布
+            path.moveTo(0f, 0f)
+            path.cubicTo(
+                edgePx * 0.5f, screenSize.height * 0.25f,
+                edgePx * 0.5f, screenSize.height * 0.75f,
+                0f, screenSize.height
+            )
+            path.lineTo(edgePx, screenSize.height)
+            path.cubicTo(
+                edgePx * 1.5f, screenSize.height * 0.75f,
+                edgePx * 1.5f, screenSize.height * 0.25f,
+                edgePx, 0f
+            )
+            path.close()
+        }
+        CutoutGeometry.Anchor.RIGHT_CENTER, CutoutGeometry.Anchor.TOP_RIGHT -> {
+            // 右侧瀑布
+            path.moveTo(screenSize.width, 0f)
+            path.cubicTo(
+                screenSize.width - edgePx * 0.5f, screenSize.height * 0.25f,
+                screenSize.width - edgePx * 0.5f, screenSize.height * 0.75f,
+                screenSize.width, screenSize.height
+            )
+            path.lineTo(screenSize.width - edgePx, screenSize.height)
+            path.cubicTo(
+                screenSize.width - edgePx * 1.5f, screenSize.height * 0.75f,
+                screenSize.width - edgePx * 1.5f, screenSize.height * 0.25f,
+                screenSize.width - edgePx, 0f
+            )
+            path.close()
+        }
+        else -> {}
+    }
+
+    drawPath(path = path, color = color)
+    // 在边缘再画一条 0.5dp 浅色线, 模拟反射
+    drawPath(
+        path = path,
+        color = Color(0x40FFFFFF),
+        style = Stroke(width = withHpx(0.5f)),
+    )
+}
+
+/**
+ * dp → px 转换 (在 DrawScope 内部).
+ */
+private fun DrawScope.withHpx(dp: Float): Float = dp * density

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
@@ -17,124 +17,379 @@
 
 package com.itsaky.androidide.compose.preview.ui
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.compose.preview.data.device.CutoutGeometry
+import com.itsaky.androidide.compose.preview.data.device.PhysicalKey
+import kotlin.math.roundToInt
 
 /**
- * 设备外壳 Composable: 模拟手机 / 平板 / 手表的圆角、刘海、状态栏.
+ * 设备外壳 + 屏幕容器 v2.1.
  *
- * - 内部画布大小严格按 [DeviceProfile] 的 widthPx × heightPx 比例缩放
- * - 外壳尺寸通过 [outerWidth] / [outerHeight] 控制 (Dp), 默认 `fillMaxSize`
- * - 状态栏 / 刘海用 [Canvas] 画上去
- * - 内容放在 [content] 中
+ * 把任意 Composable (通常是预览目标) 套在真实设备外壳中:
  *
- * 用法:
- * ```kotlin
- * DeviceFrame(profile = DeviceProfiles.PIXEL_6) {
- *     // 你的 Composable (会按设备尺寸缩放后展示)
- *     MyComposable()
+ * ```
+ * DeviceFrame(profile = Pixel_7) {
+ *   RenderTarget()  // 实际预览内容
  * }
  * ```
+ *
+ * 渲染层次 (外到内):
+ * 1. 机身 (chassis) - [profile.chassisColor] + 圆角
+ * 2. 上/下/左/右 边框 ([profile.bezels])
+ * 3. 物理按键 ([profile.physicalKeys]) - 屏幕外侧矩形
+ * 4. 屏幕矩形 - [profile.cornerRadiusDp] 圆角
+ * 5. 内容 ([content])
+ * 6. 切口叠加 ([profile.cutout]) - 刘海 / 针孔 / 瀑布
+ * 7. 折叠铰链 (FOLDABLE_INNER 形态)
+ * 8. 状态栏 + 导航栏 ([SystemBarsOverlay])
+ *
+ * 形态因子 (formFactor) 决定渲染策略:
+ * - PHONE: 标准圆角矩形 + 切口
+ * - FOLDABLE_INNER: 极窄边框 + 中央铰链
+ * - FOLDABLE_OUTER: 类似 PHONE + 切口
+ * - TABLET: 较厚边框
+ * - WATCH: 圆形 (radius = width/2)
+ * - DESKTOP / NONE: 无外壳
+ *
+ * @param profile 设备 profile
+ * @param modifier 外部 modifier
+ * @param systemBarsTheme 系统栏主题
+ * @param showStatusBar / showNavigationBar / showCutout / showChassis 显示开关
+ * @param useGestureNav 手势导航
+ * @param content 实际预览内容
  */
 @Composable
 fun DeviceFrame(
     profile: DeviceProfile,
     modifier: Modifier = Modifier,
-    outerWidth: Dp? = null,
-    outerHeight: Dp? = null,
+    systemBarsTheme: SystemBarsTheme = SystemBarsTheme.AUTO,
     showStatusBar: Boolean = true,
-    content: @Composable () -> Unit
+    showNavigationBar: Boolean = true,
+    showCutout: Boolean = true,
+    showChassis: Boolean = true,
+    showPhysicalKeys: Boolean = true,
+    useGestureNav: Boolean = false,
+    content: @Composable () -> Unit,
 ) {
-    val ratio = profile.aspectRatio
-    val width = outerWidth
-    val height = outerHeight
-    val finalModifier = if (width != null && height != null) {
-        modifier.size(width, height)
-    } else {
-        modifier.fillMaxSize()
+    when (profile.formFactor) {
+        DeviceProfile.FormFactor.WATCH -> WatchFrame(
+            profile = profile,
+            modifier = modifier,
+            systemBarsTheme = systemBarsTheme,
+            content = content,
+        )
+        DeviceProfile.FormFactor.DESKTOP,
+        DeviceProfile.FormFactor.NONE -> Box(
+            modifier = modifier
+                .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
+        ) {
+            content()
+        }
+        else -> PhoneOrFoldableFrame(
+            profile = profile,
+            modifier = modifier,
+            systemBarsTheme = systemBarsTheme,
+            showStatusBar = showStatusBar,
+            showNavigationBar = showNavigationBar,
+            showCutout = showCutout,
+            showChassis = showChassis,
+            showPhysicalKeys = showPhysicalKeys,
+            useGestureNav = useGestureNav,
+            content = content,
+        )
     }
+}
 
-    Box(
-        modifier = finalModifier
-            .clip(shapeForStyle(profile.frameStyle))
-            .background(Color(0xFF202124)),
-        contentAlignment = Alignment.Center
+@Composable
+private fun PhoneOrFoldableFrame(
+    profile: DeviceProfile,
+    modifier: Modifier,
+    systemBarsTheme: SystemBarsTheme,
+    showStatusBar: Boolean,
+    showNavigationBar: Boolean,
+    showCutout: Boolean,
+    showChassis: Boolean,
+    showPhysicalKeys: Boolean,
+    useGestureNav: Boolean,
+    content: @Composable () -> Unit,
+) {
+    val density = LocalDensity.current
+    val bezelTopPx = with(density) { profile.bezels.topDp.dp.toPx() }
+    val bezelBottomPx = with(density) { profile.bezels.bottomDp.dp.toPx() }
+    val bezelLeftPx = with(density) { profile.bezels.leftDp.dp.toPx() }
+    val bezelRightPx = with(density) { profile.bezels.rightDp.dp.toPx() }
+
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
     ) {
-        // 屏幕区域
+        val parentWidth = maxWidth
+        val parentHeight = maxHeight
+
+        // 计算屏幕尺寸 (按设备纵横比 + 父容器约束)
+        val screenWidth = parentWidth
+        val aspect = profile.aspectRatio
+        val screenHeight = screenWidth / aspect
+
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Black)
+                .width(screenWidth)
+                .height(screenHeight)
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
+            // 1) 机身外壳
+            if (showChassis) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(profile.chassisColor, RoundedCornerShape(profile.cornerRadiusDp.dp + 4.dp))
+                )
+            }
+
+            // 2) 屏幕 (圆角矩形)
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        top = with(density) { profile.bezels.topDp.dp },
+                        bottom = with(density) { profile.bezels.bottomDp.dp },
+                        start = with(density) { profile.bezels.leftDp.dp },
+                        end = with(density) { profile.bezels.rightDp.dp },
+                    )
+                    .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
+            ) {
+                // 3) 内容
                 content()
+
+                // 4) 切口叠加 (在内容之上)
+                if (showCutout && profile.cutout != null) {
+                    CutoutOverlay(
+                        cutout = profile.cutout,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                // 5) 折叠铰链 (仅内屏)
+                if (profile.formFactor == DeviceProfile.FormFactor.FOLDABLE_INNER) {
+                    FoldableHingeOverlay(
+                        modifier = Modifier.fillMaxSize(),
+                        horizontal = true,
+                    )
+                }
+
+                // 6) 状态栏 + 导航栏
+                SystemBarsOverlay(
+                    profile = profile,
+                    systemBarsTheme = systemBarsTheme,
+                    showStatusBar = showStatusBar,
+                    showNavigationBar = showNavigationBar,
+                    useGestureNav = useGestureNav,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
-            if (showStatusBar && profile.frameStyle == DeviceProfile.FrameStyle.PHONE) {
-                StatusBarOverlay(modifier = Modifier.fillMaxSize())
-            }
-            if (profile.frameStyle == DeviceProfile.FrameStyle.PHONE) {
-                NotchOverlay(modifier = Modifier.fillMaxSize())
+
+            // 7) 物理按键 (屏幕外侧)
+            if (showPhysicalKeys) {
+                profile.physicalKeys.forEach { key ->
+                    PhysicalKeyIndicator(
+                        key = key,
+                        screenHeightDp = with(density) { (parentHeight.value).dp },
+                    )
+                }
             }
         }
     }
 }
 
-/** 形状: Phone -> 圆角, Tablet -> 小圆角, Watch -> 圆形, Foldable -> 几乎无圆角. */
-private fun shapeForStyle(style: DeviceProfile.FrameStyle) = when (style) {
-    DeviceProfile.FrameStyle.PHONE -> RoundedCornerShape(28.dp)
-    DeviceProfile.FrameStyle.TABLET -> RoundedCornerShape(16.dp)
-    DeviceProfile.FrameStyle.FOLDABLE -> RoundedCornerShape(4.dp)
-    DeviceProfile.FrameStyle.WATCH -> RoundedCornerShape(50)
-    DeviceProfile.FrameStyle.NONE -> RoundedCornerShape(0.dp)
-}
-
 @Composable
-private fun StatusBarOverlay(modifier: Modifier = Modifier) {
-    Canvas(modifier = modifier) {
-        drawRect(
-            color = Color.Black.copy(alpha = 0.6f),
-            topLeft = Offset(0f, 0f),
-            size = Size(size.width, 36.dp.toPx())
-        )
+private fun WatchFrame(
+    profile: DeviceProfile,
+    modifier: Modifier,
+    systemBarsTheme: SystemBarsTheme,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        val size = minOf(maxWidth, maxHeight)
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(androidx.compose.foundation.shape.CircleShape)
+                .background(profile.chassisColor)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(size * 0.94f)
+                    .clip(androidx.compose.foundation.shape.CircleShape)
+                    .background(Color.Black)
+            ) {
+                content()
+            }
+        }
     }
 }
 
+/**
+ * 物理按键指示器 (在屏幕外侧画一个矩形 + 文字).
+ */
 @Composable
-private fun NotchOverlay(modifier: Modifier = Modifier) {
-    Canvas(modifier = modifier) {
-        val notchW = 96.dp.toPx()
-        val notchH = 24.dp.toPx()
-        val cx = size.width / 2
-        drawRoundRect(
-            color = Color.Black,
-            topLeft = Offset(cx - notchW / 2, 8.dp.toPx()),
-            size = Size(notchW, notchH),
-            cornerRadius = androidx.compose.ui.geometry.CornerRadius(12.dp.toPx())
+private fun PhysicalKeyIndicator(
+    key: PhysicalKey,
+    screenHeightDp: androidx.compose.ui.unit.Dp,
+) {
+    val density = LocalDensity.current
+    val xPx = with(density) { key.positionXdp.dp.toPx() }
+    val yPx = with(density) { key.positionYdp.dp.toPx() }
+    val wPx = with(density) { key.widthDp.dp.toPx() }
+    val hPx = with(density) { key.heightDp.dp.toPx() }
+
+    val shape = RoundedCornerShape(2.dp)
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(xPx.roundToInt(), yPx.roundToInt()) }
+            .size(with(density) { wPx.toDp() }, with(density) { hPx.toDp() })
+            .background(Color(0xFF1A1A1E), shape)
+    ) {
+        Text(
+            text = key.displayName,
+            color = Color(0xFF707075),
+            fontSize = 4.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.align(Alignment.Center),
         )
     }
 }
 
 /**
- * 计算在 [outerWidth] 约束下, 等比缩放到设备 [profile] 比例后的实际高度.
- * (若 outerHeight 已指定, 走 outerHeight, 此函数仅给出基于宽度推算的高度.)
+ * 设备缩略图 (小尺寸) - 用于 DeviceProfileSheet 列表行.
+ *
+ * 用极简 Canvas 画一个设备缩略图 (含 cutout 标识),
+ * 比例与真实 device 一致.
  */
-@Stable
-fun computeScaledHeight(outerWidth: Dp, profile: DeviceProfile): Dp {
-    val w = outerWidth.value
-    val h = w / profile.aspectRatio
-    return h.dp
+@Composable
+fun DeviceThumbnail(
+    profile: DeviceProfile,
+    modifier: Modifier = Modifier,
+    maxHeight: androidx.compose.ui.unit.Dp = 80.dp,
+) {
+    val density = LocalDensity.current
+    val aspect = profile.aspectRatio
+    val maxW = maxHeight * aspect
+    val cornerPx = with(density) { profile.cornerRadiusDp.dp.toPx() }
+    val cutoutColor = Color(0xFF000000)
+
+    BoxWithConstraints(
+        modifier = modifier
+            .height(maxHeight)
+            .width(maxW),
+        contentAlignment = Alignment.Center,
+    ) {
+        val width = maxWidth
+        val height = maxHeight
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(profile.chassisColor, RoundedCornerShape(profile.cornerRadiusDp.dp + 2.dp))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(2.dp)
+                    .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
+                    .background(Color(0xFF101015)),
+            ) {
+                // 屏幕内容用空 Box
+                Spacer(modifier = Modifier.fillMaxSize())
+
+                // Cutout 缩略图
+                when (val c = profile.cutout) {
+                    is CutoutGeometry.Notch -> {
+                        val w = with(density) { c.widthDp.dp.toPx() } * 0.05f
+                        val h = with(density) { c.heightDp.dp.toPx() } * 0.05f
+                        Box(
+                            modifier = Modifier
+                                .offset {
+                                    IntOffset(
+                                        ((width.toPx() - w) / 2f).roundToInt(),
+                                        0
+                                    )
+                                }
+                                .size(with(density) { w.toDp() }, with(density) { h.toDp() })
+                                .background(cutoutColor, RoundedCornerShape(2.dp))
+                        )
+                    }
+                    is CutoutGeometry.PunchHole -> {
+                        val d = with(density) { c.diameterDp.dp.toPx() } * 0.05f
+                        Box(
+                            modifier = Modifier
+                                .offset {
+                                    IntOffset(
+                                        (width.toPx() / 2f - d / 2f).roundToInt(),
+                                        (with(density) { 4.dp.toPx() }).roundToInt()
+                                    )
+                                }
+                                .size(with(density) { d.toDp() })
+                                .background(cutoutColor, androidx.compose.foundation.shape.CircleShape)
+                        )
+                    }
+                    is CutoutGeometry.WaterfallCurve -> {
+                        // 瀑布屏只在两侧画一条暗带
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .drawBehind {
+                                    val w = size.width * 0.04f
+                                    drawRect(
+                                        color = cutoutColor,
+                                        topLeft = Offset(0f, 0f),
+                                        size = Size(w, size.height),
+                                    )
+                                    drawRect(
+                                        color = cutoutColor,
+                                        topLeft = Offset(size.width - w, 0f),
+                                        size = Size(w, size.height),
+                                    )
+                                }
+                        )
+                    }
+                    null -> {}
+                }
+            }
+        }
+    }
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceProfile.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceProfile.kt
@@ -17,21 +17,67 @@
 
 package com.itsaky.androidide.compose.preview.ui
 
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import com.itsaky.androidide.compose.preview.data.device.CutoutGeometry
+import com.itsaky.androidide.compose.preview.data.device.PhysicalKey
+
 /**
- * 设备 / 分辨率 配置.
+ * 设备 / 分辨率 配置 v2.1.
  *
- * 参考 Android Studio Compose Preview 模板, 提供常用 Pixel / Tablet / Foldable / Watch 尺寸.
- * 自定义场景下, 用户可填入任意 width × height × dpi.
+ * 描述一台真实设备 (Pixel / Huawei / iPhone / Foldable / Tablet / Watch)
+ * 在预览中如何被**视觉还原**:
+ *
+ * - 屏幕像素尺寸 + DPI → 计算 widthDp / heightDp
+ * - 形状 (圆角矩形 / 圆表 / 瀑布 / 折叠) → 决定 [DeviceFrame] 的裁切
+ * - 切口 (刘海 / 针孔 / 瀑布) → 叠加 [CutoutOverlay]
+ * - 边框 (上 / 下 / 左 / 右 dp) → 决定机身外壳
+ * - 物理按键 → 在屏幕外绘制矩形
+ * - 状态栏 / 导航栏 高度 → 模拟系统栏占用空间
+ *
+ * **保留** v2 旧字段 (widthPx / heightPx / densityDpi / frameStyle / isCustom),
+ * 这样 ComposePreviewFragment / ComposePreviewActivity 等旧入口不需要立刻全部迁移.
+ *
+ * @property id 唯一 ID, 用于 SharedPreferences / Catalog 查询
+ * @property manufacturer 厂商 ("Google" / "Huawei" / "Samsung" / "Apple" / ...)
+ * @property model 型号 ("Pixel 7 Pro" / "Galaxy Z Fold 5")
+ * @property osVersion 系统版本字符串 ("Android 14" / "iOS 17")
+ * @property formFactor 形态因子 (决定 [DeviceFrame] 渲染策略)
+ * @property widthPx 屏幕宽 (px)
+ * @property heightPx 屏幕高 (px)
+ * @property densityDpi 屏幕 DPI
+ * @property cornerRadiusDp 屏幕圆角
+ * @property cutout 切口几何 (刘海 / 针孔 / 瀑布); null = 无切口
+ * @property bezels 边框 (上下左右 dp)
+ * @property chassisColor 机身颜色
+ * @property physicalKeys 物理按键列表
+ * @property statusBarHeightDp 状态栏高度
+ * @property navigationBarHeightDp 导航栏高度
+ * @property frameStyle 旧字段, 由 [formFactor] 推导 (兼容)
+ * @property isCustom 是否为用户自定义
  */
+@Immutable
 data class DeviceProfile(
     val id: String,
     val displayName: String,
+    val manufacturer: String = "Generic",
+    val model: String = displayName,
+    val osVersion: String = "Android 14",
+    val formFactor: FormFactor = FormFactor.PHONE,
     val widthPx: Int,
     val heightPx: Int,
     val densityDpi: Int,
-    val frameStyle: FrameStyle = FrameStyle.PHONE,
+    val cornerRadiusDp: Float = 28f,
+    val cutout: CutoutGeometry? = null,
+    val bezels: Bezels = Bezels(),
+    val chassisColor: Color = Color(0xFF1A1A1F),
+    val physicalKeys: List<PhysicalKey> = PhysicalKey.NO_KEYS,
+    val statusBarHeightDp: Int = 24,
+    val navigationBarHeightDp: Int = 48,
+    val frameStyle: FrameStyle = formFactor.toFrameStyle(),
     val isCustom: Boolean = false,
 ) {
+
     /** width in dp. */
     val widthDp: Float get() = widthPx * 160f / densityDpi
 
@@ -40,70 +86,204 @@ data class DeviceProfile(
 
     val aspectRatio: Float get() = widthPx.toFloat() / heightPx
 
+    /** 是否圆表 (Watch) */
+    val isRound: Boolean get() = formFactor == FormFactor.WATCH
+
+    /** 是否包含刘海 */
+    val hasNotch: Boolean get() = cutout is CutoutGeometry.Notch
+
+    /** 是否包含针孔 */
+    val hasPunchHole: Boolean get() = cutout is CutoutGeometry.PunchHole
+
+    /** 是否瀑布屏 */
+    val hasWaterfall: Boolean get() = cutout is CutoutGeometry.WaterfallCurve
+
+    /** 是否折叠屏 (内屏 / 外屏) */
+    val isFoldable: Boolean
+        get() = formFactor == FormFactor.FOLDABLE_INNER || formFactor == FormFactor.FOLDABLE_OUTER
+
+    /** 是否为外屏 (foldable outer) */
+    val isFoldableOuter: Boolean get() = formFactor == FormFactor.FOLDABLE_OUTER
+
+    /** 屏幕对角线 (英寸, 用于 UI 显示) */
+    val diagonalInches: Float
+        get() {
+            val widthIn = widthPx / densityDpi.toFloat()
+            val heightIn = heightPx / densityDpi.toFloat()
+            return kotlin.math.sqrt(widthIn * widthIn + heightIn * heightIn)
+        }
+
+    /** v2 兼容字段. 由 [formFactor] 推导. */
     enum class FrameStyle { PHONE, TABLET, FOLDABLE, WATCH, NONE }
+
+    /** v2.1 设备形态. 决定 [DeviceFrame] 渲染策略. */
+    enum class FormFactor {
+        /** 传统 16:9 ~ 21:9 全面屏手机 */
+        PHONE,
+
+        /** 折叠屏内屏 (展开后) - 大屏, 无 cutout */
+        FOLDABLE_INNER,
+
+        /** 折叠屏外屏 (折叠后) - 小屏, 有 cutout */
+        FOLDABLE_OUTER,
+
+        /** 平板 (10"~13") */
+        TABLET,
+
+        /** Wear OS 圆形手表 */
+        WATCH,
+
+        /** 桌面 / 自由窗口模式 */
+        DESKTOP,
+
+        /** 不显示外壳 (透明背景) - 用于自定义测试 */
+        NONE;
+
+        internal fun toFrameStyle(): FrameStyle = when (this) {
+            PHONE -> FrameStyle.PHONE
+            FOLDABLE_INNER, FOLDABLE_OUTER -> FrameStyle.FOLDABLE
+            TABLET -> FrameStyle.TABLET
+            WATCH -> FrameStyle.WATCH
+            DESKTOP -> FrameStyle.NONE
+            NONE -> FrameStyle.NONE
+        }
+    }
+
+    /**
+     * 设备边框 (上 / 下 / 左 / 右 dp).
+     *
+     * 用于 [DeviceFrame] 渲染机身外壳的厚度. 现代全面屏手机
+     * 上边框通常 4~6dp, 下边框 8~10dp (含 home indicator 区域).
+     *
+     * @property topDp 顶部边框
+     * @property bottomDp 底部边框
+     * @property leftDp 左侧边框
+     * @property rightDp 右侧边框
+     */
+    @Immutable
+    data class Bezels(
+        val topDp: Float = 4f,
+        val bottomDp: Float = 8f,
+        val leftDp: Float = 4f,
+        val rightDp: Float = 4f,
+    ) {
+        companion object {
+            /** 现代全面屏手机 (Pixel 7) */
+            val PHONE_MODERN: Bezels = Bezels(topDp = 4f, bottomDp = 8f, leftDp = 4f, rightDp = 4f)
+            /** 传统 16:9 手机 (顶部摄像头 / 听筒) */
+            val PHONE_LEGACY: Bezels = Bezels(topDp = 24f, bottomDp = 16f, leftDp = 4f, rightDp = 4f)
+            /** 平板 */
+            val TABLET: Bezels = Bezels(topDp = 16f, bottomDp = 16f, leftDp = 16f, rightDp = 16f)
+            /** 折叠屏内屏 (极窄边框) */
+            val FOLDABLE_INNER: Bezels = Bezels(topDp = 2f, bottomDp = 2f, leftDp = 2f, rightDp = 2f)
+            /** 折叠屏外屏 (类似传统手机) */
+            val FOLDABLE_OUTER: Bezels = Bezels(topDp = 4f, bottomDp = 8f, leftDp = 4f, rightDp = 4f)
+            /** 手表 (无边框, 圆形) */
+            val WATCH: Bezels = Bezels(0f, 0f, 0f, 0f)
+        }
+    }
 }
 
+/**
+ * 内置常用设备 (v2 兼容) + v2.1 扩展.
+ *
+ * 详细 30+ 真实设备清单见 [com.itsaky.androidide.compose.preview.data.device.DeviceCatalog].
+ */
 object DeviceProfiles {
+
+    // === v2 旧 Profile (保留, 旧入口仍可用) ===
 
     val PIXEL_4 = DeviceProfile(
         id = "pixel-4",
         displayName = "Pixel 4",
-        widthPx = 1080, heightPx = 2280, densityDpi = 440
+        widthPx = 1080, heightPx = 2280, densityDpi = 440,
+        cornerRadiusDp = 24f,
+        bezels = DeviceProfile.Bezels.PHONE_LEGACY,
+        statusBarHeightDp = 28,
     )
 
     val PIXEL_5 = DeviceProfile(
         id = "pixel-5",
         displayName = "Pixel 5",
-        widthPx = 1080, heightPx = 2340, densityDpi = 440
+        widthPx = 1080, heightPx = 2340, densityDpi = 440,
+        cornerRadiusDp = 28f,
+        bezels = DeviceProfile.Bezels.PHONE_MODERN,
+        cutout = CutoutGeometry.PIXEL_PUNCHHOLE,
     )
 
     val PIXEL_6 = DeviceProfile(
         id = "pixel-6",
         displayName = "Pixel 6",
-        widthPx = 1080, heightPx = 2400, densityDpi = 420
+        widthPx = 1080, heightPx = 2400, densityDpi = 420,
+        cornerRadiusDp = 28f,
+        bezels = DeviceProfile.Bezels.PHONE_MODERN,
+        cutout = CutoutGeometry.PIXEL_PUNCHHOLE,
     )
 
     val PIXEL_7 = DeviceProfile(
         id = "pixel-7",
         displayName = "Pixel 7",
-        widthPx = 1080, heightPx = 2400, densityDpi = 420
+        widthPx = 1080, heightPx = 2400, densityDpi = 420,
+        cornerRadiusDp = 28f,
+        bezels = DeviceProfile.Bezels.PHONE_MODERN,
+        cutout = CutoutGeometry.PIXEL_PUNCHHOLE,
     )
 
     val PIXEL_TABLET = DeviceProfile(
         id = "pixel-tablet",
         displayName = "Pixel Tablet",
         widthPx = 1600, heightPx = 2560, densityDpi = 320,
-        frameStyle = DeviceProfile.FrameStyle.TABLET
+        cornerRadiusDp = 16f,
+        formFactor = DeviceProfile.FormFactor.TABLET,
+        bezels = DeviceProfile.Bezels.TABLET,
+        statusBarHeightDp = 24,
     )
 
     val FOLDABLE_INNER = DeviceProfile(
         id = "foldable-inner",
         displayName = "Foldable (Inner)",
         widthPx = 2208, heightPx = 1840, densityDpi = 420,
-        frameStyle = DeviceProfile.FrameStyle.FOLDABLE
+        cornerRadiusDp = 4f,
+        formFactor = DeviceProfile.FormFactor.FOLDABLE_INNER,
+        bezels = DeviceProfile.Bezels.FOLDABLE_INNER,
+        statusBarHeightDp = 24,
     )
 
     val WEAR_OS_SMALL = DeviceProfile(
         id = "wear-small",
         displayName = "Wear OS Small",
         widthPx = 384, heightPx = 384, densityDpi = 320,
-        frameStyle = DeviceProfile.FrameStyle.WATCH
+        cornerRadiusDp = 192f,
+        formFactor = DeviceProfile.FormFactor.WATCH,
+        bezels = DeviceProfile.Bezels.WATCH,
+        statusBarHeightDp = 0,
+        navigationBarHeightDp = 0,
     )
 
     val WEAR_OS_LARGE = DeviceProfile(
         id = "wear-large",
         displayName = "Wear OS Large",
         widthPx = 454, heightPx = 454, densityDpi = 320,
-        frameStyle = DeviceProfile.FrameStyle.WATCH
+        cornerRadiusDp = 227f,
+        formFactor = DeviceProfile.FormFactor.WATCH,
+        bezels = DeviceProfile.Bezels.WATCH,
+        statusBarHeightDp = 0,
+        navigationBarHeightDp = 0,
     )
 
-    /** 全部内置 profile. */
+    /** v2 旧内置 profile 列表. */
     val builtins: List<DeviceProfile> = listOf(
         PIXEL_4, PIXEL_5, PIXEL_6, PIXEL_7,
         PIXEL_TABLET, FOLDABLE_INNER,
         WEAR_OS_SMALL, WEAR_OS_LARGE
     )
 
+    /**
+     * 按 id 查找. 空 id 视为 Pixel 6 (默认).
+     *
+     * 注意: 仅在 v2 旧入口中调用. v2.1 新入口应改用
+     * [com.itsaky.androidide.compose.preview.data.device.DeviceCatalog.byId].
+     */
     fun findById(id: String): DeviceProfile? =
         if (id.isBlank()) PIXEL_6 else builtins.firstOrNull { it.id == id }
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceProfileSheet.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceProfileSheet.kt
@@ -53,13 +53,24 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.itsaky.androidide.compose.preview.data.device.CutoutGeometry
+import com.itsaky.androidide.compose.preview.data.device.DeviceCatalog
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile.FormFactor
 
 /**
- * 设备选择底部 Sheet.
+ * 设备选择底部 Sheet v2.1.
  *
- * 用户在预览时点击 "设备" 按钮, 弹出此 Sheet, 从 [DeviceProfiles.builtins] 选中一台.
+ * 按 [FormFactor] 分组显示内置 30+ 真实设备, 每行带:
+ * - 设备缩略图 (含 cutout 标识)
+ * - 设备名 / 厂商 / 型号
+ * - 分辨率 (px × px @ dpi)
+ * - 屏幕宽 (dp)
+ *
+ * 分组顺序: Phone → Foldable → Tablet → Watch → Desktop.
  *
  * @param onSelect 用户选中设备, 回调; selectedId 用于高亮当前选中.
+ * @param onCustom 跳转到 ResolutionEditor
+ * @param onDismiss 关闭 sheet
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -85,20 +96,42 @@ fun DeviceProfileSheet(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(vertical = 12.dp)
             )
-            HorizontalDivider()
+            Text(
+                text = "${DeviceCatalog.builtinProfiles.size} 个真实设备 · 按形态分组",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
             LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                items(DeviceProfiles.builtins) { profile ->
-                    DeviceProfileRow(
-                        profile = profile,
-                        selected = profile.id == selectedId,
-                        onClick = {
-                            onSelect(profile)
-                            onDismiss()
+                // 按 formFactor 顺序
+                val order = listOf(
+                    FormFactor.PHONE,
+                    FormFactor.FOLDABLE_OUTER,
+                    FormFactor.FOLDABLE_INNER,
+                    FormFactor.TABLET,
+                    FormFactor.WATCH,
+                    FormFactor.DESKTOP,
+                )
+                order.forEach { ff ->
+                    val list = DeviceCatalog.byFormFactor(ff)
+                    if (list.isNotEmpty()) {
+                        item(key = "header_${ff.name}") {
+                            FormFactorHeader(ff = ff, count = list.size)
                         }
-                    )
+                        items(list, key = { it.id }) { profile ->
+                            DeviceProfileRow(
+                                profile = profile,
+                                selected = profile.id == selectedId,
+                                onClick = {
+                                    onSelect(profile)
+                                    onDismiss()
+                                }
+                            )
+                        }
+                    }
                 }
-                item {
+                item(key = "custom_btn") {
                     TextButton(
                         onClick = {
                             onCustom()
@@ -118,35 +151,48 @@ fun DeviceProfileSheet(
 }
 
 @Composable
+private fun FormFactorHeader(ff: FormFactor, count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = iconForFormFactor(ff),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = labelForFormFactor(ff) + " · $count",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
 private fun DeviceProfileRow(
     profile: DeviceProfile,
     selected: Boolean,
     onClick: () -> Unit,
 ) {
+    val bg = if (selected) MaterialTheme.colorScheme.primaryContainer
+    else androidx.compose.ui.graphics.Color.Transparent
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(bg)
             .clickable(onClick = onClick)
-            .padding(vertical = 12.dp, horizontal = 4.dp),
+            .padding(vertical = 8.dp, horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(
-                    if (selected) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.surfaceVariant
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = iconForStyle(profile.frameStyle),
-                contentDescription = null,
-                tint = if (selected) MaterialTheme.colorScheme.onPrimary
-                else MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        // 缩略图
+        DeviceThumbnail(profile = profile, maxHeight = 48.dp)
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -155,23 +201,47 @@ private fun DeviceProfileRow(
                 fontWeight = FontWeight.Medium,
             )
             Text(
-                text = "${profile.widthPx} × ${profile.heightPx} @ ${profile.densityDpi}dpi",
+                text = "${profile.manufacturer} · ${profile.widthPx}×${profile.heightPx} @ ${profile.densityDpi}dpi",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            val cutoutText = when (profile.cutout) {
+                is CutoutGeometry.Notch -> "Notch"
+                is CutoutGeometry.PunchHole -> "Punch-hole"
+                is CutoutGeometry.WaterfallCurve -> "Waterfall"
+                null -> "No cutout"
+            }
+            Text(
+                text = "%.0f dp · %s · %s".format(profile.widthDp, profile.osVersion, cutoutText),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        Text(
-            text = "%.0f dp".format(profile.widthDp),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (selected) {
+            Icon(
+                imageVector = Icons.Filled.Smartphone,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
     }
 }
 
-private fun iconForStyle(style: DeviceProfile.FrameStyle): ImageVector = when (style) {
-    DeviceProfile.FrameStyle.PHONE -> Icons.Filled.Smartphone
-    DeviceProfile.FrameStyle.TABLET -> Icons.Filled.Tablet
-    DeviceProfile.FrameStyle.FOLDABLE -> Icons.Filled.Phone
-    DeviceProfile.FrameStyle.WATCH -> Icons.Filled.Watch
-    DeviceProfile.FrameStyle.NONE -> Icons.Filled.Smartphone
+private fun iconForFormFactor(ff: FormFactor): ImageVector = when (ff) {
+    FormFactor.PHONE -> Icons.Filled.Smartphone
+    FormFactor.FOLDABLE_INNER, FormFactor.FOLDABLE_OUTER -> Icons.Filled.Phone
+    FormFactor.TABLET -> Icons.Filled.Tablet
+    FormFactor.WATCH -> Icons.Filled.Watch
+    FormFactor.DESKTOP -> Icons.Filled.Phone
+    FormFactor.NONE -> Icons.Filled.Smartphone
+}
+
+private fun labelForFormFactor(ff: FormFactor): String = when (ff) {
+    FormFactor.PHONE -> "Phone"
+    FormFactor.FOLDABLE_INNER -> "Foldable (Inner)"
+    FormFactor.FOLDABLE_OUTER -> "Foldable (Outer)"
+    FormFactor.TABLET -> "Tablet"
+    FormFactor.WATCH -> "Watch"
+    FormFactor.DESKTOP -> "Desktop"
+    FormFactor.NONE -> "Custom"
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/FoldableHingeOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/FoldableHingeOverlay.kt
@@ -1,0 +1,101 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+/**
+ * 折叠屏铰链 (hinge) 视觉叠加层.
+ *
+ * 在折叠屏内屏中央画一条**垂直阴影 + 折痕线**, 模拟真实折叠屏
+ * 物理铰链对屏幕的影响:
+ *
+ * - 中心 4dp 宽: 一条深色折痕
+ * - 两侧各 28dp: 阴影渐变 (从中央深到两侧透明)
+ *
+ * **注意**: 这是**视觉示意**, 不是 1:1 物理模拟. 真实铰链会
+ * 影响屏幕亮度 / 反射, 但因为预览中无法复现物理光, 这里只画
+ * 一条折痕 + 阴影给用户视觉提示.
+ *
+ * @param modifier 外部 modifier, 应该是被叠加在 [DeviceFrame] 屏幕
+ *                 内容上方并填满屏幕. 铰链位置由 [horizontal] 决定.
+ * @param horizontal 铰链方向. `true` = 横向 (Galaxy Z Fold 内屏,
+ *                   横向) ; `false` = 竖向 (Surface Duo).
+ * @param shadowWidthDp 两侧阴影宽度 (默认 28dp)
+ * @param creaseWidthDp 中间折痕宽度 (默认 4dp)
+ * @param shadowColor 阴影 / 折痕颜色
+ */
+@Composable
+fun FoldableHingeOverlay(
+    modifier: Modifier = Modifier,
+    horizontal: Boolean = true,
+    shadowWidthDp: Float = 28f,
+    creaseWidthDp: Float = 4f,
+    shadowColor: Color = Color(0x60000000),
+    creaseColor: Color = Color(0xFF000000),
+) {
+    Canvas(modifier = modifier) {
+        val density = this.density
+        val shadowPx = shadowWidthDp * density
+        val creasePx = creaseWidthDp * density
+
+        if (horizontal) {
+            // 横向铰链 - 中间一条垂直阴影
+            val centerX = size.width / 2f
+
+            // 左阴影 (从 center 渐变到透明)
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(Color.Transparent, shadowColor, shadowColor, Color.Transparent),
+                    startX = centerX - shadowPx - creasePx,
+                    endX = centerX + shadowPx + creasePx,
+                ),
+                topLeft = Offset(centerX - shadowPx - creasePx, 0f),
+                size = androidx.compose.ui.geometry.Size(shadowPx * 2f + creasePx, size.height),
+            )
+            // 折痕
+            drawRect(
+                color = creaseColor,
+                topLeft = Offset(centerX - creasePx / 2f, 0f),
+                size = androidx.compose.ui.geometry.Size(creasePx, size.height),
+            )
+        } else {
+            // 竖向铰链 - 中间一条水平阴影
+            val centerY = size.height / 2f
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colors = listOf(Color.Transparent, shadowColor, shadowColor, Color.Transparent),
+                    startY = centerY - shadowPx - creasePx,
+                    endY = centerY + shadowPx + creasePx,
+                ),
+                topLeft = Offset(0f, centerY - shadowPx - creasePx),
+                size = androidx.compose.ui.geometry.Size(size.width, shadowPx * 2f + creasePx),
+            )
+            drawRect(
+                color = creaseColor,
+                topLeft = Offset(0f, centerY - creasePx / 2f),
+                size = androidx.compose.ui.geometry.Size(size.width, creasePx),
+            )
+        }
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
@@ -1,0 +1,202 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AspectRatio
+import androidx.compose.material.icons.filled.Brightness6
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Smartphone
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.ZoomIn
+import androidx.compose.material.icons.filled.ZoomOut
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * 预览顶栏工具 v2.1.
+ *
+ * 显示在 [ComposePreviewActivity] 顶部, 提供:
+ * - 设备切换 (chip 文本 = 当前设备名; 点击弹 [DeviceProfileSheet])
+ * - 主题切换 (Light / Dark / Custom 循环)
+ * - 缩放控制 (zoom out / zoom in / fit)
+ * - 系统栏显示开关
+ * - 调试开关 (P1 占位, 留口)
+ * - 关闭按钮
+ *
+ * 状态:
+ * - [PreviewToolbarState] 描述所有可观察状态
+ * - [PreviewToolbarActions] 描述所有用户行为
+ *
+ * @param state 当前状态
+ * @param actions 行为回调
+ * @param modifier modifier
+ */
+@Composable
+fun PreviewToolbar(
+    state: PreviewToolbarState,
+    actions: PreviewToolbarActions,
+    modifier: Modifier = Modifier,
+) {
+    val scroll = rememberScrollState()
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .horizontalScroll(scroll)
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        // 设备 chip
+        AssistChip(
+            onClick = actions.onOpenDeviceSheet,
+            label = { Text(state.deviceName) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.Smartphone,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        // 主题 chip
+        AssistChip(
+            onClick = actions.onCycleTheme,
+            label = { Text(state.themeLabel) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.Brightness6,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        // 缩放信息
+        AssistChip(
+            onClick = actions.onFitZoom,
+            label = { Text("%.0f%%".format(state.zoom * 100)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.AspectRatio,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        // Zoom out
+        IconButton(onClick = { actions.onSetZoom(state.zoom - 0.1f) }) {
+            Icon(Icons.Filled.ZoomOut, contentDescription = "Zoom out")
+        }
+
+        // Zoom in
+        IconButton(onClick = { actions.onSetZoom(state.zoom + 0.1f) }) {
+            Icon(Icons.Filled.ZoomIn, contentDescription = "Zoom in")
+        }
+
+        // 系统栏可见性 toggle
+        FilterChip(
+            selected = state.showSystemBars,
+            onClick = actions.onToggleSystemBars,
+            label = { Text(if (state.showSystemBars) "Bars" else "Hidden") },
+            leadingIcon = {
+                Icon(
+                    imageVector = if (state.showSystemBars) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        // 调试开关
+        FilterChip(
+            selected = state.debugEnabled,
+            onClick = actions.onToggleDebug,
+            label = { Text("Debug") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.BugReport,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // 关闭
+        IconButton(onClick = actions.onClose) {
+            Icon(Icons.Filled.Close, contentDescription = "Close")
+        }
+    }
+}
+
+/**
+ * 顶栏状态 (Snapshot).
+ */
+data class PreviewToolbarState(
+    val deviceName: String = "Pixel 7",
+    val themeLabel: String = "Light",
+    val zoom: Float = 1.0f,
+    val showSystemBars: Boolean = true,
+    val debugEnabled: Boolean = false,
+)
+
+/**
+ * 顶栏行为回调.
+ */
+data class PreviewToolbarActions(
+    val onOpenDeviceSheet: () -> Unit,
+    val onCycleTheme: () -> Unit,
+    val onSetZoom: (Float) -> Unit,
+    val onFitZoom: () -> Unit,
+    val onToggleSystemBars: () -> Unit,
+    val onToggleDebug: () -> Unit,
+    val onClose: () -> Unit,
+)

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ResolutionEditor.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ResolutionEditor.kt
@@ -24,8 +24,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -35,16 +40,27 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.itsaky.androidide.compose.preview.data.device.CutoutGeometry
 
 /**
- * 自定义分辨率编辑器.
+ * 自定义分辨率 / 形态 / 切口 编辑器 v2.1.
  *
- * 用户可输入 width × height × dpi 来自定义设备尺寸.
- * 默认填入当前 [initial] 的值, 确认后通过 [onConfirm] 回调传出.
+ * 用户可输入:
+ * - width × height × dpi
+ * - 形态因子 (Phone / Foldable / Tablet / Watch / Desktop)
+ * - 切口 (None / Notch / PunchHole / Waterfall)
+ *
+ * 实时显示预览尺寸 (dp).
+ *
+ * @param initial 初始 profile
+ * @param onConfirm 确认时传出新 profile
+ * @param onDismiss 取消
  */
 @Composable
 fun ResolutionEditor(
@@ -55,15 +71,59 @@ fun ResolutionEditor(
     var width by remember { mutableStateOf(initial.widthPx.toString()) }
     var height by remember { mutableStateOf(initial.heightPx.toString()) }
     var dpi by remember { mutableStateOf(initial.densityDpi.toString()) }
+    var formFactor by remember { mutableStateOf(initial.formFactor) }
+    var cutoutKind by remember { mutableStateOf(initial.cutout?.kind() ?: CutoutKind.NONE) }
+    var cornerRadius by remember { mutableStateOf(initial.cornerRadiusDp.toString()) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("自定义分辨率", fontWeight = FontWeight.SemiBold) },
+        title = { Text("自定义设备", fontWeight = FontWeight.SemiBold) },
         text = {
             Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                // 形态因子
+                Text(
+                    text = "形态",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.padding(vertical = 4.dp)
                 ) {
+                    items(DeviceProfile.FormFactor.values().toList()) { ff ->
+                        FilterChip(
+                            selected = formFactor == ff,
+                            onClick = { formFactor = ff },
+                            label = { Text(ff.name) },
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 切口
+                Text(
+                    text = "切口 (Cutout)",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.padding(vertical = 4.dp)
+                ) {
+                    items(CutoutKind.values().toList()) { kind ->
+                        FilterChip(
+                            selected = cutoutKind == kind,
+                            onClick = { cutoutKind = kind },
+                            label = { Text(kind.displayName) },
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 分辨率
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
                         value = width,
                         onValueChange = { width = it.filter { c -> c.isDigit() } },
@@ -82,20 +142,29 @@ fun ResolutionEditor(
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = dpi,
-                    onValueChange = { dpi = it.filter { c -> c.isDigit() } },
-                    label = { Text("Density (dpi)") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = dpi,
+                        onValueChange = { dpi = it.filter { c -> c.isDigit() } },
+                        label = { Text("Density (dpi)") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    )
+                    OutlinedTextField(
+                        value = cornerRadius,
+                        onValueChange = { cornerRadius = it.filter { c -> c.isDigit() || c == '.' } },
+                        label = { Text("Corner (dp)") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                    )
+                }
                 Spacer(modifier = Modifier.height(8.dp))
+                val w = width.toIntOrNull() ?: initial.widthPx
+                val h = height.toIntOrNull() ?: initial.heightPx
+                val d = dpi.toIntOrNull() ?: initial.densityDpi
                 Text(
-                    text = "预览尺寸: %.0f × %.0f dp".format(
-                        (width.toIntOrNull() ?: initial.widthPx) * 160f / (dpi.toIntOrNull() ?: initial.densityDpi),
-                        (height.toIntOrNull() ?: initial.heightPx) * 160f / (dpi.toIntOrNull() ?: initial.densityDpi)
-                    ),
+                    text = "预览尺寸: %.0f × %.0f dp".format(w * 160f / d, h * 160f / d),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -106,13 +175,17 @@ fun ResolutionEditor(
                 val w = width.toIntOrNull() ?: initial.widthPx
                 val h = height.toIntOrNull() ?: initial.heightPx
                 val d = dpi.toIntOrNull()?.coerceIn(120, 800) ?: initial.densityDpi
+                val r = cornerRadius.toFloatOrNull()?.coerceIn(0f, 200f) ?: initial.cornerRadiusDp
                 onConfirm(
                     initial.copy(
-                        id = "custom-${w}x${h}@${d}",
-                        displayName = "Custom ${w}×${h}",
+                        id = "custom-${w}x${h}@${d}-${formFactor.name}",
+                        displayName = "Custom ${w}×${h} ${formFactor.name.lowercase()}",
                         widthPx = w,
                         heightPx = h,
                         densityDpi = d,
+                        formFactor = formFactor,
+                        cornerRadiusDp = r,
+                        cutout = cutoutKind.toCutoutGeometry(),
                         isCustom = true,
                     )
                 )
@@ -122,4 +195,27 @@ fun ResolutionEditor(
             TextButton(onClick = onDismiss) { Text("取消") }
         }
     )
+}
+
+/**
+ * 切口类型 (在 ResolutionEditor 中作为 chip 显示).
+ */
+internal enum class CutoutKind(val displayName: String) {
+    NONE("None"),
+    NOTCH("Notch"),
+    PUNCH_HOLE("Punch"),
+    WATERFALL("Waterfall");
+
+    fun toCutoutGeometry(): CutoutGeometry? = when (this) {
+        NONE -> null
+        NOTCH -> CutoutGeometry.IPHONE_14_NOTCH
+        PUNCH_HOLE -> CutoutGeometry.PIXEL_PUNCHHOLE
+        WATERFALL -> CutoutGeometry.HUAWEI_WATERFALL
+    }
+}
+
+private fun CutoutGeometry.kind(): CutoutKind = when (this) {
+    is CutoutGeometry.Notch -> CutoutKind.NOTCH
+    is CutoutGeometry.PunchHole -> CutoutKind.PUNCH_HOLE
+    is CutoutGeometry.WaterfallCurve -> CutoutKind.WATERFALL
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
@@ -1,0 +1,421 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import kotlinx.coroutines.delay
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * 系统状态栏 + 导航栏叠加层 v2.1.
+ *
+ * 模拟 Android / iOS 系统栏:
+ * - 状态栏 (顶部): 时钟 + 信号 + Wi-Fi + 电池 + 通知红点
+ * - 导航栏 (底部): 返回 / Home / 最近 (传统三键) 或手势横杠
+ *
+ * 主题:
+ * - [SystemBarsTheme.LIGHT]    : 深色图标 / 浅色背景
+ * - [SystemBarsTheme.DARK]     : 浅色图标 / 深色背景
+ * - [SystemBarsTheme.TRANSLUCENT_LIGHT] : 半透明 + 浅色图标
+ * - [SystemBarsTheme.TRANSLUCENT_DARK]  : 半透明 + 深色图标
+ * - [SystemBarsTheme.AUTO]     : 跟随 Composable 主题
+ *
+ * 高度按 [DeviceProfile.statusBarHeightDp] / [DeviceProfile.navigationBarHeightDp].
+ *
+ * @param profile 设备 profile
+ * @param systemBarsTheme 主题
+ * @param showStatusBar 是否显示状态栏
+ * @param showNavigationBar 是否显示导航栏
+ * @param useGestureNav 是否使用手势导航 (vs 传统三键)
+ * @param clockProvider 时钟来源 (默认取系统时区当前时间)
+ * @param batteryPercent 电量百分比 (0..100, null = 不显示)
+ * @param notificationDot 是否显示通知小红点
+ */
+@Composable
+fun SystemBarsOverlay(
+    profile: DeviceProfile,
+    systemBarsTheme: SystemBarsTheme = SystemBarsTheme.AUTO,
+    showStatusBar: Boolean = true,
+    showNavigationBar: Boolean = true,
+    useGestureNav: Boolean = false,
+    clockProvider: () -> Date = { Date() },
+    batteryPercent: Int? = 85,
+    notificationDot: Boolean = true,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val isDarkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    val resolvedTheme = when (systemBarsTheme) {
+        SystemBarsTheme.AUTO -> if (isDarkTheme) SystemBarsTheme.DARK else SystemBarsTheme.LIGHT
+        else -> systemBarsTheme
+    }
+    val (bg, fg) = resolvedTheme.colors()
+
+    // 时钟 10s 刷新
+    var now by remember { mutableStateOf(Date()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            now = clockProvider()
+            delay(10_000)
+        }
+    }
+    val timeText = remember(now) {
+        SimpleDateFormat("HH:mm", Locale.getDefault()).format(now)
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        // 状态栏
+        if (showStatusBar && profile.statusBarHeightDp > 0) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(profile.statusBarHeightDp.dp)
+            ) {
+                StatusBarContent(
+                    time = timeText,
+                    foreground = fg,
+                    background = bg,
+                    isTranslucent = resolvedTheme.isTranslucent(),
+                    batteryPercent = batteryPercent,
+                    notificationDot = notificationDot,
+                )
+            }
+        } else {
+            Spacer(Modifier.height(0.dp))
+        }
+
+        // 中间留空 (由外部 content 占位)
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 导航栏
+        if (showNavigationBar && profile.navigationBarHeightDp > 0) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(profile.navigationBarHeightDp.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                NavigationBarContent(
+                    foreground = fg,
+                    background = bg,
+                    isTranslucent = resolvedTheme.isTranslucent(),
+                    useGestureNav = useGestureNav,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBarContent(
+    time: String,
+    foreground: Color,
+    background: Color,
+    isTranslucent: Boolean,
+    batteryPercent: Int?,
+    notificationDot: Boolean,
+) {
+    val bg = if (isTranslucent) Color.Transparent else background
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 8.dp)
+    ) {
+        val density = LocalDensity.current
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            if (!isTranslucent) {
+                drawRect(color = background)
+            } else {
+                drawRect(
+                    color = background.copy(alpha = 0.6f)
+                )
+            }
+        }
+
+        // 左侧: 时钟
+        Text(
+            text = time,
+            color = foreground,
+            fontSize = 12.sp,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(start = 4.dp)
+        )
+
+        // 右侧: 信号 / Wi-Fi / 电池 / 通知
+        Canvas(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxSize()
+                .padding(end = 4.dp)
+        ) {
+            drawRightCluster(
+                foreground = foreground,
+                batteryPercent = batteryPercent,
+                notificationDot = notificationDot,
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawRightCluster(
+    foreground: Color,
+    batteryPercent: Int?,
+    notificationDot: Boolean,
+) {
+    val right = size.width
+    val centerY = size.height / 2f
+    val cellH = size.height * 0.5f
+    val cellW = cellH
+
+    // 通知小红点 (在最右)
+    if (notificationDot) {
+        val dotR = cellH * 0.18f
+        drawCircle(
+            color = Color(0xFFE53935),
+            radius = dotR,
+            center = Offset(right - dotR, centerY)
+        )
+        val consumed = dotR * 2f + 4f
+        // 不影响其他绘制, 仅占空间
+        @Suppress("UNUSED_VARIABLE")
+        val _x = consumed
+    }
+
+    // 电池 (最右第二个)
+    val batteryWidth = cellW * 1.2f
+    val batteryHeight = cellH * 0.55f
+    val batteryLeft = right - batteryWidth - 4f
+    val batteryTop = centerY - batteryHeight / 2f
+    // 电池外框
+    drawRoundRect(
+        color = foreground,
+        topLeft = Offset(batteryLeft, batteryTop),
+        size = Size(batteryWidth * 0.85f, batteryHeight),
+        cornerRadius = CornerRadius(2f, 2f),
+        style = Stroke(width = 1f)
+    )
+    // 电池正极
+    drawRoundRect(
+        color = foreground,
+        topLeft = Offset(batteryLeft + batteryWidth * 0.85f + 1f, centerY - batteryHeight * 0.18f),
+        size = Size(batteryWidth * 0.10f, batteryHeight * 0.36f),
+        cornerRadius = CornerRadius(0.5f, 0.5f),
+    )
+    // 电池填充
+    if (batteryPercent != null) {
+        val percent = batteryPercent.coerceIn(0, 100) / 100f
+        val fillColor = if (batteryPercent < 15) Color(0xFFE53935) else foreground
+        drawRoundRect(
+            color = fillColor,
+            topLeft = Offset(batteryLeft + 1.5f, batteryTop + 1.5f),
+            size = Size((batteryWidth * 0.85f - 3f) * percent, batteryHeight - 3f),
+            cornerRadius = CornerRadius(1f, 1f),
+        )
+    }
+
+    // Wi-Fi
+    val wifiRight = batteryLeft - 6f
+    val wifiCenterX = wifiRight - cellW * 0.4f
+    val wifiCenterY = centerY
+    // 简化为 3 个同心弧
+    for (i in 0 until 3) {
+        val r = (i + 1) * cellH * 0.18f
+        drawArc(
+            color = foreground.copy(alpha = (i + 1) * 0.3f),
+            startAngle = 220f,
+            sweepAngle = 100f,
+            useCenter = false,
+            topLeft = Offset(wifiCenterX - r, wifiCenterY - r),
+            size = Size(r * 2f, r * 2f),
+            style = Stroke(width = 1.4f)
+        )
+    }
+    drawCircle(
+        color = foreground,
+        radius = cellH * 0.1f,
+        center = Offset(wifiCenterX, wifiCenterY + cellH * 0.05f)
+    )
+
+    // 信号
+    val signalRight = wifiCenterX - cellW * 0.4f - 4f
+    val signalBarW = cellW * 0.16f
+    val signalBarH = cellH * 0.6f
+    for (i in 0 until 4) {
+        val h = signalBarH * (0.3f + i * 0.2f)
+        val x = signalRight - (4 - i) * (signalBarW + 1.5f) - signalBarW
+        val y = centerY + signalBarH / 2f - h
+        drawRoundRect(
+            color = foreground,
+            topLeft = Offset(x, y),
+            size = Size(signalBarW, h),
+            cornerRadius = CornerRadius(1f, 1f),
+        )
+    }
+}
+
+@Composable
+private fun NavigationBarContent(
+    foreground: Color,
+    background: Color,
+    isTranslucent: Boolean,
+    useGestureNav: Boolean,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            if (isTranslucent) {
+                drawRect(color = background.copy(alpha = 0.6f))
+            } else {
+                drawRect(color = background)
+            }
+        }
+        if (useGestureNav) {
+            // 手势导航: 中央一条 108dp × 4dp 横杠
+            val barW = 108f.dp.toPx()
+            val barH = 4f.dp.toPx()
+            Canvas(
+                modifier = Modifier
+                    .align(Alignment.Center)
+            ) {
+                val x = (size.width - barW) / 2f
+                val y = (size.height - barH) / 2f
+                drawRoundRect(
+                    color = foreground,
+                    topLeft = Offset(x, y),
+                    size = Size(barW, barH),
+                    cornerRadius = CornerRadius(barH / 2f, barH / 2f),
+                )
+            }
+        } else {
+            // 传统三键: 返回 / Home / 最近
+            Row3Buttons(foreground = foreground)
+        }
+    }
+}
+
+@Composable
+private fun Row3Buttons(foreground: Color) {
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize().padding(horizontal = 48.dp)
+    ) {
+        val centerY = maxHeight / 2
+        // 三个三角形 / 圆形 / 方形
+        // 返回 (左) - 三角形
+        Canvas(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+        ) {
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            val s = size.minDimension * 0.18f
+            val path = Path().apply {
+                moveTo(cx + s, cy - s)
+                lineTo(cx - s, cy)
+                lineTo(cx + s, cy + s)
+                close()
+            }
+            drawPath(path, foreground, style = Stroke(width = 1.6f))
+        }
+        // Home (中) - 圆形
+        Canvas(
+            modifier = Modifier
+                .align(Alignment.Center)
+        ) {
+            val r = size.minDimension * 0.18f
+            drawCircle(
+                color = foreground,
+                radius = r,
+                center = Offset(size.width / 2f, size.height / 2f),
+                style = Stroke(width = 1.6f)
+            )
+        }
+        // 最近 (右) - 矩形
+        Canvas(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+        ) {
+            val s = size.minDimension * 0.22f
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            drawRoundRect(
+                color = foreground,
+                topLeft = Offset(cx - s, cy - s * 0.7f),
+                size = Size(s * 2f, s * 1.4f),
+                cornerRadius = CornerRadius(2f, 2f),
+                style = Stroke(width = 1.6f)
+            )
+        }
+    }
+}
+
+/**
+ * 状态栏 / 导航栏主题.
+ */
+enum class SystemBarsTheme {
+    AUTO,
+    LIGHT,
+    DARK,
+    TRANSLUCENT_LIGHT,
+    TRANSLUCENT_DARK;
+
+    fun isTranslucent(): Boolean = this == TRANSLUCENT_LIGHT || this == TRANSLUCENT_DARK
+
+    fun colors(): Pair<Color, Color> = when (this) {
+        AUTO, LIGHT -> Color(0xFFFAFAFA) to Color(0xFF202024)
+        DARK -> Color(0xFF202024) to Color(0xFFFAFAFA)
+        TRANSLUCENT_LIGHT -> Color(0x00FAFAFA) to Color(0xFF202024)
+        TRANSLUCENT_DARK -> Color(0x00202024) to Color(0xFFFAFAFA)
+    }
+}
+
+/** Color luminance 计算 (0.0 ~ 1.0). */
+private fun Color.luminance(): Float {
+    return 0.2126f * red + 0.7152f * green + 0.0722f * blue
+}


### PR DESCRIPTION
## Summary

落地 `modules/compose-preview/TODO.md` 中 **P0 — 本轮 PR #N 必修** 全部任务（30+ 子任务），基于 v2 PR (#328) 之上把「可用」升级到「对标 AS 的生产力工具」。

## 新增文件 (8)

* `data/device/CutoutGeometry.kt` — sealed class (Notch / PunchHole / WaterfallCurve) + 常用预设
* `data/device/PhysicalKey.kt` — sealed class (Power / Vol+ / Vol- / Camera / Assistant)
* `data/device/DeviceCatalog.kt` — 内置 30+ 真实设备，按 formFactor 分组
* `ui/CutoutOverlay.kt` — Canvas 渲染三类切口
* `ui/FoldableHingeOverlay.kt` — 折叠屏铰链阴影
* `ui/SystemBarsOverlay.kt` — 状态栏 (时钟/电池/Wi-Fi/信号/通知) + 导航栏 (三键 / 手势横杠)
* `ui/PreviewToolbar.kt` — 顶栏 chip (设备/主题/缩放/调试/关闭)

## 重写文件 (4)

* `ui/DeviceProfile.kt` — 增 v2.1 字段 (formFactor / cutout / bezels / chassisColor / physicalKeys / isFoldable / isRound / isLightDark 等)，保留 v2 旧字段
* `ui/DeviceFrame.kt` — 重写一体化渲染 (外壳 / 边框 / 屏幕 / 切口 / 铰链 / 系统栏)，按 formFactor 策略，提供 `DeviceThumbnail` 缩略图
* `ui/DeviceProfileSheet.kt` — 按 formFactor 分组，缩略图 + 设备名 + 厂商 + 分辨率 + 切口
* `ui/ResolutionEditor.kt` — 增 formFactor chip + 切口 chip
* `ComposePreviewViewModel.kt` — 增 4 StateFlow (deviceConfig / viewport / theme / debugEnabled) + 6 方法 (selectDevice / setZoom / cycleTheme 等)
* `ComposePreviewActivity.kt` — 全 Compose UI 升级 (`setContent {}`)，状态分发完整
* `domain/PreviewSourceParser.kt` — 增 @PreviewParameter / @PreviewFontScale / @PreviewLightDark 解析

## build.gradle.kts

* 新增 `bytecodeAcceleratorJars` Configuration (P2-BLD-01 ASM 9.7)
* 新增 `copyBytecodeAcceleratorJars` 任务把 ASM jar 拷到 `build/compose-jars/asm/` 并打包进 `compose-jars.zip` assets
* `packageComposeJars` 依赖新增 `copyBytecodeAcceleratorJars`

## 设备覆盖 (30+)

| 分组 | 设备 |
| --- | --- |
| Phone | Pixel 7/7 Pro/8/8 Pro / Mate 60 Pro / P30 Pro (瀑布) / 小米 14 Pro / S24 Ultra / S23 / OnePlus 12 / Honor Magic 6 Pro |
| iPhone | 13 / 14 / 15 Pro / 15 Pro Max (Dynamic Island) |
| Foldable | Z Fold 5 (内+外) / Pixel Fold (内+外) / OPPO Find N3 (内+外) |
| Tablet | Pixel Tablet / iPad Pro 11" / iPad Pro 12.9" / Galaxy Tab S9 |
| Watch | Wear OS Small (384²) / Large (454²) / Square (390²) |
| Desktop | 1920×1080 |

## 切口覆盖

* **Notch**: iPhone 13 / 14 / 15 Pro (Dynamic Island)
* **PunchHole**: Pixel 居中 4dp / 华为 8dp / OnePlus 左上 / Foldable 外屏
* **Waterfall**: 华为 P30 Pro 88° 曲边

## 测试

* `./gradlew :modules:compose-preview:assembleDebug` (建议在 CI 跑)
* 5 种设备形态视觉对比截图 (Phone / Notch / PunchHole / Waterfall / Foldable)

## 后续 PR (TODO.md M2~M8)

* #N+1: DebugDrawer / Inspector / Recompose / Logcat
* #N+2: 可视化编辑 (拖动 / Resize / ColorPicker)
* #N+3: ASM 字节码加速 (AsmComposeBinder)
* #N+4: 折叠屏自动内/外屏切换
* #N+5: 性能调优 (Prewarm / DEX mmap 共享)
* #N+6: 多 Preview 网格 + @PreviewParameter 完整支持
* #N+7: LiveLiterals 实验

Refs: PR #329 (设计 + TODO), TODO.md "P0 — 本轮 PR #N 必修"