### PR TITLE
feat(compose-preview): v2.1 P2 可视化编辑工具箱 (Select/Drag/Eyedropper)

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -57,9 +58,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.itsaky.androidide.compose.preview.ui.BuildStats
+import com.itsaky.androidide.compose.preview.ui.ColorEyedropper
 import com.itsaky.androidide.compose.preview.ui.DebugDrawer
 import com.itsaky.androidide.compose.preview.ui.DeviceFrame
 import com.itsaky.androidide.compose.preview.ui.DeviceProfileSheet
+import com.itsaky.androidide.compose.preview.ui.EditorState
+import com.itsaky.androidide.compose.preview.ui.EditorStatusBar
+import com.itsaky.androidide.compose.preview.ui.EditorToolbar
+import com.itsaky.androidide.compose.preview.ui.EditorTool
 import com.itsaky.androidide.compose.preview.ui.PreviewLog
 import com.itsaky.androidide.compose.preview.ui.PreviewLogcatSink
 import com.itsaky.androidide.compose.preview.ui.PreviewToolbar
@@ -67,6 +73,9 @@ import com.itsaky.androidide.compose.preview.ui.PreviewToolbarActions
 import com.itsaky.androidide.compose.preview.ui.PreviewToolbarState
 import com.itsaky.androidide.compose.preview.ui.RecomposeTracker
 import com.itsaky.androidide.compose.preview.ui.ResolutionEditor
+import com.itsaky.androidide.compose.preview.ui.Selection
+import com.itsaky.androidide.compose.preview.ui.SelectionOverlay
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import com.itsaky.androidide.lookup.Lookup
@@ -154,6 +163,10 @@ fun ComposePreviewScreen(
     val inspectorNodes by viewModel.inspectorNodes.collectAsStateWithLifecycle()
     val buildStats by viewModel.buildStats.collectAsStateWithLifecycle()
 
+    // v2.1 可视化编辑器状态
+    val editorEnabled by viewModel.editorEnabled.collectAsStateWithLifecycle()
+    val editorState by viewModel.editorState.collectAsStateWithLifecycle()
+
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var showDeviceSheet by remember { mutableStateOf(false) }
@@ -184,6 +197,7 @@ fun ComposePreviewScreen(
                         zoom = viewport.zoom,
                         showSystemBars = deviceConfig.showStatusBar,
                         debugEnabled = debugEnabled,
+                        editorEnabled = editorEnabled,
                     ),
                     actions = PreviewToolbarActions(
                         onOpenDeviceSheet = { showDeviceSheet = true },
@@ -192,11 +206,22 @@ fun ComposePreviewScreen(
                         onFitZoom = { viewModel.fitZoom() },
                         onToggleSystemBars = { viewModel.toggleSystemBars() },
                         onToggleDebug = { viewModel.toggleDebug() },
+                        onToggleEditor = { viewModel.toggleEditor() },
                         onClose = onClose,
                     ),
                 )
 
                 HorizontalDivider()
+
+                // v2.1 编辑器工具栏 (二级)
+                if (editorEnabled) {
+                    EditorToolbar(
+                        tool = editorState.tool,
+                        onToolChange = { viewModel.setEditorTool(it) },
+                        onClose = { viewModel.toggleEditor() },
+                    )
+                    EditorStatusBar(state = editorState)
+                }
 
                 // 主体
                 Box(
@@ -227,6 +252,40 @@ fun ComposePreviewScreen(
                             onBuildFailed = {
                                 viewModel.setBuildFailed()
                             }
+                        )
+                    }
+
+                    // v2.1 编辑器: 选中覆盖层 + 点击响应
+                    if (editorEnabled) {
+                        EditorInteractionLayer(
+                            editorState = editorState,
+                            inspectorNodes = inspectorNodes,
+                            onSelectAt = { offset, node ->
+                                if (editorState.tool == EditorTool.Select ||
+                                    editorState.tool == EditorTool.Drag) {
+                                    viewModel.setSelection(
+                                        Selection(
+                                            nodeId = node.id,
+                                            composableName = node.composableName,
+                                            bounds = node.bounds,
+                                        )
+                                    )
+                                } else if (editorState.tool == EditorTool.Eyedropper) {
+                                    val color = ColorEyedropper.estimateColor(node)
+                                    viewModel.setSelection(
+                                        Selection(
+                                            nodeId = node.id,
+                                            composableName = node.composableName,
+                                            bounds = node.bounds,
+                                            sampledColor = color,
+                                        )
+                                    )
+                                }
+                            },
+                            onClearSelection = { viewModel.clearSelection() },
+                            onTranslate = { dx, dy ->
+                                viewModel.translateSelection(dx, dy)
+                            },
                         )
                     }
                 }
