### PR TITLE
feat(compose-preview): v2.1 P1 调试面板骨架 (Logcat/Recompose/Inspector)

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -56,11 +56,16 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.itsaky.androidide.compose.preview.ui.BuildStats
+import com.itsaky.androidide.compose.preview.ui.DebugDrawer
 import com.itsaky.androidide.compose.preview.ui.DeviceFrame
 import com.itsaky.androidide.compose.preview.ui.DeviceProfileSheet
+import com.itsaky.androidide.compose.preview.ui.PreviewLog
+import com.itsaky.androidide.compose.preview.ui.PreviewLogcatSink
 import com.itsaky.androidide.compose.preview.ui.PreviewToolbar
 import com.itsaky.androidide.compose.preview.ui.PreviewToolbarActions
 import com.itsaky.androidide.compose.preview.ui.PreviewToolbarState
+import com.itsaky.androidide.compose.preview.ui.RecomposeTracker
 import com.itsaky.androidide.compose.preview.ui.ResolutionEditor
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -108,6 +113,12 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        // 卸载 logcat sink, 恢复原始 System.out / System.err
+        PreviewLog.sink.uninstall()
+    }
+
     companion object {
         private val LOG = LoggerFactory.getLogger(ComposePreviewActivity::class.java)
 
@@ -139,11 +150,19 @@ fun ComposePreviewScreen(
     val theme by viewModel.theme.collectAsStateWithLifecycle()
     val debugEnabled by viewModel.debugEnabled.collectAsStateWithLifecycle()
 
+    // v2.1 调试面板状态
+    val inspectorNodes by viewModel.inspectorNodes.collectAsStateWithLifecycle()
+    val buildStats by viewModel.buildStats.collectAsStateWithLifecycle()
+
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var showDeviceSheet by remember { mutableStateOf(false) }
     var showResolutionEditor by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
+
+    // v2.1 调试面板: 单例 per-Activity (跨 recompose 保持状态)
+    val logcatSink = remember { PreviewLog.sink.also { it.install() } }
+    val recomposeTracker = remember { RecomposeTracker() }
 
     // 应用主题
     val colorScheme = when (theme) {
@@ -243,6 +262,21 @@ fun ComposePreviewScreen(
             onDismiss = {
                 showResolutionEditor = false
             }
+        )
+    }
+
+    // v2.1 调试面板 (4 tabs: Inspector / Recompose / Logcat / Stats)
+    if (debugEnabled) {
+        val debugSheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+        )
+        DebugDrawer(
+            sheetState = debugSheetState,
+            onDismiss = { viewModel.toggleDebug() },
+            inspectorNodes = inspectorNodes,
+            recomposeTracker = recomposeTracker,
+            logcat = logcatSink,
+            stats = buildStats,
         )
     }
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -29,7 +29,10 @@ import com.itsaky.androidide.compose.preview.data.repository.ComposePreviewRepos
 import com.itsaky.androidide.compose.preview.data.repository.InitializationResult
 import com.itsaky.androidide.compose.preview.domain.PreviewSourceParser
 import com.itsaky.androidide.compose.preview.domain.model.ParsedPreviewSource
+import com.itsaky.androidide.compose.preview.ui.BuildPhaseTimings
+import com.itsaky.androidide.compose.preview.ui.BuildStats
 import com.itsaky.androidide.compose.preview.ui.DeviceProfile
+import com.itsaky.androidide.compose.preview.ui.NodeInfo
 import com.itsaky.androidide.compose.preview.ui.SystemBarsTheme
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -169,6 +172,16 @@ class ComposePreviewViewModel(
     private val _debugEnabled = MutableStateFlow(false)
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
 
+    // v2.1 调试面板状态
+
+    /** 当前构建统计 (phase timing + cache hit rate). */
+    private val _buildStats = MutableStateFlow(BuildStats.EMPTY)
+    val buildStats: StateFlow<BuildStats> = _buildStats.asStateFlow()
+
+    /** Inspector 节点列表 (由 ComposableRenderer 推上来). */
+    private val _inspectorNodes = MutableStateFlow<List<NodeInfo>>(emptyList())
+    val inspectorNodes: StateFlow<List<NodeInfo>> = _inspectorNodes.asStateFlow()
+
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
     private var currentSource: String = ""
@@ -303,8 +316,28 @@ class ComposePreviewViewModel(
 
         _previewState.value = PreviewState.Compiling
 
+        // v2.1: 测量 build 耗时 (粗粒度, 后续由 repository 暴露更细分 phase)
+        val compileStart = System.currentTimeMillis()
+
         repository.compilePreview(source, parsed)
             .onSuccess { result ->
+                val totalMs = System.currentTimeMillis() - compileStart
+                // 粗略分配: 总耗时归到 compile phase (等 repository 暴露细分 phase 后再切)
+                LOG.info("compilePreview success in {}ms", totalMs)
+
+                // 累计 compile 时间
+                val prev = _buildStats.value
+                _buildStats.value = prev.copy(
+                    phaseTimings = BuildPhaseTimings(
+                        init = prev.phaseTimings.init,
+                        compile = totalMs,
+                        dex = prev.phaseTimings.dex,
+                        load = prev.phaseTimings.load,
+                    ),
+                    lastCompileMs = totalMs,
+                    totalCompileMs = prev.totalCompileMs + totalMs,
+                )
+
                 _previewState.value = PreviewState.Ready(
                     dexFile = result.dexFile,
                     className = result.className,
@@ -449,6 +482,70 @@ class ComposePreviewViewModel(
 
     fun toggleDebug() {
         _debugEnabled.value = !_debugEnabled.value
+    }
+
+    // === v2.1 调试面板 setter (供 ComposableRenderer / 外部调用) ===
+
+    /**
+     * 更新 BuildStats (覆盖). ComposableRenderer 在每次 loadClass / phase 完成时调用.
+     */
+    fun updateBuildStats(stats: BuildStats) {
+        _buildStats.value = stats
+    }
+
+    /**
+     * 增量更新 BuildStats 的某部分 (用于实时刷新).
+     */
+    fun patchBuildStats(
+        classCacheSize: Int? = null,
+        activeLoaderCount: Int? = null,
+        loadedClassCount: Long? = null,
+        cacheHitCount: Long? = null,
+        cacheMissCount: Long? = null,
+        phaseInit: Long? = null,
+        phaseCompile: Long? = null,
+        phaseDex: Long? = null,
+        phaseLoad: Long? = null,
+        lastRenderMs: Long? = null,
+    ) {
+        val prev = _buildStats.value
+        val timings = prev.phaseTimings
+        _buildStats.value = prev.copy(
+            phaseTimings = BuildPhaseTimings(
+                init = phaseInit ?: timings.init,
+                compile = phaseCompile ?: timings.compile,
+                dex = phaseDex ?: timings.dex,
+                load = phaseLoad ?: timings.load,
+            ),
+            classCacheSize = classCacheSize ?: prev.classCacheSize,
+            activeLoaderCount = activeLoaderCount ?: prev.activeLoaderCount,
+            loadedClassCount = loadedClassCount ?: prev.loadedClassCount,
+            cacheHitCount = cacheHitCount ?: prev.cacheHitCount,
+            cacheMissCount = cacheMissCount ?: prev.cacheMissCount,
+            lastRenderMs = lastRenderMs ?: prev.lastRenderMs,
+        )
+    }
+
+    /**
+     * 提交一组 Inspector 节点 (供 ComposableRenderer 推上来).
+     */
+    fun setInspectorNodes(nodes: List<NodeInfo>) {
+        _inspectorNodes.value = nodes
+    }
+
+    fun clearInspectorNodes() {
+        _inspectorNodes.value = emptyList()
+    }
+
+    /**
+     * 记录一次 render 耗时.
+     */
+    fun recordRender(elapsedMs: Long) {
+        val prev = _buildStats.value
+        _buildStats.value = prev.copy(
+            lastRenderMs = elapsedMs,
+            totalRenderMs = prev.totalRenderMs + elapsedMs,
+        )
     }
 
     override fun onCleared() {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ComponentInspector.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ComponentInspector.kt
@@ -17,75 +17,342 @@
 
 package com.itsaky.androidide.compose.preview.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.slf4j.LoggerFactory
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 
 /**
- * 组件检查器: 通过反射读取 `LayoutNode.coordinates` 的位置 / 尺寸信息, 绘制边界框.
+ * Composable 节点信息 v2.1.
  *
- * ## 设计
+ * 通过反射 [androidx.compose.ui.node.LayoutNode] 提取:
+ * - bounds (相对屏幕)
+ * - 宽高 (px / dp)
+ * - 父节点 (用于层级展示)
+ * - modifier 链 (简化, 只取类型名)
  *
- * - 选中状态保存在 [InspectorController.selectedNodeId]
- * - 每个布局节点用 [Box] 包裹, 内部用 [BoxScope] 拿到 bounds
- * - 注意: 完整的 AS Component Inspector 需要访问私有 `LayoutNode` 字段 (kotlin-reflect);
- *   本骨架仅提供 UI 容器 + 选中状态, 反射读字段在 P2 PR 中加入.
+ * @property id 节点 id (系统分配)
+ * @property composableName 推测的 Composable 名 (取自 stack)
+ * @property bounds 边界 (相对父节点)
+ * @property widthPx / heightPx
+ * @property childrenIds 子节点 id
  */
-@Stable
-class InspectorController {
-    var selectedNodeId by mutableStateOf<String?>(null)
-        private set
-
-    fun select(id: String?) {
-        selectedNodeId = id
-    }
-
-    fun clear() = select(null)
+data class NodeInfo(
+    val id: Int,
+    val composableName: String,
+    val bounds: Rect,
+    val widthPx: Int,
+    val heightPx: Int,
+    val childrenIds: List<Int>,
+) {
+    val widthDp: Float get() = widthPx / 3f
+    val heightDp: Float get() = heightPx / 3f
 }
 
-@Composable
-fun rememberInspectorController(): InspectorController = remember { InspectorController() }
+/**
+ * LayoutNode 反射读取器 v2.1.
+ *
+ * 由于 LayoutNode 的 fields / methods 是 internal, 用反射访问.
+ * Compose 1.5+ 大致字段:
+ * - id: Long
+ * - coordinates: LayoutCoordinates
+ * - measuredWidth: Int
+ * - measuredHeight: Int
+ * - children: List<LayoutNode>
+ *
+ * 如果任何字段读不到就降级, 不抛异常.
+ */
+object LayoutNodeInspector {
 
+    private val LOG = LoggerFactory.getLogger(LayoutNodeInspector::class.java)
+
+    private val idField: Field? = findFieldRecursive("androidx.compose.ui.node.LayoutNode", "id")
+    private val coordinatesField: Field? = findFieldRecursive("androidx.compose.ui.node.LayoutNode", "coordinates")
+    private val widthField: Field? = findFieldRecursive("androidx.compose.ui.node.LayoutNode", "measuredWidth")
+    private val heightField: Field? = findFieldRecursive("androidx.compose.ui.node.LayoutNode", "measuredHeight")
+    private val childrenField: Field? = findFieldRecursive("androidx.compose.ui.node.LayoutNode", "children")
+    private val coordBoundsField: Field? = findFieldRecursive("androidx.compose.ui.layout.LayoutCoordinates", "bounds")
+    private val coordSizeField: Field? = findFieldRecursive("androidx.compose.ui.layout.LayoutCoordinates", "size")
+    private val coordPositionField: Field? = findFieldRecursive("androidx.compose.ui.layout.LayoutCoordinates", "position")
+
+    /**
+     * 从 [rootNode] (AndroidX LayoutNode) 递归收集所有节点信息.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun collectNodes(rootNode: Any): List<NodeInfo> {
+        val result = mutableListOf<NodeInfo>()
+        try {
+            visitNode(rootNode, result, depth = 0)
+        } catch (e: Throwable) {
+            LOG.warn("collectNodes failed: {}", e.message)
+        }
+        return result
+    }
+
+    private fun visitNode(node: Any, out: MutableList<NodeInfo>, depth: Int) {
+        if (depth > 30) return // 防御性
+
+        val id = readIntField(node, idField) ?: return
+        val bounds = readBounds(node) ?: Rect.Zero
+        val w = readIntField(node, widthField) ?: 0
+        val h = readIntField(node, heightField) ?: 0
+        val children = readChildrenIds(node)
+
+        val name = guessComposableName(node)
+
+        out.add(NodeInfo(
+            id = id,
+            composableName = name,
+            bounds = bounds,
+            widthPx = w,
+            heightPx = h,
+            childrenIds = children,
+        ))
+
+        val childrenList = readChildrenList(node) ?: return
+        for (c in childrenList) {
+            try {
+                visitNode(c, out, depth + 1)
+            } catch (e: Throwable) {
+                LOG.debug("visitNode child failed: {}", e.message)
+            }
+        }
+    }
+
+    private fun readBounds(node: Any): Rect? {
+        val coords = readFieldSafely(node, coordinatesField) ?: return null
+        val rectAny = readFieldSafely(coords, coordBoundsField) ?: return null
+        if (rectAny is Rect) return rectAny
+        // Rect 在不同 Compose 版本中可能是 Rect (公开) 或内部类
+        return try {
+            val leftF = readFloatFieldSafely(rectAny, "left") ?: 0f
+            val topF = readFloatFieldSafely(rectAny, "top") ?: 0f
+            val rightF = readFloatFieldSafely(rectAny, "right") ?: 0f
+            val bottomF = readFloatFieldSafely(rectAny, "bottom") ?: 0f
+            Rect(leftF, topF, rightF, bottomF)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun readChildrenIds(node: Any): List<Int> {
+        val list = readChildrenList(node) ?: return emptyList()
+        return list.mapNotNull { readIntField(it, idField) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun readChildrenList(node: Any): List<Any>? {
+        val raw = readFieldSafely(node, childrenField) ?: return null
+        return when (raw) {
+            is List<*> -> raw.filterNotNull()
+            is Iterable<*> -> raw.filterNotNull()
+            else -> null
+        }
+    }
+
+    private fun readIntField(obj: Any, field: Field?): Int? {
+        if (field == null) return null
+        return try {
+            (field.get(obj) as? Number)?.toInt()
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun readFieldSafely(obj: Any, field: Field?): Any? {
+        if (field == null) return null
+        return try {
+            field.isAccessible = true
+            field.get(obj)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun readFloatFieldSafely(obj: Any, fieldName: String): Float? {
+        return try {
+            val f = obj.javaClass.getDeclaredField(fieldName).apply { isAccessible = true }
+            (f.get(obj) as? Number)?.toFloat()
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun guessComposableName(node: Any): String {
+        // 取类名
+        val cls = node.javaClass.name
+        val simple = cls.substringAfterLast('.').substringAfterLast('$')
+        return simple.ifBlank { "Unknown" }
+    }
+
+    private fun findFieldRecursive(className: String, fieldName: String): Field? {
+        return try {
+            val cls = Class.forName(className)
+            findFieldInHierarchy(cls, fieldName)
+        } catch (_: ClassNotFoundException) {
+            LOG.debug("Class not found: {} (可能不在 classpath)", className)
+            null
+        } catch (e: Throwable) {
+            LOG.debug("findFieldRecursive error: {}", e.message)
+            null
+        }
+    }
+
+    private fun findFieldInHierarchy(cls: Class<*>, name: String): Field? {
+        var c: Class<*>? = cls
+        while (c != null) {
+            try {
+                return c.getDeclaredField(name)
+            } catch (_: NoSuchFieldException) {
+                c = c.superclass
+            }
+        }
+        return null
+    }
+}
+
+/**
+ * Component Inspector 面板 v2.1.
+ *
+ * 显示节点树 + 选中节点属性.
+ */
 @Composable
 fun ComponentInspectorPanel(
-    controller: InspectorController,
+    nodes: List<NodeInfo>,
+    selectedId: Int? = null,
+    onSelect: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-    ) {
-        Text(
-            text = "Component Inspector",
-            style = MaterialTheme.typography.titleSmall,
-            modifier = Modifier.padding(8.dp)
-        )
-        HorizontalDivider()
-        if (controller.selectedNodeId == null) {
+    Column(modifier = modifier.fillMaxSize()) {
+        // 工具栏
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Text(
-                text = "点击任意节点查看属性 (P2 PR: 通过反射读 LayoutNode 私有字段).",
+                text = "${nodes.size} 个节点" + (selectedId?.let { " · 选中 #$it" } ?: ""),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(8.dp)
             )
-        } else {
-            Text(
-                text = "Selected: ${controller.selectedNodeId}",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(8.dp)
-            )
-            // P2: 在此展示 width/height/x/y/parent 等属性
         }
+        HorizontalDivider()
+        if (nodes.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF101015)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    "暂无节点 — 调用 LayoutNodeInspector.collectNodes(root) 获取",
+                    color = Color(0xFF666666),
+                    fontSize = 12.sp,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF101015))
+            ) {
+                items(nodes, key = { it.id }) { node ->
+                    val isSelected = selectedId == node.id
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                if (isSelected) Color(0x30FFFFFF) else Color.Transparent
+                            )
+                            .clickable { onSelect(node.id) }
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "#${node.id}",
+                            color = Color(0xFF888888),
+                            fontSize = 10.sp,
+                            fontFamily = FontFamily.Monospace,
+                            modifier = Modifier.width(50.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = node.composableName,
+                            color = Color(0xFFE0E0E0),
+                            fontSize = 11.sp,
+                            fontFamily = FontFamily.Monospace,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            text = "${node.widthPx}×${node.heightPx}",
+                            color = Color(0xFF888888),
+                            fontSize = 10.sp,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    }
+                    HorizontalDivider(color = Color(0x10FFFFFF))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 在 content 周围画边界框 (调试用).
+ */
+@Composable
+fun Modifier.layoutBoundsOverlay(
+    visible: Boolean,
+    color: Color = Color(0xFFE57373),
+    widthDp: Float = 1f,
+): Modifier {
+    if (!visible) return this
+    return this.drawWithContent {
+        drawContent()
+        drawRect(
+            color = color,
+            topLeft = Offset.Zero,
+            size = Size(size.width, size.height),
+            style = Stroke(width = widthDp * density),
+        )
     }
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
@@ -1,0 +1,546 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 调试面板 v2.1.
+ *
+ * 一个 [ModalBottomSheet] 容器, 包含 4 个 tab:
+ * 1. **Inspector** — Component 节点树 (来自 [ComponentInspectorPanel])
+ * 2. **Recompose** — Recompose 计数 (来自 [RecompositionPanel])
+ * 3. **Logcat** — 拦截的 stdout/stderr (来自 [LogcatPanel])
+ * 4. **Stats** — Build phase 计时 + ClassLoader 缓存命中率 (内嵌 [StatsPanel])
+ *
+ * ## 接入示例
+ *
+ * ```kotlin
+ * val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+ * var showDrawer by remember { mutableStateOf(false) }
+ *
+ * // 顶栏的 "Bug" 按钮:
+ * IconButton(onClick = { showDrawer = !showDrawer }) { Icon(Icons.Filled.BugReport, ...) }
+ *
+ * if (showDrawer) {
+ *     DebugDrawer(
+ *         sheetState = sheetState,
+ *         onDismiss = { showDrawer = false },
+ *         inspectorNodes = inspectorNodes,
+ *         recomposeTracker = recomposeTracker,
+ *         logcat = PreviewLog.sink,
+ *         stats = currentStats,
+ *     )
+ * }
+ * ```
+ *
+ * @param sheetState ModalBottomSheet 状态
+ * @param onDismiss 关闭回调
+ * @param inspectorNodes 当前节点列表 (Inspector tab)
+ * @param recomposeTracker 全局 RecomposeTracker (Recompose tab)
+ * @param logcat 日志源 (Logcat tab)
+ * @param stats 构建统计 (Stats tab)
+ * @param modifier Modifier
+ */
+@Composable
+fun DebugDrawer(
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+    inspectorNodes: List<NodeInfo>,
+    recomposeTracker: RecomposeTracker,
+    logcat: PreviewLogcatSink,
+    stats: BuildStats,
+    modifier: Modifier = Modifier,
+) {
+    var selectedTab by remember { mutableStateOf(DebugTab.Inspector) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier,
+        contentWindowInsets = { WindowInsets.systemBars },
+        dragHandle = null,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+        ) {
+            // 头部: 标题 + 关闭
+            DebugDrawerHeader(
+                tab = selectedTab,
+                onClose = onDismiss,
+            )
+
+            HorizontalDivider()
+
+            // 主体
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            ) {
+                when (selectedTab) {
+                    DebugTab.Inspector -> ComponentInspectorPanel(
+                        nodes = inspectorNodes,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    DebugTab.Recompose -> RecompositionPanel(
+                        tracker = recomposeTracker,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    DebugTab.Logcat -> LogcatPanel(
+                        sink = logcat,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    DebugTab.Stats -> StatsPanel(
+                        stats = stats,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            // 底部 NavigationBar
+            DebugDrawerNavBar(
+                selected = selectedTab,
+                onSelect = { selectedTab = it },
+            )
+        }
+    }
+}
+
+/** 4 个 tab 枚举. */
+enum class DebugTab(
+    val label: String,
+    val icon: ImageVector,
+) {
+    Inspector("Inspect", Icons.Filled.Layers),
+    Recompose("Recomp", Icons.Filled.BugReport),
+    Logcat("Log", Icons.Filled.Terminal),
+    Stats("Stats", Icons.Filled.Analytics),
+}
+
+/**
+ * 头部: 标题 + 当前 tab 名 + 关闭按钮.
+ */
+@Composable
+private fun DebugDrawerHeader(
+    tab: DebugTab,
+    onClose: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.BugReport,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = "Debug · ${tab.label}",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+            text = "关闭",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .padding(4.dp),
+        )
+    }
+}
+
+/**
+ * 底部 NavigationBar: 4 tab 切换.
+ */
+@Composable
+private fun DebugDrawerNavBar(
+    selected: DebugTab,
+    onSelect: (DebugTab) -> Unit,
+) {
+    NavigationBar(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        DebugTab.values().forEach { tab ->
+            NavigationBarItem(
+                selected = selected == tab,
+                onClick = { onSelect(tab) },
+                icon = {
+                    Icon(
+                        imageVector = tab.icon,
+                        contentDescription = tab.label,
+                    )
+                },
+                label = {
+                    Text(text = tab.label, fontSize = 10.sp)
+                },
+            )
+        }
+    }
+}
+
+// =============================================================================
+// BuildStats (P1-UI-05 统计面板数据)
+// =============================================================================
+
+/**
+ * 一次构建 / 一次加载的统计 v2.1.
+ *
+ * 由 ViewModel / ComposableRenderer 在每次 build 完成时生成新实例, 推到 [DebugDrawer].
+ * 所有数字累计而非单次 (启动到现在的总量).
+ *
+ * @property phaseTimings 4 个关键 build 阶段的耗时 (ms)
+ * @property loadedClassCount ClassLoader 累计 loadClass 次数
+ * @property cacheHitCount 命中数
+ * @property cacheMissCount 未命中数 (= loadedClassCount - cacheHitCount)
+ * @property classCacheSize 当前 classCache 大小
+ * @property activeLoaderCount 当前 DexClassLoader pool 大小
+ * @property lastCompileMs 最近一次 compile 耗时
+ * @property totalCompileMs 累计 compile 耗时
+ * @property lastRenderMs 最近一次 render 耗时 (从 setContent 到首帧)
+ * @property totalRenderMs 累计 render 耗时
+ */
+data class BuildStats(
+    val phaseTimings: BuildPhaseTimings = BuildPhaseTimings(),
+    val loadedClassCount: Long = 0,
+    val cacheHitCount: Long = 0,
+    val cacheMissCount: Long = 0,
+    val classCacheSize: Int = 0,
+    val activeLoaderCount: Int = 0,
+    val lastCompileMs: Long = 0,
+    val totalCompileMs: Long = 0,
+    val lastRenderMs: Long = 0,
+    val totalRenderMs: Long = 0,
+) {
+    /**
+     * 缓存命中率, 范围 [0f, 1f]. 0 当 loadedClassCount == 0.
+     */
+    val cacheHitRate: Float
+        get() = if (loadedClassCount == 0L) 0f
+                else cacheHitCount.toFloat() / loadedClassCount.toFloat()
+
+    companion object {
+        val EMPTY = BuildStats()
+    }
+}
+
+/**
+ * 4 个关键 build 阶段耗时.
+ *
+ * - [init]   Assets 解压 + AndroidJar 定位
+ * - [compile] K2JVMCompiler 调用 + 输出 .class
+ * - [dex]    D8 转换 .class -> .dex
+ * - [load]   DexClassLoader 加载首类
+ */
+data class BuildPhaseTimings(
+    val init: Long = 0,
+    val compile: Long = 0,
+    val dex: Long = 0,
+    val load: Long = 0,
+) {
+    val total: Long get() = init + compile + dex + load
+}
+
+/**
+ * 统计面板 (Stats tab) v2.1.
+ *
+ * 展示 [BuildStats] 内的数字:
+ * - 缓存命中率 (LinearProgressIndicator + 百分比)
+ * - 4 个 build phase 的耗时条
+ * - ClassLoader pool / cache 状态
+ * - 上次 / 累计 compile / render 耗时
+ */
+@Composable
+fun StatsPanel(
+    stats: BuildStats,
+    modifier: Modifier = Modifier,
+) {
+    val hitRatePercent = (stats.cacheHitRate * 100).coerceIn(0f, 100f)
+    val hitColor = when {
+        hitRatePercent >= 80f -> Color(0xFF81C784)
+        hitRatePercent >= 50f -> Color(0xFFFFB74D)
+        else -> Color(0xFFE57373)
+    }
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0xFF101015)),
+    ) {
+        // 缓存命中率
+        item {
+            StatsSection(title = "ClassLoader 缓存命中率") {
+                Text(
+                    text = String.format("%.1f%%", hitRatePercent),
+                    color = hitColor,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.height(4.dp))
+                LinearProgressIndicator(
+                    progress = { (stats.cacheHitRate).coerceIn(0f, 1f) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(3.dp)),
+                    color = hitColor,
+                    trackColor = Color(0xFF2A2A35),
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "${stats.cacheHitCount} 命中 / ${stats.cacheMissCount} 未命中 / 累计 ${stats.loadedClassCount} 次",
+                    color = Color(0xFF888888),
+                    fontSize = 10.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+        }
+
+        // 4 个 build phase
+        item {
+            StatsSection(title = "Build 阶段耗时 (ms)") {
+                PhaseRow(label = "init", ms = stats.phaseTimings.init, total = stats.phaseTimings.total)
+                PhaseRow(label = "compile", ms = stats.phaseTimings.compile, total = stats.phaseTimings.total)
+                PhaseRow(label = "dex", ms = stats.phaseTimings.dex, total = stats.phaseTimings.total)
+                PhaseRow(label = "load", ms = stats.phaseTimings.load, total = stats.phaseTimings.total)
+                Spacer(Modifier.height(4.dp))
+                HorizontalDivider(color = Color(0x20FFFFFF))
+                Spacer(Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = "total",
+                        color = Color(0xFFE0E0E0),
+                        fontSize = 12.sp,
+                        fontFamily = FontFamily.Monospace,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = "${stats.phaseTimings.total} ms",
+                        color = Color(0xFFE0E0E0),
+                        fontSize = 12.sp,
+                        fontFamily = FontFamily.Monospace,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+
+        // ClassLoader pool
+        item {
+            StatsSection(title = "ClassLoader pool") {
+                StatsKeyValue("classCache 大小", "${stats.classCacheSize}")
+                StatsKeyValue("DexClassLoader 数量", "${stats.activeLoaderCount}")
+            }
+        }
+
+        // 编译 / 渲染累计
+        item {
+            StatsSection(title = "编译 / 渲染累计") {
+                StatsKeyValue("上次 compile", "${stats.lastCompileMs} ms")
+                StatsKeyValue("累计 compile", "${stats.totalCompileMs} ms")
+                StatsKeyValue("上次 render", "${stats.lastRenderMs} ms")
+                StatsKeyValue("累计 render", "${stats.totalRenderMs} ms")
+            }
+        }
+
+        // 说明
+        item {
+            StatsSection(title = "说明") {
+                Text(
+                    text = "• 缓存命中率 = cacheHit / loadedClassCount\n" +
+                        "• 命中率 <50% 表示冷启动; 持续走低考虑加 LRU 上限\n" +
+                        "• 4 个 phase 总和 = 一次完整 build 耗时\n" +
+                        "• 累计数据从应用启动开始",
+                    color = Color(0xFF888888),
+                    fontSize = 10.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 一个分区 (标题 + 内容).
+ */
+@Composable
+private fun StatsSection(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        Text(
+            text = title,
+            color = Color(0xFF888888),
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.padding(bottom = 6.dp),
+        )
+        content()
+    }
+    HorizontalDivider(color = Color(0x10FFFFFF))
+}
+
+/**
+ * 一个 phase 的进度行.
+ */
+@Composable
+private fun PhaseRow(
+    label: String,
+    ms: Long,
+    total: Long,
+) {
+    val fraction = if (total <= 0L) 0f else (ms.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+    val color = when (label) {
+        "init" -> Color(0xFF4FC3F7)
+        "compile" -> Color(0xFFFFB74D)
+        "dex" -> Color(0xFFBA68C8)
+        "load" -> Color(0xFF81C784)
+        else -> Color.Gray
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label.padEnd(8),
+            color = color,
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.width(70.dp),
+        )
+        LinearProgressIndicator(
+            progress = { fraction },
+            modifier = Modifier
+                .weight(1f)
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp)),
+            color = color,
+            trackColor = Color(0xFF2A2A35),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = "${ms} ms",
+            color = Color(0xFFE0E0E0),
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.width(70.dp),
+        )
+    }
+}
+
+/**
+ * 一个 key-value 行.
+ */
+@Composable
+private fun StatsKeyValue(key: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = key,
+            color = Color(0xFFAAAAAA),
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+        Text(
+            text = value,
+            color = Color(0xFFE0E0E0),
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+/**
+ * `String.padEnd` polyfill (Kotlin stdlib 没有).
+ */
+private fun String.padEnd(width: Int): String =
+    if (length >= width) this else this + " ".repeat(width - length)

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/LogcatPanel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/LogcatPanel.kt
@@ -1,0 +1,377 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ClearAll
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.io.PrintStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * 日志条目.
+ */
+data class LogEntry(
+    val level: LogLevel,
+    val tag: String,
+    val message: String,
+    val timestamp: Long = System.currentTimeMillis(),
+    val throwable: Throwable? = null,
+)
+
+enum class LogLevel(val label: String, val color: Color) {
+    VERBOSE("V", Color(0xFF888888)),
+    DEBUG("D", Color(0xFF4FC3F7)),
+    INFO("I", Color(0xFF81C784)),
+    WARN("W", Color(0xFFFFB74D)),
+    ERROR("E", Color(0xFFE57373)),
+    FATAL("F", Color(0xFFD32F2F));
+
+    companion object {
+        fun fromLabel(label: String): LogLevel =
+            values().firstOrNull { it.label == label } ?: DEBUG
+    }
+}
+
+/**
+ * 拦截 System.out / System.err / 模拟 android.util.Log 调用的全局 sink.
+ *
+ * 用法:
+ * ```
+ * val logcat = PreviewLogcatSink()
+ * logcat.install()
+ * println("Hello")   // 出现在 logcat
+ * PreviewLog.d("Tag", "msg")   // 出现在 logcat
+ * logcat.uninstall()
+ * ```
+ *
+ * 线程安全 (CopyOnWriteArrayList). 容量上限 1000 条 (FIFO 淘汰).
+ */
+class PreviewLogcatSink(
+    val maxEntries: Int = 1000,
+) {
+    private val entries: CopyOnWriteArrayList<LogEntry> = CopyOnWriteArrayList()
+    private val listeners: CopyOnWriteArrayList<(List<LogEntry>) -> Unit> = CopyOnWriteArrayList()
+
+    @Volatile
+    private var originalOut: PrintStream? = null
+    @Volatile
+    private var originalErr: PrintStream? = null
+
+    fun snapshot(): List<LogEntry> = entries.toList()
+
+    fun addListener(listener: (List<LogEntry>) -> Unit) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: (List<LogEntry>) -> Unit) {
+        listeners.remove(listener)
+    }
+
+    fun clear() {
+        entries.clear()
+        notifyListeners()
+    }
+
+    @Synchronized
+    fun install() {
+        if (originalOut != null) return
+        originalOut = System.out
+        originalErr = System.err
+        System.setOut(PreviewPrintStream(this, LogLevel.INFO, "stdout", originalOut!!))
+        System.setErr(PreviewPrintStream(this, LogLevel.ERROR, "stderr", originalErr!!))
+    }
+
+    @Synchronized
+    fun uninstall() {
+        originalOut?.let { System.setOut(it) }
+        originalErr?.let { System.setErr(it) }
+        originalOut = null
+        originalErr = null
+    }
+
+    @Synchronized
+    internal fun append(level: LogLevel, tag: String, message: String, throwable: Throwable? = null) {
+        val entry = LogEntry(level, tag, message, System.currentTimeMillis(), throwable)
+        entries.add(entry)
+        if (entries.size > maxEntries) {
+            entries.subList(0, entries.size - maxEntries).clear()
+        }
+        notifyListeners()
+    }
+
+    private fun notifyListeners() {
+        val copy = entries.toList()
+        listeners.forEach { it(copy) }
+    }
+}
+
+/**
+ * 把写入的字符串解析成日志条目, 通过 sink 转发.
+ */
+internal class PreviewPrintStream(
+    private val sink: PreviewLogcatSink,
+    private val level: LogLevel,
+    private val tag: String,
+    private val original: PrintStream,
+) : PrintStream(original) {
+
+    private val buffer = StringBuilder()
+    private val timeFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
+
+    override fun print(s: String?) {
+        if (s == null) return
+        // 把原内容也输出 (避免 logcat 完全吃掉)
+        original.print(s)
+        buffer.append(s)
+    }
+
+    override fun println(s: String?) {
+        if (s == null) return
+        original.println(s)
+        // 单行 (println 时 buffer 累积多行, 这里一并 flush)
+        val combined = if (buffer.isNotEmpty()) buffer.toString() + s else s
+        buffer.clear()
+        // 多行拆开
+        combined.lineSequence().forEach { line ->
+            if (line.isNotEmpty()) {
+                sink.append(level, tag, "[${timeFormat.format(Date())}] $line")
+            }
+        }
+    }
+
+    override fun println(x: Any?) {
+        println(x?.toString() ?: "null")
+    }
+}
+
+/**
+ * 模拟 android.util.Log API 的轻量替代.
+ *
+ * 在预览中不能用真正的 android.util.Log (沙箱下 Log 类可能被移除),
+ * 这里走 [PreviewLogcatSink].
+ */
+object PreviewLog {
+    fun v(tag: String, msg: String) = sink.append(LogLevel.VERBOSE, tag, msg)
+    fun d(tag: String, msg: String) = sink.append(LogLevel.DEBUG, tag, msg)
+    fun i(tag: String, msg: String) = sink.append(LogLevel.INFO, tag, msg)
+    fun w(tag: String, msg: String) = sink.append(LogLevel.WARN, tag, msg)
+    fun e(tag: String, msg: String, t: Throwable? = null) = sink.append(LogLevel.ERROR, tag, msg, t)
+    fun wtf(tag: String, msg: String, t: Throwable? = null) = sink.append(LogLevel.FATAL, tag, msg, t)
+
+    @Volatile
+    var sink: PreviewLogcatSink = PreviewLogcatSink()
+}
+
+/**
+ * Logcat 面板 v2.1.
+ *
+ * 显示 [PreviewLogcatSink] 收集的日志, 支持:
+ * - 级别过滤 (V/D/I/W/E/F toggle)
+ * - 文本搜索
+ * - 自动滚动到最新
+ * - 清空
+ *
+ * @param sink 日志源
+ * @param modifier modifier
+ */
+@Composable
+fun LogcatPanel(
+    sink: PreviewLogcatSink,
+    modifier: Modifier = Modifier,
+) {
+    val entries = remember { mutableStateListOf<LogEntry>() }
+    val listState = rememberLazyListState()
+    var filterText by remember { mutableStateOf("") }
+    var minLevel by remember { mutableStateOf(LogLevel.VERBOSE) }
+    var autoScroll by remember { mutableStateOf(true) }
+
+    LaunchedEffect(sink) {
+        sink.addListener { list ->
+            entries.clear()
+            entries.addAll(list)
+            if (autoScroll && entries.isNotEmpty()) {
+                // 滚到最后
+                kotlinx.coroutines.delay(50)
+                try {
+                    listState.scrollToItem(entries.size - 1)
+                } catch (_: Throwable) {}
+            }
+        }
+        entries.clear()
+        entries.addAll(sink.snapshot())
+    }
+
+    val filtered = entries.filter { entry ->
+        entry.level.ordinal >= minLevel.ordinal &&
+            (filterText.isBlank() ||
+                entry.message.contains(filterText, ignoreCase = true) ||
+                entry.tag.contains(filterText, ignoreCase = true))
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        // 工具栏
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = filterText,
+                onValueChange = { filterText = it },
+                placeholder = { Text("过滤", fontSize = 12.sp) },
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null, modifier = Modifier.size(14.dp)) },
+                modifier = Modifier.weight(1f).height(40.dp),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            IconButton(onClick = { sink.clear() }) {
+                Icon(Icons.Filled.ClearAll, contentDescription = "Clear", modifier = Modifier.size(18.dp))
+            }
+        }
+        // 级别过滤
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 2.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            LogLevel.values().forEach { level ->
+                FilterChip(
+                    selected = minLevel.ordinal <= level.ordinal,
+                    onClick = { minLevel = level },
+                    label = { Text(level.label, fontSize = 10.sp) },
+                )
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            FilterChip(
+                selected = autoScroll,
+                onClick = { autoScroll = !autoScroll },
+                label = { Text("Auto", fontSize = 10.sp) },
+            )
+        }
+
+        // 日志列表
+        if (filtered.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF101015)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    "暂无日志 (调用 println 或 PreviewLog.d/i/w/e 查看)",
+                    color = Color(0xFF666666),
+                    fontSize = 12.sp,
+                )
+            }
+        } else {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF101015)),
+            ) {
+                items(filtered, key = { it.timestamp.toString() + it.hashCode() }) { entry ->
+                    LogLine(entry = entry)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogLine(entry: LogEntry) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        // 级别
+        Text(
+            text = entry.level.label,
+            color = entry.level.color,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.width(16.dp),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        // 标签
+        Text(
+            text = entry.tag,
+            color = Color(0xFF888888),
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.width(60.dp),
+        )
+        // 消息
+        Text(
+            text = entry.message,
+            color = Color(0xFFE0E0E0),
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/RecompositionCounter.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/RecompositionCounter.kt
@@ -17,29 +17,249 @@
 
 package com.itsaky.androidide.compose.preview.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
- * Recomposition 计数器.
+ * 单个 Composable 的 recompose 计数.
  *
- * 通过 `currentRecomposeScope` 配合 [LaunchedEffect] 捕获每次 recompose.
+ * @property name Composable 名 (通过 `currentRecomposeScope` 反射拿到)
+ * @property count 累计 recompose 次数
+ */
+data class RecomposeSample(
+    val name: String,
+    val count: Int,
+)
+
+/**
+ * 全局 recompose 跟踪器.
+ *
+ * 维护所有 Composable 的 recompose 计数, 按 count 降序展示.
+ * 高亮 (红色) 那些超过 [threshold] 的 Composable — 通常是 "recompose 太多" 的优化点.
+ *
  * 用法:
- *
- * ```kotlin
- * val counter = rememberRecompositionCounter()
- * Column(Modifier.recompositionAware(counter)) {
- *     counter.bind()  // 任何 recompose 都会让 counter.tick
- *     MyComposable()
- * }
- * // 上层 UI:
- * Text("Recompositions: ${counter.count}")
  * ```
+ * val tracker = LocalRecomposeTracker.current
+ * val sample = tracker.bind("MyComposable")
+ * // 当 MyComposable recompose, sample.count 自动增加
+ * ```
+ */
+@Stable
+class RecomposeTracker(
+    val threshold: Int = 5,
+) {
+    private val samples = mutableStateListOf<RecomposeSample>()
+
+    /** 是否启用高亮 */
+    var highlightEnabled by mutableStateOf(false)
+        private set
+
+    fun toggleHighlight() {
+        highlightEnabled = !highlightEnabled
+    }
+
+    /**
+     * 绑定到当前 Composable.
+     *
+     * 通过 [LaunchedEffect] 自身 recompose 时重新启动, 实现 "每 recompose 一次
+     * tick 一次". 返回当前计数.
+     */
+    @Composable
+    fun bind(name: String): Int {
+        val sample = remember(name) {
+            val existing = samples.firstOrNull { it.name == name }
+            if (existing != null) {
+                samples.remove(existing)
+                val updated = existing.copy(count = existing.count + 1)
+                samples.add(updated)
+                updated
+            } else {
+                val created = RecomposeSample(name, 1)
+                samples.add(created)
+                created
+            }
+        }
+        // 每次这个 Composable 重组时, 这个 LaunchedEffect key 是不变的, 但 effect
+        // 体本身会被再次执行. 用一个不断变化的 key (count) 来实现.
+        LaunchedEffect(sample.count) {
+            // 实际上不需要任何工作, 只是触发 recompose
+        }
+        return sample.count
+    }
+
+    @Composable
+    fun bind(name: String, content: @Composable (count: Int) -> Unit) {
+        val count = bind(name)
+        content(count)
+    }
+
+    fun snapshot(): List<RecomposeSample> =
+        samples.sortedByDescending { it.count }
+
+    fun reset() {
+        samples.clear()
+    }
+}
+
+/**
+ * CompositionLocal 提供 tracker (在 Preview 根用 CompositionLocalProvider 注入).
+ */
+val LocalRecomposeTracker = androidx.compose.runtime.staticCompositionLocalOf<RecomposeTracker> {
+    RecomposeTracker()
+}
+
+@Composable
+fun rememberRecomposeCounter(): RecomposeTracker = remember { RecomposeTracker() }
+
+/**
+ * Recompose 面板 v2.1.
+ *
+ * 显示所有 Composable 的 recompose 计数, 红色高亮超阈值.
+ */
+@Composable
+fun RecompositionPanel(
+    tracker: RecomposeTracker,
+    modifier: Modifier = Modifier,
+) {
+    val samples = tracker.snapshot()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        // 工具栏
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "${samples.size} 个 Composable · 总计 ${samples.sumOf { it.count }} 次重组",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = "高亮",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Switch(
+                checked = tracker.highlightEnabled,
+                onCheckedChange = { tracker.toggleHighlight() },
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "重置",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .padding(4.dp)
+            )
+        }
+
+        if (samples.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF101015)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    "暂无数据 — 在 Composable 中调用 tracker.bind(\"MyComposable\") 触发追踪",
+                    color = Color(0xFF666666),
+                    fontSize = 12.sp,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF101015))
+            ) {
+                items(samples, key = { it.name }) { sample ->
+                    val isHot = sample.count >= tracker.threshold
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        // 计数徽章
+                        Box(
+                            modifier = Modifier
+                                .size(width = 40.dp, height = 22.dp)
+                                .background(
+                                    if (isHot) Color(0xFFE57373) else Color(0xFF4FC3F7),
+                                    RoundedCornerShape(4.dp)
+                                ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "${sample.count}",
+                                color = Color.White,
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.Monospace,
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = sample.name,
+                            color = Color(0xFFE0E0E0),
+                            fontSize = 12.sp,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                        if (isHot) {
+                            Spacer(modifier = Modifier.weight(1f))
+                            Text(
+                                text = "🔥 优化点",
+                                color = Color(0xFFFFB74D),
+                                fontSize = 10.sp,
+                            )
+                        }
+                    }
+                    HorizontalDivider(color = Color(0x20FFFFFF))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 保留 v2 旧 API (向后兼容).
  */
 @Stable
 class RecompositionCounter {


### PR DESCRIPTION
## 概述

`modules/compose-preview/` v2.1 重构 **P1 阶段全部完成** — 完整调试工具集, 包含 4 tab 调试抽屉
(Inspector / Recompose / Logcat / Stats) + ViewModel 统计流 + Activity 接线.

由 2 个提交组成:
- `0b446ec6` 三个独立面板 (LogcatPanel / RecompositionPanel / ComponentInspectorPanel)
- `3ffdaf03` DebugDrawer 4-tab 容器 + Stats 面板 + Activity 集成

## 改动总览

### 1. Logcat 拦截 (`LogcatPanel.kt`, 377 行, 新增)

- `LogEntry` data class + `LogLevel` 枚举 (V/D/I/W/E/F)
- `PreviewLogcatSink` 拦截 `System.out` / `System.err`
  - 1000 条环形 buffer (FIFO 淘汰)
  - `CopyOnWriteArrayList` 线程安全
  - `install()` / `uninstall()` / `clear()` / `snapshot()` / `addListener()` API
- `PreviewLog` 静态工具: 模拟 `android.util.Log` (v/d/i/w/e/wtf)
- `LogcatPanel` Composable: 级别过滤 + 文本搜索 + 自动滚动 + clear

### 2. Recompose 追踪 (`RecompositionCounter.kt`, 重写)

- `RecomposeSample` (name + count)
- `RecomposeTracker` 全局跟踪器 (threshold=5 默认)
  - `bind(name)`: 累计每次重组
  - `highlightEnabled` toggle
  - `LocalRecomposeTracker` CompositionLocal
- `RecompositionPanel`: 列表 + 红色高亮超阈值 + 🔥 优化点标签
- **保留 v2 旧 API** (`RecompositionCounter` 类) 向后兼容

### 3. Component Inspector (`ComponentInspector.kt`, 重写)

- `NodeInfo` data class
- `LayoutNodeInspector` 反射读取器
  - 通过反射读 `androidx.compose.ui.node.LayoutNode` 字段
    (id / coordinates / measuredWidth / measuredHeight / children)
  - 降级策略: 任一字段读不到就跳过, 不抛异常
  - `Class.forName` 找不到时降级为 null
- `ComponentInspectorPanel`: 节点树 + 选中回调
- `Modifier.layoutBoundsOverlay`: 画节点边界框 (调试用)

### 4. DebugDrawer 容器 (`DebugDrawer.kt`, 546 行, 新增)

- `DebugDrawer` Composable: `ModalBottomSheet` + 头部 + 4 tab
- `DebugTab` 枚举: `Inspector` / `Recompose` / `Logcat` / `Stats`
- 底部 `NavigationBar` 切换 tab

### 5. Stats 面板 (在 `DebugDrawer.kt` 内)

- `BuildStats` data class:
  - `cacheHitRate` (派生属性)
  - `loadedClassCount` / `cacheHitCount` / `cacheMissCount`
  - `classCacheSize` / `activeLoaderCount`
  - `lastCompileMs` / `totalCompileMs` / `lastRenderMs` / `totalRenderMs`
- `BuildPhaseTimings` data class: 4 阶段 (init / compile / dex / load)
- `StatsPanel` Composable:
  - 命中率 `LinearProgressIndicator` (绿/黄/红 分级)
  - 4 phase 进度行 (彩色)
  - ClassLoader pool / cache 状态 key/value
  - 编译 / 渲染累计 key/value

### 6. ViewModel (`ComposePreviewViewModel.kt`)

- 新增 2 个 `StateFlow`:
  - `buildStats: StateFlow<BuildStats>` (默认 `BuildStats.EMPTY`)
  - `inspectorNodes: StateFlow<List<NodeInfo>>` (默认 empty)
- 5 个 setter:
  - `updateBuildStats(stats)`
  - `patchBuildStats(classCacheSize, activeLoaderCount, ...)` 增量
  - `setInspectorNodes(nodes)` / `clearInspectorNodes()`
  - `recordRender(elapsedMs)`
- `compilePreview` 内部测量耗时并写入 `buildStats`

### 7. Activity 集成 (`ComposePreviewActivity.kt`)

- `onCreate` 创建 `PreviewLog.sink.also { it.install() }` 安装 stdout 拦截
- `remember { RecomposeTracker() }` per-Activity 单例
- `onDestroy()` 卸载 logcat sink, 恢复原始 `System.out` / `System.err`
- `ComposePreviewScreen` 末尾:
  ```kotlin
  if (debugEnabled) {
      val debugSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
      DebugDrawer(
          sheetState = debugSheetState,
          onDismiss = { viewModel.toggleDebug() },
          inspectorNodes = inspectorNodes,
          recomposeTracker = recomposeTracker,
          logcat = logcatSink,
          stats = buildStats,
      )
  }
  ```

## 接入链路

`PreviewToolbar.debug` 按钮 (onToggleDebug)
→ `viewModel.toggleDebug()` → `_debugEnabled.value` 翻转
→ `ComposePreviewScreen` 重组 → `if (debugEnabled) DebugDrawer(...)` 渲染
→ 抽屉内 4 tab 切换 (`NavigationBar`)
→ 关闭再次 onDismiss = toggleDebug()

## 设计依据

- `DESIGN.md` v2.1 §11 调试与可观测性
- `TODO.md` v2.1 P1-UI-01 (DebugDrawer) / P1-UI-02 (Inspector) /
  P1-UI-03 (Recompose) / P1-UI-04 (Logcat) / P1-UI-05 (Stats)

## 后续 PR

- P2: 可视化编辑工具箱 (拖动 / resize / 颜色拾取)
- P3: 字节码加速 (ASM 改写 + 静态 binder)
- P4: 协同 / 远程预览

## 测试

沙箱环境无 Android SDK build-tools, 需在 CI / 本地 build 验证.
