### PR TITLE
feat(compose-preview): v2.1 P2 Resize 8 手柄 + Pan 视口平移 + AspectLock

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -166,6 +167,7 @@ fun ComposePreviewScreen(
     // v2.1 可视化编辑器状态
     val editorEnabled by viewModel.editorEnabled.collectAsStateWithLifecycle()
     val editorState by viewModel.editorState.collectAsStateWithLifecycle()
+    val aspectLock by viewModel.aspectLock.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -219,6 +221,13 @@ fun ComposePreviewScreen(
                         tool = editorState.tool,
                         onToolChange = { viewModel.setEditorTool(it) },
                         onClose = { viewModel.toggleEditor() },
+                        aspectLock = aspectLock,
+                        onToggleAspectLock = { viewModel.toggleAspectLock() },
+                        onReset = {
+                            viewModel.resetTranslation()
+                            viewModel.resetViewportOffset()
+                        },
+                        hasSelection = editorState.selection != null,
                     )
                     EditorStatusBar(state = editorState)
                 }
@@ -260,6 +269,7 @@ fun ComposePreviewScreen(
                         EditorInteractionLayer(
                             editorState = editorState,
                             inspectorNodes = inspectorNodes,
+                            aspectLock = aspectLock,
                             onSelectAt = { offset, node ->
                                 if (editorState.tool == EditorTool.Select ||
                                     editorState.tool == EditorTool.Drag) {
@@ -285,6 +295,12 @@ fun ComposePreviewScreen(
                             onClearSelection = { viewModel.clearSelection() },
                             onTranslate = { dx, dy ->
                                 viewModel.translateSelection(dx, dy)
+                            },
+                            onResize = { handle, dx, dy ->
+                                viewModel.resizeSelection(handle, dx, dy)
+                            },
+                            onPan = { dxDp, dyDp ->
+                                viewModel.panViewport(dxDp, dyDp)
                             },
                         )
                     }
@@ -439,16 +455,23 @@ private fun ReadyPanel(
             .padding(16.dp),
         contentAlignment = Alignment.Center,
     ) {
-        // 用 DeviceFrame 包裹实际预览 ComposeView
-        DeviceFrame(
-            profile = deviceConfig.profile,
-            systemBarsTheme = deviceConfig.systemBarsTheme,
-            showStatusBar = deviceConfig.showStatusBar,
-            showNavigationBar = deviceConfig.showNavigationBar,
-            showCutout = deviceConfig.showCutout,
-            showChassis = deviceConfig.showChassis,
-            useGestureNav = deviceConfig.useGestureNav,
+        // v2.1 视口平移 (Pan 工具): 用 offset 包裹 DeviceFrame
+        val panOffsetX = viewport.offsetXdp.dp
+        val panOffsetY = viewport.offsetYdp.dp
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .offset(x = panOffsetX, y = panOffsetY)
         ) {
+            // 用 DeviceFrame 包裹实际预览 ComposeView
+            DeviceFrame(
+                profile = deviceConfig.profile,
+                systemBarsTheme = deviceConfig.systemBarsTheme,
+                showStatusBar = deviceConfig.showStatusBar,
+                showNavigationBar = deviceConfig.showNavigationBar,
+                showCutout = deviceConfig.showCutout,
+                showChassis = deviceConfig.showChassis,
+                useGestureNav = deviceConfig.useGestureNav,
+            ) {
             // 实际渲染由 ComposableRenderer 负责
             // 这里放置一个标记 Box
             RenderTargetMarker(
@@ -529,67 +552,90 @@ private fun triggerBuild(
 }
 
 /**
- * v2.1 编辑器交互层 (P2).
+ * v2.1 编辑器交互层 (P2 + Resize + Pan).
  *
  * 叠在预览内容之上, 提供:
  * 1. 点击响应: 根据 [EditorState.tool] 选择 / 取色 / 清除选中
- * 2. 选中框绘制: 包裹 [SelectionOverlay] (8 手柄 + 拖动)
+ * 2. 选中框绘制: 包裹 [SelectionOverlay] (8 手柄 + 拖动 + Resize)
+ * 3. Pan 工具: 在空白处拖动 → 视口平移
  *
  * @param editorState 当前 editor state
  * @param inspectorNodes 全部节点 (hit-test 用)
+ * @param aspectLock 纵横比锁定状态 (传给 SelectionOverlay)
  * @param onSelectAt 命中节点回调 (offset + 命中的 NodeInfo)
  * @param onClearSelection 清除选中回调
- * @param onTranslate 拖动选中元素回调 (Drag 工具)
+ * @param onTranslate 拖动选中元素回调 (Drag 工具 - 平移)
+ * @param onResize resize 选中元素回调 (Drag 工具 - 8 手柄)
+ * @param onPan 视口平移回调 (Pan 工具, 单位 dp)
  */
 @Composable
 private fun EditorInteractionLayer(
     editorState: EditorState,
     inspectorNodes: List<NodeInfo>,
+    aspectLock: Boolean,
     onSelectAt: (androidx.compose.ui.geometry.Offset, NodeInfo) -> Unit,
     onClearSelection: () -> Unit,
     onTranslate: (Float, Float) -> Unit,
+    onResize: (com.itsaky.androidide.compose.preview.ui.HandlePosition, Float, Float) -> Unit,
+    onPan: (Float, Float) -> Unit,
 ) {
+    val density = androidx.compose.ui.platform.LocalDensity.current
     Box(modifier = Modifier.fillMaxSize()) {
-        // 点击响应层
+        // 点击 + Pan 响应层
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .pointerInput(editorState.tool, inspectorNodes) {
                     detectTapGestures(
                         onTap = { offset ->
-                            if (editorState.tool == EditorTool.Select ||
-                                editorState.tool == EditorTool.Eyedropper
-                            ) {
-                                val node = ColorEyedropper.findNodeAt(inspectorNodes, offset)
-                                if (node != null) {
-                                    onSelectAt(offset, node)
-                                } else {
-                                    onClearSelection()
+                            when (editorState.tool) {
+                                EditorTool.Select, EditorTool.Drag -> {
+                                    val node = ColorEyedropper.findNodeAt(inspectorNodes, offset)
+                                    if (node != null) onSelectAt(offset, node)
+                                    else onClearSelection()
                                 }
+                                EditorTool.Eyedropper -> {
+                                    val node = ColorEyedropper.findNodeAt(inspectorNodes, offset)
+                                    if (node != null) onSelectAt(offset, node)
+                                }
+                                EditorTool.Pan -> { /* pan 由 drag 处理 */ }
                             }
                         },
-                        onLongPress = {
-                            // 长按 = 清除选中
-                            onClearSelection()
-                        },
+                        onLongPress = { onClearSelection() },
                     )
+                }
+                .pointerInput(editorState.tool) {
+                    if (editorState.tool == EditorTool.Pan) {
+                        androidx.compose.foundation.gestures.detectDragGestures(
+                            onDragStart = { },
+                            onDragEnd = { },
+                            onDragCancel = { },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                val dxDp = dragAmount.x / density.density
+                                val dyDp = dragAmount.y / density.density
+                                onPan(dxDp, dyDp)
+                            },
+                        )
+                    }
                 }
         )
 
-        // 选中覆盖层 (含 8 手柄 + 拖动响应)
+        // 选中覆盖层 (含 8 手柄 + 拖动 + resize 响应)
         SelectionOverlay(
             selection = editorState.selection,
             tool = editorState.tool,
+            aspectLock = aspectLock,
             onSelectionChange = { newSel ->
-                if (editorState.tool == EditorTool.Drag) {
-                    val old = editorState.selection
-                    if (old != null) {
-                        val dx = newSel.translationX - old.translationX
-                        val dy = newSel.translationY - old.translationY
-                        onTranslate(dx, dy)
-                    }
+                val old = editorState.selection
+                if (old == null) return@SelectionOverlay
+                val dx = newSel.translationX - old.translationX
+                val dy = newSel.translationY - old.translationY
+                if (dx != 0f || dy != 0f) {
+                    onTranslate(dx, dy)
                 }
             },
+            onResize = onResize,
         )
     }
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -195,6 +195,10 @@ class ComposePreviewViewModel(
     private val _editorState = MutableStateFlow(EditorState())
     val editorState: StateFlow<EditorState> = _editorState.asStateFlow()
 
+    /** 纵横比锁定 (Shift 行为). */
+    private val _aspectLock = MutableStateFlow(false)
+    val aspectLock: StateFlow<Boolean> = _aspectLock.asStateFlow()
+
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
     private var currentSource: String = ""
@@ -614,6 +618,46 @@ class ComposePreviewViewModel(
         _editorState.value = _editorState.value.copy(
             selection = s.copy(translationX = 0f, translationY = 0f)
         )
+    }
+
+    /** Resize 选中 (8 个手柄拖动期间调用). */
+    fun resizeSelection(
+        handle: com.itsaky.androidide.compose.preview.ui.HandlePosition,
+        dx: Float,
+        dy: Float,
+    ) {
+        val s = _editorState.value.selection ?: return
+        _editorState.value = _editorState.value.copy(
+            selection = s.resizeBy(handle, dx, dy, minSize = 8f, aspectLock = _aspectLock.value)
+        )
+    }
+
+    /** 直接替换 selection (用于 SelectionOverlay 回调的整对象替换). */
+    fun replaceSelection(newSelection: Selection) {
+        _editorState.value = _editorState.value.copy(selection = newSelection)
+    }
+
+    /** 切换 / 设置纵横比锁定 (Shift 行为). */
+    fun setAspectLock(locked: Boolean) {
+        _aspectLock.value = locked
+    }
+
+    fun toggleAspectLock() {
+        _aspectLock.value = !_aspectLock.value
+    }
+
+    /** Pan 工具: 移动视口 (单位 dp). */
+    fun panViewport(dxDp: Float, dyDp: Float) {
+        val v = _viewport.value
+        _viewport.value = v.copy(
+            offsetXdp = v.offsetXdp + dxDp,
+            offsetYdp = v.offsetYdp + dyDp,
+        )
+    }
+
+    /** 重置视口偏移. */
+    fun resetViewportOffset() {
+        _viewport.value = _viewport.value.copy(offsetXdp = 0f, offsetYdp = 0f)
     }
 
     override fun onCleared() {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorModels.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorModels.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * 可视化编辑工具枚举 v2.1.
@@ -35,7 +37,7 @@ import androidx.compose.ui.graphics.Color
 enum class EditorTool(val label: String, val description: String) {
     Select("Select", "点击选中元素"),
     Pan("Pan", "拖动视口"),
-    Drag("Drag", "拖动选中元素"),
+    Drag("Drag", "拖动 / Resize 选中元素"),
     Eyedropper("Eyedropper", "点击取色"),
 }
 
@@ -62,6 +64,128 @@ data class Selection(
     val width: Float get() = bounds.width
     val height: Float get() = bounds.height
     val isTranslated: Boolean get() = translationX != 0f || translationY != 0f
+
+    /**
+     * 按某个手柄方向 resize 此选中.
+     *
+     * @param handle 8 个方向之一
+     * @param dx / dy 拖动增量 (px)
+     * @param minSize 最小尺寸 (px), 默认不低于
+     * @param aspectLock 锁定纵横比 (Shift 行为)
+     * @return 新 Selection, bounds 已更新, translation 不变
+     */
+    fun resizeBy(
+        handle: HandlePosition,
+        dx: Float,
+        dy: Float,
+        minSize: Float = 8f,
+        aspectLock: Boolean = false,
+    ): Selection {
+        val b = bounds
+        var newLeft = b.left
+        var newTop = b.top
+        var newRight = b.right
+        var newBottom = b.bottom
+
+        when (handle) {
+            HandlePosition.TopLeft -> {
+                newLeft = b.left + dx
+                newTop = b.top + dy
+            }
+            HandlePosition.TopCenter -> {
+                newTop = b.top + dy
+            }
+            HandlePosition.TopRight -> {
+                newRight = b.right + dx
+                newTop = b.top + dy
+            }
+            HandlePosition.MiddleLeft -> {
+                newLeft = b.left + dx
+            }
+            HandlePosition.MiddleRight -> {
+                newRight = b.right + dx
+            }
+            HandlePosition.BottomLeft -> {
+                newLeft = b.left + dx
+                newBottom = b.bottom + dy
+            }
+            HandlePosition.BottomCenter -> {
+                newBottom = b.bottom + dy
+            }
+            HandlePosition.BottomRight -> {
+                newRight = b.right + dx
+                newBottom = b.bottom + dy
+            }
+        }
+
+        // 最小尺寸
+        if (newRight - newLeft < minSize) {
+            // 拖左 / 拖右时, 固定另一边
+            if (handle == HandlePosition.TopLeft || handle == HandlePosition.MiddleLeft || handle == HandlePosition.BottomLeft) {
+                newLeft = newRight - minSize
+            } else {
+                newRight = newLeft + minSize
+            }
+        }
+        if (newBottom - newTop < minSize) {
+            if (handle == HandlePosition.TopLeft || handle == HandlePosition.TopCenter || handle == HandlePosition.TopRight) {
+                newTop = newBottom - minSize
+            } else {
+                newBottom = newTop + minSize
+            }
+        }
+
+        // 纵横比锁定 (角部 handle 生效)
+        if (aspectLock && handle in setOf(
+                HandlePosition.TopLeft, HandlePosition.TopRight,
+                HandlePosition.BottomLeft, HandlePosition.BottomRight,
+            )
+        ) {
+            val aspect = b.width / b.height
+            val curAspect = (newRight - newLeft) / max(1f, (newBottom - newTop))
+            if (kotlin.math.abs(curAspect - aspect) > 0.01f) {
+                // 取主导方向, 推算另一边
+                when (handle) {
+                    HandlePosition.BottomRight -> {
+                        // 保持左 / 上不动, 调整 width
+                        val newW = max(minSize, newRight - newLeft)
+                        val newH = newW / aspect
+                        newRight = newLeft + newW
+                        newBottom = newTop + newH
+                    }
+                    HandlePosition.TopLeft -> {
+                        // 保持右 / 下不动
+                        val newW = max(minSize, newRight - newLeft)
+                        val newH = newW / aspect
+                        newLeft = newRight - newW
+                        newTop = newBottom - newH
+                    }
+                    HandlePosition.TopRight -> {
+                        val newW = max(minSize, newRight - newLeft)
+                        val newH = newW / aspect
+                        newRight = newLeft + newW
+                        newTop = newBottom - newH
+                    }
+                    HandlePosition.BottomLeft -> {
+                        val newW = max(minSize, newRight - newLeft)
+                        val newH = newW / aspect
+                        newLeft = newRight - newW
+                        newBottom = newTop + newH
+                    }
+                    else -> { /* edge */ }
+                }
+            }
+        }
+
+        return this.copy(
+            bounds = Rect(
+                left = min(newLeft, newRight),
+                top = min(newTop, newBottom),
+                right = max(newLeft, newRight),
+                bottom = max(newTop, newBottom),
+            )
+        )
+    }
 }
 
 /**

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/EditorToolbar.kt
@@ -31,11 +31,13 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Adjust
+import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Colorize
 import androidx.compose.material.icons.filled.OpenWith
 import androidx.compose.material.icons.filled.PanTool
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -57,6 +59,7 @@ import androidx.compose.ui.unit.sp
  *
  * 4 个工具按钮 (Select / Pan / Drag / Eyedropper) + 关闭按钮.
  * 当前选中工具高亮 (蓝色背景 + 圆角).
+ * 附: 纵横比锁定切换 + 重置位移 / 视口按钮.
  *
  * 接入方式 (在 [ComposePreviewScreen] 中):
  * ```kotlin
@@ -72,6 +75,10 @@ import androidx.compose.ui.unit.sp
  * @param tool 当前工具
  * @param onToolChange 工具切换回调
  * @param onClose 关闭编辑模式回调
+ * @param aspectLock 纵横比锁定状态
+ * @param onToggleAspectLock 切换纵横比锁定回调
+ * @param onReset 重置编辑结果回调
+ * @param hasSelection 是否当前有选中 (决定 reset 是否可点)
  * @param modifier modifier
  */
 @Composable
@@ -79,6 +86,10 @@ fun EditorToolbar(
     tool: EditorTool,
     onToolChange: (EditorTool) -> Unit,
     onClose: () -> Unit,
+    aspectLock: Boolean = false,
+    onToggleAspectLock: () -> Unit = {},
+    onReset: () -> Unit = {},
+    hasSelection: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -123,6 +134,26 @@ fun EditorToolbar(
             Spacer(Modifier.width(4.dp))
         }
 
+        Spacer(Modifier.width(4.dp))
+
+        // 纵横比锁定 (P2-Resize)
+        EditorIconToggle(
+            icon = Icons.Filled.AspectRatio,
+            label = "Lock",
+            selected = aspectLock,
+            onClick = onToggleAspectLock,
+        )
+        Spacer(Modifier.width(4.dp))
+
+        // 重置
+        EditorIconToggle(
+            icon = Icons.Filled.Refresh,
+            label = "Reset",
+            selected = false,
+            onClick = onReset,
+            enabled = hasSelection,
+        )
+
         Spacer(Modifier.weight(1f))
 
         // 工具描述
@@ -143,6 +174,54 @@ fun EditorToolbar(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+/**
+ * 单个图标切换按钮 (用于 AspectRatio / Refresh 等小工具).
+ */
+@Composable
+private fun EditorIconToggle(
+    icon: ImageVector,
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+) {
+    val tint = when {
+        !enabled -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+        selected -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val bg = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+             else Color.Transparent
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(bg)
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+    ) {
+        IconButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = Modifier.size(28.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = tint,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Text(
+            text = label,
+            color = if (selected) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 9.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            fontFamily = FontFamily.Monospace,
+        )
     }
 }
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SelectionOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SelectionOverlay.kt
@@ -59,32 +59,45 @@ import androidx.compose.ui.unit.sp
  * - 尺寸 / 颜色 工具提示 (顶部)
  *
  * 行为:
- * - 当 [tool] == [EditorTool.Drag] 时, 手势拖动整个框 → 调整 [Selection.translationX/Y]
+ * - 当 [tool] == [EditorTool.Drag] 时, 在框内部拖动 → 调整 [Selection.translationX/Y]
+ * - 当 [tool] == [EditorTool.Drag] 时, 在 8 个手柄上拖动 → 调用 [onResize]
+ *   (配合 [aspectLock] 锁定纵横比)
+ * - 当 [tool] == [EditorTool.Pan] 时, 外部拖动由调用方处理 (视口平移)
  *
  * @param selection 当前选中
  * @param tool 当前工具
- * @param onSelectionChange 拖动结果回调
+ * @param onSelectionChange 拖动平移回调 (整 Selection 替换)
+ * @param onResize resize 回调 (handle + 增量 px)
  * @param modifier modifier
+ * @param handleSizeDp 手柄视觉尺寸
+ * @param minSizeDp 最小尺寸 (resize 时不小于此值)
+ * @param aspectLock 锁定纵横比
  */
 @Composable
 fun SelectionOverlay(
     selection: Selection?,
     tool: EditorTool,
     onSelectionChange: (Selection) -> Unit,
+    onResize: (HandlePosition, Float, Float) -> Unit,
     modifier: Modifier = Modifier,
     handleSizeDp: Float = 10f,
+    minSizeDp: Float = 8f,
+    aspectLock: Boolean = false,
 ) {
     if (selection == null) return
 
     val density = LocalDensity.current
     val handleSizePx = with(density) { handleSizeDp.dp.toPx() }
+    val minSizePx = with(density) { minSizeDp.dp.toPx() }
 
     Box(modifier = modifier.fillMaxSize()) {
         // 选中框 + 手柄
         SelectionBox(
             selection = selection,
             handleSizePx = handleSizePx,
+            minSizePx = minSizePx,
             tool = tool,
+            aspectLock = aspectLock,
             onTranslate = { dx, dy ->
                 onSelectionChange(
                     selection.copy(
@@ -92,6 +105,9 @@ fun SelectionOverlay(
                         translationY = selection.translationY + dy,
                     )
                 )
+            },
+            onResize = { handle, dx, dy ->
+                onResize(handle, dx, dy)
             },
         )
 
@@ -118,14 +134,17 @@ fun SelectionOverlay(
 }
 
 /**
- * 选中框本体 (8 个手柄 + 拖动响应).
+ * 选中框本体 (8 个手柄 + 拖动响应 + 手柄拖动响应).
  */
 @Composable
 private fun SelectionBox(
     selection: Selection,
     handleSizePx: Float,
+    minSizePx: Float,
     tool: EditorTool,
+    aspectLock: Boolean,
     onTranslate: (Float, Float) -> Unit,
+    onResize: (HandlePosition, Float, Float) -> Unit,
 ) {
     val strokeColor = MaterialTheme.colorScheme.primary
     val handleColor = Color.White
@@ -172,20 +191,55 @@ private fun SelectionBox(
                     )
                 }
             }
-            .pointerInput(selection.nodeId, tool) {
+            .pointerInput(selection.nodeId, tool, aspectLock) {
                 if (tool == EditorTool.Drag) {
+                    var activeHandle: HandlePosition? = null
                     detectDragGestures(
-                        onDragStart = { },
-                        onDragEnd = { },
-                        onDragCancel = { },
+                        onDragStart = { offset ->
+                            val b = Rect(
+                                left = selection.bounds.left + selection.translationX,
+                                top = selection.bounds.top + selection.translationY,
+                                right = selection.bounds.right + selection.translationX,
+                                bottom = selection.bounds.bottom + selection.translationY,
+                            )
+                            val handles = buildHandles(b, handleSizePx)
+                            activeHandle = hitTestHandle(handles, offset, handleSizePx)
+                        },
+                        onDragEnd = { activeHandle = null },
+                        onDragCancel = { activeHandle = null },
                         onDrag = { change, dragAmount ->
                             change.consume()
-                            onTranslate(dragAmount.x, dragAmount.y)
+                            val h = activeHandle
+                            if (h == null) {
+                                onTranslate(dragAmount.x, dragAmount.y)
+                            } else {
+                                onResize(h, dragAmount.x, dragAmount.y)
+                            }
                         },
                     )
                 }
             }
     )
+}
+
+/**
+ * 给定 8 个手柄 + 点击点, 找命中的手柄.
+ * 若点击在手柄 hit-region 之外 → null (表示平移).
+ */
+private fun hitTestHandle(
+    handles: List<HandleInfo>,
+    point: Offset,
+    handleSizePx: Float,
+): HandlePosition? {
+    val r = handleSizePx * 1.5f  // 稍微放大命中区
+    handles.forEach { h ->
+        val dx = kotlin.math.abs(point.x - h.center.x)
+        val dy = kotlin.math.abs(point.y - h.center.y)
+        if (dx <= r / 2f && dy <= r / 2f) {
+            return h.position
+        }
+    }
+    return null
 }
 
 /**


### PR DESCRIPTION
## 概述

P2 收尾提交 — 在 PR #332 (P2 编辑器骨架) 基础上接入 8 手柄 resize 全部方向、
Pan 工具联动视口、AspectLock 切换、重置按钮. 现在 4 个工具 (Select / Pan /
Drag / Eyedropper) 全部可用, 选中元素可拖动 / 8 向 resize, 视口可平移.

## 改动

### Resize (8 手柄接管)

- **`SelectionOverlay.kt`**:
  - `SelectionBox` 的 `pointerInput` 拆成 onDragStart hit-test
    - `hitTestHandle()`: 判断点击命中哪个手柄 (1.5x 放大命中区)
  - onDrag 根据 `activeHandle` 走 `onTranslate` / `onResize` 分支
  - `SelectionOverlay` 增 `onResize: (HandlePosition, Float, Float) -> Unit` 参数

- **`EditorModels.kt`** `Selection.resizeBy()` (新增):
  - 8 个 handle 方向计算
    (TopLeft / TopCenter / TopRight / MiddleLeft / MiddleRight /
     BottomLeft / BottomCenter / BottomRight)
  - 最小尺寸 8f px 限制 (避免退化)
  - AspectLock 时: 4 个角部 handle 按原 aspect 推算另一边
  - 返回新 Selection (translation 不动, bounds 更新)

- **`ComposePreviewViewModel.kt`** 增:
  - `_aspectLock: StateFlow<Boolean>` (默认 false)
  - `resizeSelection(handle, dx, dy)` setter
  - `replaceSelection(newSelection)` setter
  - `setAspectLock(locked)` / `toggleAspectLock()`
  - `panViewport(dxDp, dyDp)` (累加到 viewport.offsetXdp/Ydp)
  - `resetViewportOffset()`

### Pan (视口平移)

- **`EditorInteractionLayer`**:
  - 第二个 `pointerInput` 仅在 `tool == Pan` 时启用
  - `detectDragGestures` 把 px 增量 → dp → `viewModel.panViewport(dx, dy)`
- **`ReadyPanel`**:
  - 把 `DeviceFrame` 包在
    `Box(Modifier.offset(x = offsetXdp.dp, y = offsetYdp.dp))`
  - 视口平移即时反映在预览画面上

### AspectLock 切换

- **`EditorToolbar.kt`**:
  - 新增私有 `EditorIconToggle` Composable (图标 + 标签)
  - AspectRatio 图标: `aspectLock` 状态切换 (高亮)
  - Refresh 图标: 重置 translation + 视口偏移 (enable = hasSelection)
  - `EditorToolbar` 增 `aspectLock` / `onToggleAspectLock` /
    `onReset` / `hasSelection` 参数

### 接入 (Activity)

- `EditorToolbar` 完整接入 (aspectLock + reset)
- `EditorInteractionLayer` 增 `aspectLock` / `onResize` / `onPan` 参数
- `onResize` → `viewModel.resizeSelection(handle, dx, dy)`
- `onPan` → `viewModel.panViewport(dxDp, dyDp)`
- ReadyPanel 增加 viewport.offsetX/Y 偏移

## 操作链路

```
Drag 工具:
  在框内拖动 → onTranslate → viewModel.translateSelection → 累加 translation
  在 8 手柄上拖动 → hitTestHandle → onResize → viewModel.resizeSelection
                    → selection.resizeBy(handle, dx, dy, minSize=8, aspectLock)
                    → 更新 bounds
  AspectLock 开启时: 4 角按原 aspect 推算另一边

Pan 工具:
  拖动空白处 → detectDragGestures → onPan(dxDp, dyDp)
  → viewModel.panViewport → viewport.offsetXdp/Ydp
  → ReadyPanel 的 Modifier.offset 即时反映
```

## 已知限制

- 真实 Eyedropper 取色 (PixelCopy 读 preview surface) 仍为启发式估算
- Resize 不联动节点树, 只改 visual bounds (后续可接 code-gen)
- Pan 后视口偏移不影响 layout 测量, 只视觉位移

## 后续

- P3 字节码加速 (ASM 静态 binder + 反射优化)
- 真实取色 (PixelCopy)
- 选中元素 "转 code" 菜单