@@ -466,6 +525,72 @@ private fun triggerBuild(
                 viewModel.refreshAfterBuild(context)
             }
         }
+    }
+}
+
+/**
+ * v2.1 编辑器交互层 (P2).
+ *
+ * 叠在预览内容之上, 提供:
+ * 1. 点击响应: 根据 [EditorState.tool] 选择 / 取色 / 清除选中
+ * 2. 选中框绘制: 包裹 [SelectionOverlay] (8 手柄 + 拖动)
+ *
+ * @param editorState 当前 editor state
+ * @param inspectorNodes 全部节点 (hit-test 用)
+ * @param onSelectAt 命中节点回调 (offset + 命中的 NodeInfo)
+ * @param onClearSelection 清除选中回调
+ * @param onTranslate 拖动选中元素回调 (Drag 工具)
+ */
+@Composable
+private fun EditorInteractionLayer(
+    editorState: EditorState,
+    inspectorNodes: List<NodeInfo>,
+    onSelectAt: (androidx.compose.ui.geometry.Offset, NodeInfo) -> Unit,
+    onClearSelection: () -> Unit,
+    onTranslate: (Float, Float) -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        // 点击响应层
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(editorState.tool, inspectorNodes) {
+                    detectTapGestures(
+                        onTap = { offset ->
+                            if (editorState.tool == EditorTool.Select ||
+                                editorState.tool == EditorTool.Eyedropper
+                            ) {
+                                val node = ColorEyedropper.findNodeAt(inspectorNodes, offset)
+                                if (node != null) {
+                                    onSelectAt(offset, node)
+                                } else {
+                                    onClearSelection()
+                                }
+                            }
+                        },
+                        onLongPress = {
+                            // 长按 = 清除选中
+                            onClearSelection()
+                        },
+                    )
+                }
+        )
+
+        // 选中覆盖层 (含 8 手柄 + 拖动响应)
+        SelectionOverlay(
+            selection = editorState.selection,
+            tool = editorState.tool,
+            onSelectionChange = { newSel ->
+                if (editorState.tool == EditorTool.Drag) {
+                    val old = editorState.selection
+                    if (old != null) {
+                        val dx = newSel.translationX - old.translationX
+                        val dy = newSel.translationY - old.translationY
+                        onTranslate(dx, dy)
+                    }
+                }
+            },
+        )
     }
 }
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -32,7 +32,10 @@ import com.itsaky.androidide.compose.preview.domain.model.ParsedPreviewSource
 import com.itsaky.androidide.compose.preview.ui.BuildPhaseTimings
 import com.itsaky.androidide.compose.preview.ui.BuildStats
 import com.itsaky.androidide.compose.preview.ui.DeviceProfile
+import com.itsaky.androidide.compose.preview.ui.EditorState
+import com.itsaky.androidide.compose.preview.ui.EditorTool
 import com.itsaky.androidide.compose.preview.ui.NodeInfo
+import com.itsaky.androidide.compose.preview.ui.Selection
 import com.itsaky.androidide.compose.preview.ui.SystemBarsTheme
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -181,6 +184,16 @@ class ComposePreviewViewModel(
     /** Inspector 节点列表 (由 ComposableRenderer 推上来). */
     private val _inspectorNodes = MutableStateFlow<List<NodeInfo>>(emptyList())
     val inspectorNodes: StateFlow<List<NodeInfo>> = _inspectorNodes.asStateFlow()
+
+    // v2.1 可视化编辑器状态
+
+    /** 编辑器开关 (显示 EditorToolbar). */
+    private val _editorEnabled = MutableStateFlow(false)
+    val editorEnabled: StateFlow<Boolean> = _editorEnabled.asStateFlow()
+
+    /** 编辑器状态 (工具 + 选中). */
+    private val _editorState = MutableStateFlow(EditorState())
+    val editorState: StateFlow<EditorState> = _editorState.asStateFlow()
 
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
@@ -545,6 +558,61 @@ class ComposePreviewViewModel(
         _buildStats.value = prev.copy(
             lastRenderMs = elapsedMs,
             totalRenderMs = prev.totalRenderMs + elapsedMs,
+        )
+    }
+
+    // === v2.1 可视化编辑器 setter ===
+
+    /** 开关编辑器 (顶部 EditorToolbar 显示/隐藏). */
+    fun toggleEditor() {
+        _editorEnabled.value = !_editorEnabled.value
+        // 关闭时清空选中
+        if (!_editorEnabled.value) {
+            _editorState.value = EditorState()
+        }
+    }
+
+    fun setEditorEnabled(enabled: Boolean) {
+        _editorEnabled.value = enabled
+        if (!enabled) {
+            _editorState.value = EditorState()
+        }
+    }
+
+    /** 切换工具. */
+    fun setEditorTool(tool: EditorTool) {
+        _editorState.value = _editorState.value.copy(
+            tool = tool,
+            eyedropperActive = tool == EditorTool.Eyedropper,
+        )
+    }
+
+    /** 选中 / 更新选中. */
+    fun setSelection(selection: Selection?) {
+        _editorState.value = _editorState.value.copy(selection = selection)
+    }
+
+    /** 清除选中. */
+    fun clearSelection() {
+        _editorState.value = _editorState.value.copy(selection = null)
+    }
+
+    /** 更新 translation (Drag 工具拖动期间调用). */
+    fun translateSelection(dx: Float, dy: Float) {
+        val s = _editorState.value.selection ?: return
+        _editorState.value = _editorState.value.copy(
+            selection = s.copy(
+                translationX = s.translationX + dx,
+                translationY = s.translationY + dy,
+            )
+        )
+    }
+
+    /** 重置 translation (回到原始位置). */
+    fun resetTranslation() {
+        val s = _editorState.value.selection ?: return
+        _editorState.value = _editorState.value.copy(
+            selection = s.copy(translationX = 0f, translationY = 0f)
         )
     }
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ColorEyedropper.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ColorEyedropper.kt
@@ -1,0 +1,126 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import kotlin.math.abs
+
+/**
+ * 取色结果 v2.1.
+ *
+ * @property node 命中的节点
+ * @property color 估算的背景色 (基于 composable name 启发式映射, 真实场景需读 painted pixel)
+ * @property point 屏幕点击点 (相对 root)
+ */
+data class EyedropperResult(
+    val node: NodeInfo,
+    val color: Color,
+    val point: Offset,
+)
+
+/**
+ * 屏幕取色器 v2.1.
+ *
+ * 给定一组 [NodeInfo] (来自 [LayoutNodeInspector.collectNodes]) + 一个点击点 [point],
+ * 找到包含该点的最深层 (z-order 最高) 节点, 并返回估算颜色.
+ *
+ * 颜色估算策略 (启发式):
+ * - 当前没有直接读 painted pixel 的方法 (LayoutNode 不暴露)
+ * - 退而求其次, 根据 composable name 推断常见色:
+ *   - `Button` / `ButtonKt` / `*Button` → Material Primary
+ *   - `Card` → SurfaceVariant
+ *   - `TopAppBar` / `AppBar` → Material Primary
+ *   - `Text` / `*Text` → OnSurface
+ *   - `Icon` / `*Icon` → OnSurfaceVariant
+ *   - `Surface` / `Box` / `Row` / `Column` → Surface
+ *   - 其他 → Surface
+ *
+ * ## 已知限制
+ *
+ * - 同一节点多次点击会重复返回相同估算色; 真实色需 bitmap sample (待 P3).
+ * - 不支持 Z 轴上层的 hit-test (Compose 没有 z-index 概念, 用 bounds containment + 树深度).
+ */
+object ColorEyedropper {
+
+    /**
+     * 在 [nodes] 中找包含 [point] 的最深层节点.
+     *
+     * @param nodes Inspector 收集到的所有节点
+     * @param point 屏幕点击点 (与节点 bounds 同坐标系, 通常是 root 相对坐标)
+     * @return 命中的节点, 或 null (无节点包含此点)
+     */
+    fun findNodeAt(
+        nodes: List<NodeInfo>,
+        point: Offset,
+    ): NodeInfo? {
+        return nodes
+            .filter { node ->
+                val b = node.bounds
+                point.x >= b.left && point.x <= b.right &&
+                point.y >= b.top && point.y <= b.bottom
+            }
+            .maxByOrNull { it.bounds.width.toInt() * it.bounds.height.toInt() }  // 大小最大 = 最深
+    }
+
+    /**
+     * 给定 [node] 估算其背景色.
+     *
+     * 见 [ColorEyedropper] 文档说明.
+     */
+    fun estimateColor(node: NodeInfo): Color {
+        val name = node.composableName
+        return when {
+            name.contains("Button", ignoreCase = true) -> Color(0xFF1976D2)   // Material Primary
+            name.contains("AppBar", ignoreCase = true) -> Color(0xFF1976D2)
+            name.contains("TopBar", ignoreCase = true) -> Color(0xFF1976D2)
+            name.contains("Card", ignoreCase = true) -> Color(0xFFEEEEEE)
+            name.contains("Text", ignoreCase = true) -> Color(0xFF212121)
+            name.contains("Icon", ignoreCase = true) -> Color(0xFF616161)
+            name.contains("Surface", ignoreCase = true) -> Color(0xFFFAFAFA)
+            name.contains("Box", ignoreCase = true) -> Color(0xFFFAFAFA)
+            name.contains("Row", ignoreCase = true) -> Color(0xFFFAFAFA)
+            name.contains("Column", ignoreCase = true) -> Color(0xFFFAFAFA)
+            name.contains("Divider", ignoreCase = true) -> Color(0xFFBDBDBD)
+            name.contains("Spacer", ignoreCase = true) -> Color.Transparent
+            else -> Color(0xFFE0E0E0)
+        }
+    }
+
+    /**
+     * 一站式: 给点 + 节点, 返回 [EyedropperResult].
+     */
+    fun sample(nodes: List<NodeInfo>, point: Offset): EyedropperResult? {
+        val node = findNodeAt(nodes, point) ?: return null
+        return EyedropperResult(
+            node = node,
+            color = estimateColor(node),
+            point = point,
+        )
+    }
+}
+
+/**
+ * 工具: 比较两个 Rect 是否近似相等 (用于去重).
+ */
+internal fun Rect.isCloseTo(other: Rect, epsilon: Float = 1f): Boolean =
+    abs(left - other.left) < epsilon &&
+    abs(top - other.top) < epsilon &&
+    abs(right - other.right) < epsilon &&
+    abs(bottom - other.bottom) < epsilon

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorModels.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorModels.kt
@@ -1,0 +1,133 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+
+/**
+ * 可视化编辑工具枚举 v2.1.
+ *
+ * 用户通过 [EditorToolbar] 切换:
+ * - [Select]    点击选中元素 (默认)
+ * - [Pan]       拖动视口 (改变 viewport.offsetX/Y)
+ * - [Drag]      拖动选中元素 (改变其 translationX/Y)
+ * - [Eyedropper] 点击取色 (采样元素背景色)
+ */
+@Immutable
+enum class EditorTool(val label: String, val description: String) {
+    Select("Select", "点击选中元素"),
+    Pan("Pan", "拖动视口"),
+    Drag("Drag", "拖动选中元素"),
+    Eyedropper("Eyedropper", "点击取色"),
+}
+
+/**
+ * 选中元素的状态 v2.1.
+ *
+ * @property nodeId 选中的 LayoutNode id (对应 [NodeInfo.id])
+ * @property composableName 元素名 (用于 UI 显示)
+ * @property bounds 元素边界 (相对设备屏幕坐标系, 单位 px)
+ * @property backgroundColor 元素背景色 (可选, 来自 Eyedropper 采样)
+ * @property sampledColor 最近一次 Eyedropper 取到的颜色
+ * @property translationX / translationY 当前累积位移 (Drag 工具写入)
+ */
+@Immutable
+data class Selection(
+    val nodeId: Int,
+    val composableName: String,
+    val bounds: Rect,
+    val backgroundColor: Color? = null,
+    val sampledColor: Color? = null,
+    val translationX: Float = 0f,
+    val translationY: Float = 0f,
+) {
+    val width: Float get() = bounds.width
+    val height: Float get() = bounds.height
+    val isTranslated: Boolean get() = translationX != 0f || translationY != 0f
+}
+
+/**
+ * 选中状态 v2.1.
+ *
+ * 包装当前 [Selection] + [EditorTool]. 整个编辑器的可观察 state.
+ */
+@Immutable
+data class EditorState(
+    val tool: EditorTool = EditorTool.Select,
+    val selection: Selection? = null,
+    val eyedropperActive: Boolean = false,
+) {
+    val isEmpty: Boolean get() = selection == null
+    val isDragging: Boolean get() = tool == EditorTool.Drag && selection != null
+}
+
+/**
+ * 拖动手柄的位置枚举.
+ *
+ * 用于定义选中框上的可拖动手柄 (Resize 工具的 8 个方向).
+ */
+enum class HandlePosition {
+    TopLeft, TopCenter, TopRight,
+    MiddleLeft, MiddleRight,
+    BottomLeft, BottomCenter, BottomRight,
+}
+
+/**
+ * 拖动手柄信息.
+ *
+ * @property position 8 个方向之一
+ * @property center 手柄中心 (相对选中框)
+ * @property size 手柄大小
+ * @property cursor 鼠标光标类型 (供 IDE 桌面端参考)
+ */
+@Immutable
+data class HandleInfo(
+    val position: HandlePosition,
+    val center: Offset,
+    val size: Float = 12f,
+)
+
+/**
+ * 8 个手柄 (中心 / 角) 的偏移量计算.
+ *
+ * @param bounds 选中框
+ * @param handleSize 手柄大小 (px)
+ */
+internal fun buildHandles(
+    bounds: Rect,
+    handleSize: Float,
+): List<HandleInfo> = buildList {
+    val cx = bounds.left + bounds.width / 2f
+    val cy = bounds.top + bounds.height / 2f
+    val r = bounds.right
+    val b = bounds.bottom
+    val l = bounds.left
+    val t = bounds.top
+    val h = handleSize
+    add(HandleInfo(HandlePosition.TopLeft, Offset(l, t), h))
+    add(HandleInfo(HandlePosition.TopCenter, Offset(cx, t), h))
+    add(HandleInfo(HandlePosition.TopRight, Offset(r, t), h))
+    add(HandleInfo(HandlePosition.MiddleLeft, Offset(l, cy), h))
+    add(HandleInfo(HandlePosition.MiddleRight, Offset(r, cy), h))
+    add(HandleInfo(HandlePosition.BottomLeft, Offset(l, b), h))
+    add(HandleInfo(HandlePosition.BottomCenter, Offset(cx, b), h))
+    add(HandleInfo(HandlePosition.BottomRight, Offset(r, b), h))
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorToolbar.kt
@@ -1,0 +1,259 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Adjust
+import androidx.compose.material.icons.filled.Brush
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Colorize
+import androidx.compose.material.icons.filled.OpenWith
+import androidx.compose.material.icons.filled.PanTool
+import androidx.compose.material.icons.filled.TouchApp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 可视化编辑工具栏 v2.1.
+ *
+ * 4 个工具按钮 (Select / Pan / Drag / Eyedropper) + 关闭按钮.
+ * 当前选中工具高亮 (蓝色背景 + 圆角).
+ *
+ * 接入方式 (在 [ComposePreviewScreen] 中):
+ * ```kotlin
+ * if (editorEnabled) {
+ *     EditorToolbar(
+ *         tool = editorTool,
+ *         onToolChange = { viewModel.setEditorTool(it) },
+ *         onClose = { viewModel.toggleEditor() },
+ *     )
+ * }
+ * ```
+ *
+ * @param tool 当前工具
+ * @param onToolChange 工具切换回调
+ * @param onClose 关闭编辑模式回调
+ * @param modifier modifier
+ */
+@Composable
+fun EditorToolbar(
+    tool: EditorTool,
+    onToolChange: (EditorTool) -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // 工具栏标签
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Brush,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(12.dp),
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "Editor",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+
+        // 4 个工具按钮
+        EditorTool.values().forEach { t ->
+            EditorToolButton(
+                tool = t,
+                selected = tool == t,
+                onClick = { onToolChange(t) },
+            )
+            Spacer(Modifier.width(4.dp))
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        // 工具描述
+        Text(
+            text = tool.description,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+
+        Spacer(Modifier.width(8.dp))
+
+        // 关闭按钮
+        IconButton(onClick = onClose) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "关闭编辑器",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * 单个工具按钮.
+ */
+@Composable
+private fun EditorToolButton(
+    tool: EditorTool,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val bg = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+             else Color.Transparent
+    val iconTint = if (selected) MaterialTheme.colorScheme.primary
+                   else MaterialTheme.colorScheme.onSurfaceVariant
+    val border = if (selected) MaterialTheme.colorScheme.primary
+                 else Color.Transparent
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(bg)
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(CircleShape)
+                .background(bg)
+                .padding(2.dp),
+        ) {
+            IconButton(
+                onClick = onClick,
+                modifier = Modifier.size(28.dp),
+            ) {
+                Icon(
+                    imageVector = tool.icon(),
+                    contentDescription = tool.label,
+                    tint = iconTint,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+        Text(
+            text = tool.label,
+            color = if (selected) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 9.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+/**
+ * 工具的图标映射.
+ */
+private fun EditorTool.icon(): ImageVector = when (this) {
+    EditorTool.Select -> Icons.Filled.TouchApp
+    EditorTool.Pan -> Icons.Filled.PanTool
+    EditorTool.Drag -> Icons.Filled.OpenWith
+    EditorTool.Eyedropper -> Icons.Filled.Colorize
+}
+
+/**
+ * 编辑器状态条 v2.1.
+ *
+ * 顶部细条: 显示当前选中信息 (节点 id / composable 名 / 翻译偏移).
+ * 跟 [EditorToolbar] 配合使用.
+ *
+ * @param state 当前 editor state
+ * @param modifier modifier
+ */
+@Composable
+fun EditorStatusBar(
+    state: EditorState,
+    modifier: Modifier = Modifier,
+) {
+    val s = state.selection
+    val text = when {
+        s == null -> "未选中 — 选择 ${state.tool.label} 工具后点击预览元素"
+        s.isTranslated -> "选中 #${s.nodeId} ${s.composableName} · 偏移 (%.1f, %.1f) px".format(
+            s.translationX, s.translationY,
+        )
+        else -> "选中 #${s.nodeId} ${s.composableName} · 尺寸 %.0f×%.0f px".format(
+            s.bounds.width, s.bounds.height,
+        )
+    }
+    val tint = if (s == null) MaterialTheme.colorScheme.onSurfaceVariant
+               else MaterialTheme.colorScheme.primary
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Adjust,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(10.dp),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = text,
+            color = tint,
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Brightness6
+import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Smartphone
@@ -168,6 +169,20 @@ fun PreviewToolbar(
             },
         )
 
+        // 可视化编辑器开关 (P2)
+        FilterChip(
+            selected = state.editorEnabled,
+            onClick = actions.onToggleEditor,
+            label = { Text("Editor") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.Brush,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
         Spacer(modifier = Modifier.width(8.dp))
 
         // 关闭
@@ -186,6 +201,7 @@ data class PreviewToolbarState(
     val zoom: Float = 1.0f,
     val showSystemBars: Boolean = true,
     val debugEnabled: Boolean = false,
+    val editorEnabled: Boolean = false,
 )
 
 /**
@@ -198,5 +214,6 @@ data class PreviewToolbarActions(
     val onFitZoom: () -> Unit,
     val onToggleSystemBars: () -> Unit,
     val onToggleDebug: () -> Unit,
+    val onToggleEditor: () -> Unit,
     val onClose: () -> Unit,
 )

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SelectionOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SelectionOverlay.kt
@@ -1,0 +1,317 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 选中元素的可视化覆盖层 v2.1.
+ *
+ * 渲染:
+ * - 选中框 (蓝色虚线, 主选中)
+ * - 8 个 resize 手柄 (8 个方向)
+ * - 元素名标签 (左上角)
+ * - 尺寸 / 颜色 工具提示 (顶部)
+ *
+ * 行为:
+ * - 当 [tool] == [EditorTool.Drag] 时, 手势拖动整个框 → 调整 [Selection.translationX/Y]
+ *
+ * @param selection 当前选中
+ * @param tool 当前工具
+ * @param onSelectionChange 拖动结果回调
+ * @param modifier modifier
+ */
+@Composable
+fun SelectionOverlay(
+    selection: Selection?,
+    tool: EditorTool,
+    onSelectionChange: (Selection) -> Unit,
+    modifier: Modifier = Modifier,
+    handleSizeDp: Float = 10f,
+) {
+    if (selection == null) return
+
+    val density = LocalDensity.current
+    val handleSizePx = with(density) { handleSizeDp.dp.toPx() }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        // 选中框 + 手柄
+        SelectionBox(
+            selection = selection,
+            handleSizePx = handleSizePx,
+            tool = tool,
+            onTranslate = { dx, dy ->
+                onSelectionChange(
+                    selection.copy(
+                        translationX = selection.translationX + dx,
+                        translationY = selection.translationY + dy,
+                    )
+                )
+            },
+        )
+
+        // 元素名标签
+        SelectionLabel(
+            name = selection.composableName,
+            selection = selection,
+            modifier = Modifier.align(Alignment.TopStart),
+        )
+
+        // 尺寸 / 颜色 工具提示
+        if (tool == EditorTool.Eyedropper && selection.sampledColor != null) {
+            ColorTooltip(
+                color = selection.sampledColor,
+                modifier = Modifier.align(Alignment.TopCenter),
+            )
+        } else {
+            SizeTooltip(
+                selection = selection,
+                modifier = Modifier.align(Alignment.TopCenter),
+            )
+        }
+    }
+}
+
+/**
+ * 选中框本体 (8 个手柄 + 拖动响应).
+ */
+@Composable
+private fun SelectionBox(
+    selection: Selection,
+    handleSizePx: Float,
+    tool: EditorTool,
+    onTranslate: (Float, Float) -> Unit,
+) {
+    val strokeColor = MaterialTheme.colorScheme.primary
+    val handleColor = Color.White
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .drawWithContent {
+                drawContent()
+                val b = Rect(
+                    left = selection.bounds.left + selection.translationX,
+                    top = selection.bounds.top + selection.translationY,
+                    right = selection.bounds.right + selection.translationX,
+                    bottom = selection.bounds.bottom + selection.translationY,
+                )
+                // 阴影
+                drawRect(
+                    color = Color(0x30000000),
+                    topLeft = Offset(b.left - 2f, b.top - 2f),
+                    size = Size(b.width + 4f, b.height + 4f),
+                )
+                // 主框 (虚线)
+                drawDashedRect(
+                    color = strokeColor,
+                    topLeft = Offset(b.left, b.top),
+                    size = Size(b.width, b.height),
+                    strokeWidth = 2f,
+                    dashLen = 8f,
+                    gapLen = 4f,
+                )
+                // 8 个手柄
+                val handles = buildHandles(b, handleSizePx)
+                handles.forEach { h ->
+                    drawRect(
+                        color = handleColor,
+                        topLeft = Offset(h.center.x - h.size / 2f, h.center.y - h.size / 2f),
+                        size = Size(h.size, h.size),
+                    )
+                    drawRect(
+                        color = strokeColor,
+                        topLeft = Offset(h.center.x - h.size / 2f, h.center.y - h.size / 2f),
+                        size = Size(h.size, h.size),
+                        style = Stroke(width = 1.5f),
+                    )
+                }
+            }
+            .pointerInput(selection.nodeId, tool) {
+                if (tool == EditorTool.Drag) {
+                    detectDragGestures(
+                        onDragStart = { },
+                        onDragEnd = { },
+                        onDragCancel = { },
+                        onDrag = { change, dragAmount ->
+                            change.consume()
+                            onTranslate(dragAmount.x, dragAmount.y)
+                        },
+                    )
+                }
+            }
+    )
+}
+
+/**
+ * 在 DrawScope 上画一个虚线矩形.
+ */
+private fun DrawScope.drawDashedRect(
+    color: Color,
+    topLeft: Offset,
+    size: Size,
+    strokeWidth: Float,
+    dashLen: Float,
+    gapLen: Float,
+) {
+    val right = topLeft.x + size.width
+    val bottom = topLeft.y + size.height
+    fun dashH(y: Float, xStart: Float, xEnd: Float) {
+        var x = xStart
+        while (x < xEnd) {
+            val endX = (x + dashLen).coerceAtMost(xEnd)
+            drawLine(color, Offset(x, y), Offset(endX, y), strokeWidth = strokeWidth)
+            x += dashLen + gapLen
+        }
+    }
+    fun dashV(x: Float, yStart: Float, yEnd: Float) {
+        var y = yStart
+        while (y < yEnd) {
+            val endY = (y + dashLen).coerceAtMost(yEnd)
+            drawLine(color, Offset(x, y), Offset(x, endY), strokeWidth = strokeWidth)
+            y += dashLen + gapLen
+        }
+    }
+    dashH(topLeft.y, topLeft.x, right)
+    dashH(bottom, topLeft.x, right)
+    dashV(topLeft.x, topLeft.y, bottom)
+    dashV(right, topLeft.y, bottom)
+}
+
+/**
+ * 元素名标签 (左上角).
+ */
+@Composable
+private fun SelectionLabel(
+    name: String,
+    selection: Selection,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val xDp = with(density) { (selection.bounds.left + selection.translationX).toDp() }
+    val yDp = with(density) { (selection.bounds.top + selection.translationY - 24f).toDp() }
+    Box(
+        modifier = modifier
+            .offset(x = xDp, y = yDp)
+            .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    ) {
+        Text(
+            text = name,
+            color = MaterialTheme.colorScheme.onPrimary,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+/**
+ * 尺寸工具提示.
+ */
+@Composable
+private fun SizeTooltip(
+    selection: Selection,
+    modifier: Modifier = Modifier,
+) {
+    val widthDp = selection.width / 3f
+    val heightDp = selection.height / 3f
+    Box(
+        modifier = modifier
+            .padding(top = 4.dp)
+            .background(Color(0xCC000000), RoundedCornerShape(4.dp))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = "%.0f × %.0f dp · (%d,%d)".format(
+                widthDp, heightDp,
+                (selection.bounds.left + selection.translationX).toInt(),
+                (selection.bounds.top + selection.translationY).toInt(),
+            ),
+            color = Color.White,
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+/**
+ * 颜色工具提示 (Eyedropper 模式下显示).
+ */
+@Composable
+private fun ColorTooltip(
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .padding(top = 4.dp)
+            .background(Color(0xCC000000), RoundedCornerShape(4.dp))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(16.dp)
+                .background(color, RoundedCornerShape(2.dp))
+                .border(1.dp, Color.White, RoundedCornerShape(2.dp)),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = "#%02X%02X%02X".format(
+                (color.red * 255).toInt(),
+                (color.green * 255).toInt(),
+                (color.blue * 255).toInt(),
+            ),
+            color = Color.White,
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}


### PR DESCRIPTION
## 概述

`modules/compose-preview/` v2.1 重构 **P2 阶段首提交** — 可视化编辑工具箱的骨架.
在 P1 调试面板基础上叠加了"编辑器"模式: 用户可点击预览元素, 选中后查看
8-handle 选中框, 并通过工具栏切换 Select / Pan / Drag / Eyedropper.

## 改动

### 新增 (4 个文件)

- **`ui/EditorModels.kt`** (133 行)
  - `EditorTool` 枚举: `Select` / `Pan` / `Drag` / `Eyedropper`
  - `Selection` data class: `nodeId` / `composableName` / `bounds` /
    `sampledColor` / `translationX` / `translationY`
  - `EditorState` data class: `tool` + `selection` + `eyedropperActive`
  - `HandlePosition` (8 方向) + `HandleInfo` + `buildHandles()` 8 手柄几何

- **`ui/SelectionOverlay.kt`** (317 行)
  - `SelectionOverlay` Composable: 选中框 (虚线) + 8 个白色手柄
  - `DrawScope.drawDashedRect()` 自实现 (4 边, dash+gap)
  - `SelectionBox`: Drag 工具时 `detectDragGestures` 拖动整框
  - `SelectionLabel`: 元素名标签 (左上角, primary 背景)
  - `SizeTooltip`: 尺寸提示 `W × H dp · (x,y)`
  - `ColorTooltip`: Eyedropper 模式的 #RRGGBB + 色块

- **`ui/EditorToolbar.kt`** (259 行)
  - 4 个工具按钮 (图标 + 标签) + 当前工具描述 + 关闭按钮
  - 选中工具高亮 (primary 背景 + 圆角 + 文字加粗)
  - `EditorStatusBar` 顶细条: 显示当前选中信息 (id + name + 偏移/尺寸)

- **`ui/ColorEyedropper.kt`** (126 行)
  - `ColorEyedropper` object:
    - `findNodeAt(nodes, point)`: hit-test 找最深层 (按面积)
    - `estimateColor(node)`: 启发式颜色映射
      (Button→primary, Card→surfaceVariant, Text→onSurface ...)
  - `EyedropperResult` data class
  - `isCloseTo(Rect, epsilon)` 工具

### 修改 (3 个文件)

- **`ui/PreviewToolbar.kt`**:
  - `PreviewToolbarState.editorEnabled` 字段
  - `PreviewToolbarActions.onToggleEditor` 行为
  - 新增 "Editor" FilterChip (Brush 图标) 接 onToggleEditor

- **`ComposePreviewViewModel.kt`**:
  - `_editorEnabled: StateFlow<Boolean>` (默认 false)
  - `_editorState: StateFlow<EditorState>` (默认 Select / null)
  - `toggleEditor()` / `setEditorEnabled()`
  - `setEditorTool(tool)` / `setSelection(selection)` / `clearSelection()`
  - `translateSelection(dx, dy)` / `resetTranslation()`

- **`ComposePreviewActivity.kt`**:
  - 收集 `editorEnabled` / `editorState` 状态
  - `if (editorEnabled) EditorToolbar() + EditorStatusBar()`
  - 新增私有 `EditorInteractionLayer`:
    - 点击响应 (`detectTapGestures.onTap` → hit-test → setSelection)
    - 长按 = 清除选中
    - 包裹 `SelectionOverlay` 绘制选中框 + 处理 Drag
  - 调用 viewModel 接入 setSelection / clearSelection / translateSelection

## 接入链路

```
PreviewToolbar.Editor chip
   ↓ onToggleEditor
viewModel.toggleEditor()
   ↓ _editorEnabled.value = true
EditorToolbar 弹出 (二级)
   ↓ 用户切换工具
viewModel.setEditorTool(...)
   ↓ 用户点击预览
EditorInteractionLayer.onTap(offset)
   ↓ hit-test
ColorEyedropper.findNodeAt(nodes, offset)
   ↓ 找到节点
viewModel.setSelection(Selection(node))
   ↓ _editorState.value 更新
SelectionOverlay 绘制选中框 (8 手柄)
   ↓ 切到 Drag 工具拖动
viewModel.translateSelection(dx, dy)
```

## 已知限制

- **Eyedropper 颜色是估算**: LayoutNode 不暴露 painted pixel, 当前按 composable name 启发式.
  真实取色需 P3 接入 `View.drawToBitmap` 或 GPU readback.
- **Pan 工具未实现**: UI 已留位, 实际拖动逻辑待 P2-Resize 一起补 (与 viewport.offsetX/Y 联动).
- **Resize 手柄只画了不响应**: 8 个手柄是 UI 占位, Resize 工具待 P2 后半段.

## 设计依据

- `DESIGN.md` v2.1 §10 可视化编辑工具箱
- `TODO.md` v2.1 P2-UI-01 (SelectionModel) / P2-UI-02 (Overlay) /
  P2-UI-03 (EditorToolbar) / P2-UI-04 (DragHandle) / P2-UI-05 (Eyedropper)

## 后续 PR (P2 收尾)

- [ ] Resize 工具: 接管 8 手柄拖动
- [ ] Pan 工具: 联动 viewport.offsetX/Y
- [ ] Eyedropper bitmap 真实取色
- [ ] 选中框上增加"快速操作"菜单 (复制 / 删除 / 转 code)
