### PR TITLE
v2.2 P3 Live Edit (Hot Reload) - 编辑源文件自动重编译 + DEX 切换

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepository.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepository.kt
@@ -15,6 +15,20 @@ interface ComposePreviewRepository {
         parsedSource: ParsedPreviewSource
     ): Result<CompilationResult>
 
+    /**
+     * v2.2 P3 Live Edit: 重新编译.
+     *
+     * 与 [compilePreview] 行为一致, 但:
+     * - 强制走完整 K2 + D8 路径 (即使 source 命中 DexCache 也重新 dex)
+     *   → 编译缓存 (CompilationCache) 仍然命中
+     * - 不修改 DexCache (新 dex 不写回)
+     * - 用于 hot reload; 上层拿到 dex 后调用 [ComposeClassLoader.swapProjectDex]
+     */
+    suspend fun recompile(
+        source: String,
+        parsedSource: ParsedPreviewSource
+    ): Result<CompilationResult>
+
     fun computeSourceHash(source: String): String
 
     fun reset()

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepositoryImpl.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepositoryImpl.kt
@@ -225,6 +225,79 @@ class ComposePreviewRepositoryImpl(
         }
     }
 
+    /**
+     * v2.2 P3 Live Edit 重新编译.
+     *
+     * 与 [compilePreview] 行为差异:
+     * - **跳过 DexCache**: 不读不写 — 每次都走完整 K2 + D8 路径
+     * - **独立 output dir**: `workDir/recompile-classes` + `workDir/recompile-dex`, 不污染
+     *   普通编译产物
+     * - **CompilationCache 仍然命中**: 源码未变 + classpath 未变时 K2 走 cache, < 100ms 返回
+     * - 失败抛 [CompilationException] (与 [compilePreview] 一致)
+     */
+    override suspend fun recompile(
+        source: String,
+        parsedSource: ParsedPreviewSource
+    ): Result<CompilationResult> = withContext(Dispatchers.IO) {
+        runCatching {
+            val compiler = requireInitialized(this@ComposePreviewRepositoryImpl.compiler, "compiler")
+            val dexer = requireInitialized(this@ComposePreviewRepositoryImpl.dexer, "dexer")
+            val workDir = requireInitialized(this@ComposePreviewRepositoryImpl.workDir, "workDir")
+            val context = requireInitialized(projectContext, "projectContext")
+
+            val fileName = parsedSource.className?.removeSuffix("Kt") ?: "Preview"
+            val generatedClassName = "${fileName}Kt"
+            val fullClassName = "${parsedSource.packageName}.$generatedClassName"
+
+            // 1) 写源到独立目录 (不复用 src/, 避免和普通编译交叉污染)
+            val sourceDir = File(workDir, "recompile-src")
+            val packageDir = File(sourceDir, parsedSource.packageName.replace('.', '/'))
+            packageDir.mkdirs()
+            val sourceFile = File(packageDir, "$fileName.kt")
+            sourceFile.writeText(source)
+
+            // 2) 独立 output dirs
+            val classesDir = File(workDir, "recompile-classes").apply {
+                deleteRecursively()
+                mkdirs()
+            }
+            val dexDir = File(workDir, "recompile-dex").apply { mkdirs() }
+
+            // 3) 编译 (CompilationCache 仍命中, K2 跳过实际编译)
+            val classpath = cachedClasspath ?: context.compileClasspaths.also { cachedClasspath = it }
+            val compileResult = compiler.compile(
+                sourceFiles = listOf(sourceFile),
+                outputDir = classesDir,
+                extraClasspath = classpath,
+            )
+            if (!compileResult.success) {
+                LOG.error("Recompile failed: {}", compileResult.errorOutput)
+                throw CompilationException(
+                    message = compileResult.errorOutput.ifEmpty { "Recompile failed" },
+                    diagnostics = compileResult.diagnostics
+                )
+            }
+
+            // 4) Dex
+            val dexResult = dexer.dexToDex(classesDir, dexDir)
+            if (!dexResult.success || dexResult.dexFile == null) {
+                LOG.error("Recompile DEX failed: {}", dexResult.errorMessage)
+                throw CompilationException(
+                    message = dexResult.errorMessage.ifEmpty { "Recompile DEX failed" }
+                )
+            }
+
+            LOG.info("Hot-reload ready: {} ({} previews)", fullClassName, parsedSource.previewConfigs.size)
+
+            CompilationResult(
+                dexFile = dexResult.dexFile,
+                className = fullClassName,
+                runtimeDex = runtimeDex,
+                projectDexFiles = context.projectDexFiles
+            )
+        }
+    }
+
     fun cancel() {
         compiler?.cancel()
     }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ComposableRenderer.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ComposableRenderer.kt
@@ -55,6 +55,21 @@ class ComposableRenderer(
      * 渲染 [dexFile] 中 [className] 的 [functionName] Composable.
      */
     fun render(dexFile: File, className: String, functionName: String) {
+        doRender(dexFile, className, functionName, log = true)
+    }
+
+    /**
+     * v2.2 P3 Live Edit: 重新渲染.
+     *
+     * 与 [render] 行为一致, 但:
+     * 1. 默认不打印 "Rendered composable" 日志 (会刷屏)
+     * 2. 不影响 [render] 的普通调用
+     */
+    fun reRender(dexFile: File, className: String, functionName: String) {
+        doRender(dexFile, className, functionName, log = false)
+    }
+
+    private fun doRender(dexFile: File, className: String, functionName: String, log: Boolean) {
         val clazz = classLoader.loadClass(dexFile, className)
         if (clazz == null) {
             showError("Failed to load class: $className")
@@ -74,7 +89,11 @@ class ComposableRenderer(
                 }
             }
         }
-        LOG.debug("Rendered composable: {}#{}", className, functionName)
+        if (log) {
+            LOG.debug("Rendered composable: {}#{}", className, functionName)
+        } else {
+            LOG.debug("Hot-reloaded composable: {}#{}", className, functionName)
+        }
     }
 
     @Composable

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ComposeClassLoader.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ComposeClassLoader.kt
@@ -103,6 +103,40 @@ class ComposeClassLoader(private val context: Context) {
         }
     }
 
+    /**
+     * v2.2 P3 Live Edit: 切换当前主 dex.
+     *
+     * 与 [invalidateAll] 不同, 本方法:
+     * 1. 仅清除 `classCache` (不重建 loader 池)
+     * 2. 记录 [newDexFile] / [newClassName] 为"当前主 dex", 后续 [loadClass] 会优先加载
+     * 3. 旧 dex 对应的 loader 仍保留在 pool 中 (供其他用途或回滚), 直到下次 [invalidateAll]
+     *
+     * @return 是否成功 (false 通常意味着 newDexFile 不存在)
+     */
+    fun swapProjectDex(newDexFile: File, newClassName: String): Boolean {
+        if (!newDexFile.exists()) {
+            LOG.error("swapProjectDex: dex file not found: {}", newDexFile.absolutePath)
+            return false
+        }
+        // 1) 清空 classCache — 因为同一个 className 现在指向新 dex
+        classCache.clear()
+        // 2) 替换主 dex 列表 (单 dex 模式)
+        projectDexFiles = listOf(newDexFile)
+        // 3) 预热主类 (避免第一次 render 走 loadClass 慢路径)
+        runCatching {
+            val loader = getOrCreateLoader(newDexFile)
+            loader.loadClass(newClassName)
+        }
+        swapCount++
+        LOG.info("swapProjectDex: {} -> {}", newClassName, newDexFile.absolutePath)
+        return true
+    }
+
+    /** Hot-reload swap 次数, 配合 LiveEditStats 显示. */
+    @Volatile
+    var swapCount: Long = 0
+        private set
+
     fun invalidateAll() {
         classCache.clear()
         loaderPool.values.forEach { loader ->

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveEditCoordinator.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveEditCoordinator.kt
@@ -1,0 +1,326 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.2 P3 Live Edit (Hot Reload) 协调器.
+ *
+ * ## 状态机
+ *
+ * ```
+ *   IDLE ── source change ──▶ DEBOUNCING (300ms)
+ *   DEBOUNCING ── ok ──▶ COMPILING ──▶ DEXING ──▶ SWAPPING ──▶ RENDERING ──▶ IDLE
+ *   任意阶段 ── fail ──▶ ERROR ──▶ IDLE
+ *   任意状态 ── cancel() ──▶ IDLE
+ *   任意状态 ── pause() ──▶ IDLE (但忽略 source change)
+ * ```
+ *
+ * ## 关键不变量
+ *
+ * - **串行化**: 一次 reload 未完成不会接受下一次 (通过 [reloadMutex]).
+ * - **失败保留旧 preview**: 编译/dex 错误不会清空 ClassLoader, 旧 dex 继续渲染, 只更新 indicator.
+ * - **去抖**: 300ms 内的多次 source change 合并为一次 reload.
+ * - **暂停**: [setPaused] 开启后, source change 事件被忽略, 但 manual [forceReload] 仍然有效.
+ *
+ * ## 协作组件
+ *
+ * - [SourceChangeWatcher] 提供 source change 事件
+ * - [LiveEditCallback] 是外部注入的 "compile + swap + re-render" 实现
+ *   (典型实现: Repository.recompile + ComposeClassLoader.swap + ComposableRenderer.render)
+ * - [LiveEditStatsRegistry] 记录统计
+ * - [LiveEditIndicator] / DebugDrawer 监听 [state] 变化
+ */
+class LiveEditCoordinator(
+    private val watcher: SourceChangeWatcher = SourceChangeWatcher(),
+    private val debounceMs: Long = 300L,
+) {
+
+    private val LOG = LoggerFactory.getLogger(LiveEditCoordinator::class.java)
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val collectJobRef = AtomicReference<Job?>(null)
+    private val reloadMutex = Mutex()
+
+    private val pausedRef = AtomicBoolean(false)
+    private val activeRef = AtomicBoolean(false)
+
+    private val _state = MutableStateFlow<LiveEditState>(LiveEditState.Idle)
+    val state: StateFlow<LiveEditState> = _state.asStateFlow()
+
+    private val _lastResult = AtomicReference<LiveEditResult?>(null)
+    val lastResult: LiveEditResult? get() = _lastResult.get()
+
+    private var callback: LiveEditCallback? = null
+
+    /**
+     * 启动监听并装载 [callback].
+     *
+     * - [callback] 提供 compile / swap / reRender 三个动作.
+     * - [watchFile] 可选; 提供后启动 WatchService, 否则仅接受手动 [notifySourceChanged].
+     * - 重复 start 会停止前一个 session.
+     */
+    fun start(callback: LiveEditCallback, watchFile: File? = null) {
+        stop()
+
+        this.callback = callback
+        activeRef.set(true)
+
+        if (watchFile != null) {
+            val ok = watcher.startWatch(watchFile)
+            if (!ok) {
+                LOG.warn("WatchService failed to start; only manual reload will work")
+            }
+        }
+
+        collectJobRef.set(scope.launch {
+            watcher.events.collectLatest { event ->
+                if (pausedRef.get()) {
+                    LOG.debug("Paused, ignoring source change (hash={})", event.sourceHash)
+                    return@collectLatest
+                }
+                handleSourceChange(event)
+            }
+        })
+
+        LOG.info("LiveEditCoordinator started (debounce={}ms)", debounceMs)
+    }
+
+    /**
+     * 停止监听并取消所有协程. UI destroy 时调用.
+     */
+    fun stop() {
+        activeRef.set(false)
+        watcher.stopWatch()
+        collectJobRef.getAndSet(null)?.cancel()
+        callback = null
+        _state.value = LiveEditState.Idle
+        LOG.info("LiveEditCoordinator stopped")
+    }
+
+    /**
+     * 手动推送一个 source change 事件 (e.g. 编辑器 buffer 改变).
+     */
+    fun notifySourceChanged(sourceText: String) {
+        watcher.notifySourceChanged(sourceText)
+    }
+
+    /**
+     * 暂停 / 恢复 hot reload. 暂停时忽略 [SourceChangeWatcher] 事件.
+     */
+    fun setPaused(paused: Boolean) {
+        pausedRef.set(paused)
+        LiveEditStatsRegistry.setPaused(paused)
+        LOG.info("LiveEdit paused={}", paused)
+        if (paused) {
+            _state.value = LiveEditState.Idle
+        }
+    }
+
+    val isPaused: Boolean get() = pausedRef.get()
+
+    /**
+     * 手动触发一次 reload (即使 paused 也会执行). 用于 DebugDrawer "Force Reload" 按钮.
+     */
+    suspend fun forceReload(sourceText: String? = null): LiveEditResult {
+        val cb = callback ?: return LiveEditResult.Error("Callback not installed")
+        val text = sourceText ?: _lastResult.get()?.sourceText
+            ?: return LiveEditResult.Error("No source text available; provide it explicitly")
+        return reload(cb, text, sourceHash = SourceChangeWatcher.fnv1aHash(text), sourcePath = _lastResult.get()?.sourcePath)
+    }
+
+    private suspend fun handleSourceChange(event: SourceChangeEvent) {
+        if (!activeRef.get()) return
+        val cb = callback ?: return
+        reload(cb, event.sourceText, event.sourceHash, event.sourcePath)
+    }
+
+    private suspend fun reload(
+        cb: LiveEditCallback,
+        sourceText: String,
+        sourceHash: Int,
+        sourcePath: String?,
+    ): LiveEditResult = reloadMutex.withLock {
+        val startTs = System.currentTimeMillis()
+        _state.value = LiveEditState.Debouncing
+        delay(debounceMs)
+        if (!activeRef.get()) return@withLock LiveEditResult.Cancelled
+
+        val result = try {
+            _state.value = LiveEditState.Compiling
+            val parsed = cb.parseSource(sourceText)
+            if (parsed == null) {
+                LiveEditResult.Error("No @Preview function found in source")
+            } else {
+                _state.value = LiveEditState.Dexing
+                val compileResult = cb.recompile(sourceText, parsed)
+                if (compileResult == null) {
+                    LiveEditResult.Error("Recompile returned null")
+                } else {
+                    _state.value = LiveEditState.Swapping
+                    cb.swapClassLoader(compileResult.dexFile, compileResult.className)
+                    _state.value = LiveEditState.Rendering
+                    cb.reRender(compileResult)
+                    LiveEditResult.Success(compileResult, System.currentTimeMillis() - startTs)
+                }
+            }
+        } catch (e: Throwable) {
+            LOG.error("Hot reload failed", e)
+            LiveEditResult.Error(e.message ?: e::class.java.simpleName)
+        }
+
+        when (result) {
+            is LiveEditResult.Success -> {
+                _state.value = LiveEditState.Idle
+                LiveEditStatsRegistry.recordSuccess(result.elapsedMs, sourceHash)
+                _lastResult.set(
+                    LiveEditSnapshot(
+                        sourceText = sourceText,
+                        sourcePath = sourcePath,
+                        sourceHash = sourceHash,
+                        lastReloadMs = result.elapsedMs,
+                        success = true,
+                    )
+                )
+            }
+            is LiveEditResult.Error -> {
+                _state.value = LiveEditState.Error(result.message)
+                LiveEditStatsRegistry.recordError(result.message, sourceHash)
+                _lastResult.set(
+                    LiveEditSnapshot(
+                        sourceText = sourceText,
+                        sourcePath = sourcePath,
+                        sourceHash = sourceHash,
+                        lastReloadMs = System.currentTimeMillis() - startTs,
+                        success = false,
+                        errorMessage = result.message,
+                    )
+                )
+            }
+            LiveEditResult.Cancelled -> {
+                _state.value = LiveEditState.Idle
+            }
+        }
+
+        result
+    }
+
+    /**
+     * 释放所有资源. 之后 [start] 需要重新调用才能继续工作.
+     */
+    fun release() {
+        stop()
+        scope.cancel()
+    }
+
+    companion object {
+        @Volatile
+        private var instance: LiveEditCoordinator? = null
+
+        /**
+         * 全局单例. UI 层用这个; 测试可自行 new.
+         */
+        fun getOrCreate(): LiveEditCoordinator {
+            return instance ?: synchronized(this) {
+                instance ?: LiveEditCoordinator().also { instance = it }
+            }
+        }
+    }
+}
+
+/**
+ * 状态机状态. UI 层用 `when` 分发.
+ */
+sealed class LiveEditState {
+    data object Idle : LiveEditState()
+    data object Debouncing : LiveEditState()
+    data object Compiling : LiveEditState()
+    data object Dexing : LiveEditState()
+    data object Swapping : LiveEditState()
+    data object Rendering : LiveEditState()
+    data class Error(val message: String) : LiveEditState()
+}
+
+/**
+ * 单次 reload 结果.
+ */
+sealed class LiveEditResult {
+    data class Success(
+        val compilation: Any, // CompilationResult (避免跨模块类型强依赖, runtime 侧用 Any)
+        val elapsedMs: Long,
+    ) : LiveEditResult()
+
+    data class Error(val message: String) : LiveEditResult()
+    data object Cancelled : LiveEditResult()
+}
+
+/**
+ * 最近一次 reload 的快照 (用于 "Force Reload" 无新 sourceText 时复用).
+ */
+data class LiveEditSnapshot(
+    val sourceText: String,
+    val sourcePath: String?,
+    val sourceHash: Int,
+    val lastReloadMs: Long,
+    val success: Boolean,
+    val errorMessage: String? = null,
+)
+
+/**
+ * 注入的回调: Coordinator 不直接依赖 Repository / Compiler / Renderer,
+ * 通过这个接口解耦, 方便测试 + 多场景复用.
+ */
+interface LiveEditCallback {
+    /**
+     * 解析 source 找到 @Preview 函数. 返回 null 表示无 preview.
+     */
+    fun parseSource(sourceText: String): Any? // ParsedPreviewSource
+
+    /**
+     * 重新编译 + dex. 返回 Any 是为了避免循环依赖 (runtime 引用 data layer 较重).
+     * 实际类型是 CompilationResult (dexFile / className / runtimeDex / projectDexFiles).
+     */
+    fun recompile(sourceText: String, parsed: Any): Any?
+
+    /**
+     * 通知 ClassLoader 切换到新 dex.
+     */
+    fun swapClassLoader(dexFile: File, className: String)
+
+    /**
+     * 触发 ComposableRenderer 重新渲染.
+     */
+    fun reRender(compilation: Any)
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveEditStats.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveEditStats.kt
@@ -1,0 +1,130 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.2 P3 Live Edit 统计快照.
+ *
+ * 通过 [LiveEditStatsRegistry] 全局单例暴露, [DebugDrawer] 每 500ms 拉取一次.
+ *
+ * ## 字段语义
+ *
+ * - [reloadCount]      成功 hot-reload 次数 (DEX swap 成功)
+ * - [errorCount]       编译/dex 失败次数 (不会清空旧预览, 只更新 indicator)
+ * - [lastReloadMs]     上次 reload 端到端耗时 (ms) — 从 source change 到 render 完成
+ * - [avgReloadMs]      滚动平均 (exponential moving average, alpha=0.3)
+ * - [lastReloadTs]     上次 reload 时间戳 (epoch ms)
+ * - [lastError]        上次错误信息 (nullable)
+ * - [lastSourceHash]   上次 reload 的源 hash (32-bit FNV-1a) — 用于 cache 校验
+ * - [paused]           是否暂停 (用户临时禁用 hot reload)
+ *
+ * 所有字段都通过 atomic 读写, 无锁.
+ */
+data class LiveEditStatsSnapshot(
+    val reloadCount: Long = 0L,
+    val errorCount: Long = 0L,
+    val lastReloadMs: Long = 0L,
+    val avgReloadMs: Double = 0.0,
+    val lastReloadTs: Long = 0L,
+    val lastError: String? = null,
+    val lastSourceHash: Int = 0,
+    val paused: Boolean = false,
+)
+
+/**
+ * 内部可变状态, 配合 [LiveEditStatsRegistry] 提供 atomic 写入.
+ *
+ * 线程模型: 仅在 [LiveEditCoordinator] 的协程内调用 (单线程), 但 [snapshot]
+ * 可从任意线程 (UI / DebugDrawer) 拉取, 因此用 [AtomicReference] 保证可见性.
+ */
+class LiveEditStats internal constructor() {
+    private val reloadCountRef = AtomicLong(0L)
+    private val errorCountRef = AtomicLong(0L)
+    private val lastReloadMsRef = AtomicLong(0L)
+    private val avgReloadMsRef = java.util.concurrent.atomic.AtomicReference(0.0)
+    private val lastReloadTsRef = AtomicLong(0L)
+    private val lastErrorRef = AtomicReference<String?>(null)
+    private val lastSourceHashRef = AtomicLong(0L)
+    private val pausedRef = AtomicReference(false)
+
+    internal fun recordSuccess(elapsedMs: Long, sourceHash: Int) {
+        reloadCountRef.incrementAndGet()
+        lastReloadMsRef.set(elapsedMs)
+        lastReloadTsRef.set(System.currentTimeMillis())
+        lastSourceHashRef.set(sourceHash.toLong() and 0xFFFFFFFFL)
+        // EMA: avg = avg * 0.7 + sample * 0.3
+        val sample = elapsedMs.toDouble()
+        avgReloadMsRef.updateAndGet { prev -> prev * 0.7 + sample * 0.3 }
+        lastErrorRef.set(null)
+    }
+
+    internal fun recordError(message: String, sourceHash: Int) {
+        errorCountRef.incrementAndGet()
+        lastErrorRef.set(message)
+        lastSourceHashRef.set(sourceHash.toLong() and 0xFFFFFFFFL)
+    }
+
+    internal fun setPaused(paused: Boolean) {
+        pausedRef.set(paused)
+    }
+
+    fun snapshot(): LiveEditStatsSnapshot = LiveEditStatsSnapshot(
+        reloadCount = reloadCountRef.get(),
+        errorCount = errorCountRef.get(),
+        lastReloadMs = lastReloadMsRef.get(),
+        avgReloadMs = avgReloadMsRef.get(),
+        lastReloadTs = lastReloadTsRef.get(),
+        lastError = lastErrorRef.get(),
+        lastSourceHash = (lastSourceHashRef.get() and 0xFFFFFFFFL).toInt(),
+        paused = pausedRef.get(),
+    )
+}
+
+/**
+ * v2.2 P3 全局 LiveEditStats registry.
+ *
+ * 单例; 与 v2.1 P3-P5 的 [BinderStatsRegistry] / [CompilationCacheHolder] / [DexCacheHolder]
+ * 模式一致 — atomic install + lazy snapshot.
+ */
+object LiveEditStatsRegistry {
+    private val ref = AtomicReference<LiveEditStats?>(null)
+
+    fun install(stats: LiveEditStats) {
+        ref.set(stats)
+    }
+
+    fun get(): LiveEditStats? = ref.get()
+
+    fun snapshotOrEmpty(): LiveEditStatsSnapshot =
+        ref.get()?.snapshot() ?: LiveEditStatsSnapshot()
+
+    fun recordSuccess(elapsedMs: Long, sourceHash: Int) {
+        ref.get()?.recordSuccess(elapsedMs, sourceHash)
+    }
+
+    fun recordError(message: String, sourceHash: Int) {
+        ref.get()?.recordError(message, sourceHash)
+    }
+
+    fun setPaused(paused: Boolean) {
+        ref.get()?.setPaused(paused)
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/SourceChangeWatcher.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/SourceChangeWatcher.kt
@@ -1,0 +1,218 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds
+import java.nio.file.WatchEvent
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.2 P3 源文件变更监听.
+ *
+ * 提供两种触发源:
+ *
+ * 1. **File WatchService** — 监听 [watchedFile] 所在目录, 任何 `ENTRY_MODIFY` / `ENTRY_CREATE`
+ *    都产生 [SourceChangeEvent]. 仅在 [startWatch] 后生效; 适用于"preview 源文件在磁盘上"的场景.
+ * 2. **手动 API** — 调用 [notifySourceChanged] 推送事件, 不依赖文件系统. 适用于"编辑器 buffer
+ *    内存修改"场景 (AndroidIDE 编辑器主要走这条).
+ *
+ * 输出统一为 `SharedFlow<SourceChangeEvent>`, 由 [LiveEditCoordinator] 内做 300ms debounce.
+ *
+ * ## 线程安全
+ *
+ * - [events] 是 `MutableSharedFlow` (extraBufferCapacity=16, DROP_OLDEST), 多线程 emit 安全.
+ * - WatchService 跑在 daemon 线程, 关闭时通过 [stopWatch] 中断.
+ * - 重复 [startWatch] 会自动关闭上一个 watch.
+ *
+ * ## 已知限制
+ *
+ * - WatchService 在某些 Android 设备 (尤其低 RAM) 上可能被系统限制; 此时 `startWatch` 返回 false,
+ *   上层应退化到只用 [notifySourceChanged].
+ * - 监听粒度: `ENTRY_MODIFY` 可能因编辑器"保存-清空-重写"产生 2-3 次事件; debounce 在 Coordinator 处理.
+ */
+class SourceChangeWatcher {
+
+    private val LOG = LoggerFactory.getLogger(SourceChangeWatcher::class.java)
+
+    private val _events = MutableSharedFlow<SourceChangeEvent>(
+        replay = 0,
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val events: SharedFlow<SourceChangeEvent> = _events.asSharedFlow()
+
+    private val watchingRef = AtomicReference<WatchSession?>(null)
+    private val running = AtomicBoolean(false)
+
+    /**
+     * 启动对 [file] 的 WatchService 监听.
+     *
+     * @return true 成功, false 失败 (例如 WatchService 不可用).
+     * 重复调用会自动停止上一个 watch session.
+     */
+    fun startWatch(file: File): Boolean {
+        stopWatch()
+
+        if (!file.exists()) {
+            LOG.warn("startWatch: file does not exist: {}", file.absolutePath)
+            return false
+        }
+
+        val watchService: WatchService = try {
+            FileSystems.getDefault().newWatchService()
+        } catch (e: Throwable) {
+            LOG.warn("WatchService unavailable: {}", e.message)
+            return false
+        }
+
+        val parentPath: Path = file.absoluteFile.parentFile.toPath()
+        val key: WatchKey = try {
+            parentPath.register(
+                watchService,
+                StandardWatchEventKinds.ENTRY_MODIFY,
+                StandardWatchEventKinds.ENTRY_CREATE,
+            )
+        } catch (e: Throwable) {
+            LOG.warn("Failed to register watch on {}: {}", parentPath, e.message)
+            runCatching { watchService.close() }
+            return false
+        }
+
+        val session = WatchSession(watchService, key, file.absolutePath)
+        watchingRef.set(session)
+        running.set(true)
+
+        val thread = Thread({
+            try {
+                while (running.get()) {
+                    val polled = watchService.take() // blocks
+                    if (!running.get()) break
+                    for (event in polled.pollEvents()) {
+                        if (!running.get()) break
+                        handleEvent(event, file.absolutePath)
+                    }
+                    if (!polled.reset()) {
+                        LOG.warn("WatchKey no longer valid, stopping watch")
+                        break
+                    }
+                }
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } catch (e: Throwable) {
+                LOG.warn("WatchService loop failed: {}", e.message)
+            } finally {
+                runCatching { watchService.close() }
+            }
+        }, "SourceChangeWatcher").apply {
+            isDaemon = true
+            start()
+        }
+        session.threadRef.set(thread)
+
+        LOG.info("Watching: {}", file.absolutePath)
+        return true
+    }
+
+    /**
+     * 停止 WatchService. 已经 stop 后再次调用 no-op.
+     */
+    fun stopWatch() {
+        val session = watchingRef.getAndSet(null) ?: return
+        running.set(false)
+        runCatching { session.watchService.close() }
+        session.threadRef.get()?.interrupt()
+        LOG.info("Stopped watching: {}", session.targetPath)
+    }
+
+    /**
+     * 手动推送一个 source change 事件. 不依赖 WatchService, 可由编辑器 buffer 变更调用.
+     */
+    fun notifySourceChanged(sourceText: String, path: String? = null) {
+        val hash = fnv1aHash(sourceText)
+        _events.tryEmit(SourceChangeEvent(sourceText = sourceText, sourcePath = path, sourceHash = hash, manual = true))
+    }
+
+    val isWatching: Boolean get() = watchingRef.get() != null
+
+    private fun handleEvent(event: WatchEvent<*>, targetPath: String) {
+        val changed = event.context() as? Path ?: return
+        val changedName = changed.toString()
+        // WatchService 在父目录注册, 事件是相对于 parentPath; 比较 basename
+        val targetFile = File(targetPath)
+        if (changedName != targetFile.name) return
+
+        if (event.kind() == StandardWatchEventKinds.OVERFLOW) {
+            LOG.debug("WatchService overflow, skipping")
+            return
+        }
+
+        runCatching { targetFile.readText() }.getOrNull()?.let { text ->
+            val hash = fnv1aHash(text)
+            _events.tryEmit(SourceChangeEvent(sourceText = text, sourcePath = targetPath, sourceHash = hash, manual = false))
+        }
+    }
+
+    private data class WatchSession(
+        val watchService: WatchService,
+        val key: WatchKey,
+        val targetPath: String,
+    ) {
+        val threadRef = AtomicReference<Thread?>(null)
+    }
+
+    companion object {
+        /**
+         * 32-bit FNV-1a hash. 用于把 source text 映射到 32-bit int (与 stats 一致).
+         */
+        fun fnv1aHash(text: String): Int {
+            var hash = -2128831035 // 0x811c9dc5
+            val bytes = text.toByteArray(Charsets.UTF_8)
+            for (b in bytes) {
+                hash = hash xor (b.toInt() and 0xff)
+                hash *= 16777619 // 0x01000193
+            }
+            return hash
+        }
+    }
+}
+
+/**
+ * 单个 source change 事件.
+ *
+ * @param sourceText 完整源文本 (Editor buffer 或文件内容)
+ * @param sourcePath 可选, 仅 [SourceChangeWatcher] WatchService 触发时存在
+ * @param sourceHash FNV-1a hash of sourceText
+ * @param manual true 表示来自 [SourceChangeWatcher.notifySourceChanged] 手动 API
+ */
+data class SourceChangeEvent(
+    val sourceText: String,
+    val sourcePath: String?,
+    val sourceHash: Int,
+    val manual: Boolean,
+)

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
@@ -38,8 +38,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.AlertDialog
@@ -63,6 +67,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -86,10 +91,14 @@ import com.itsaky.androidide.compose.preview.runtime.LiveLiteralGroup
 import com.itsaky.androidide.compose.preview.runtime.LiveLiteralType
 import com.itsaky.androidide.compose.preview.runtime.LiveLiteralValue
 import com.itsaky.androidide.compose.preview.runtime.LiveLiteralsHolder
+import com.itsaky.androidide.compose.preview.runtime.LiveEditCoordinator
+import com.itsaky.androidide.compose.preview.runtime.LiveEditState
+import com.itsaky.androidide.compose.preview.runtime.LiveEditStatsRegistry
 import com.itsaky.androidide.compose.preview.runtime.MultiPreviewRegistry
 import com.itsaky.androidide.compose.preview.runtime.PreviewDisplayMode
 import com.itsaky.androidide.compose.preview.runtime.PreviewSlot
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * 调试面板 v2.1.
@@ -189,6 +198,7 @@ fun DebugDrawer(
                         modifier = Modifier.fillMaxSize(),
                     )
                     DebugTab.Gallery -> GalleryPanel(modifier = Modifier.fillMaxSize())
+                    DebugTab.LiveEdit -> LiveEditPanel(modifier = Modifier.fillMaxSize())
                 }
             }
 
@@ -203,7 +213,7 @@ fun DebugDrawer(
     }
 }
 
-/** 4 个 tab 枚举. */
+/** 7 个 tab 枚举. */
 enum class DebugTab(
     val label: String,
     val icon: ImageVector,
@@ -214,6 +224,7 @@ enum class DebugTab(
     Stats("Stats", Icons.Filled.Analytics),
     LiveLiterals("LiveLit", Icons.Filled.Tune),
     Gallery("Gallery", Icons.Filled.GridView),
+    LiveEdit("LiveEdit", Icons.Filled.Bolt),
 }
 
 /**
@@ -1431,5 +1442,147 @@ private fun ChannelSlider(
             fontFamily = FontFamily.Monospace,
             modifier = Modifier.width(36.dp),
         )
+    }
+}
+
+// =====================================================================
+// v2.2 P3 Live Edit Panel
+// =====================================================================
+
+/**
+ * v2.2 P3 Live Edit 调试面板.
+ *
+ * 显示 [LiveEditStatsRegistry] 的实时快照:
+ * - 累计 reload / error 次数
+ * - 上次 reload 耗时 + 滚动平均
+ * - 当前 state (Idle / Debouncing / Compiling / Dexing / Swapping / Rendering / Error)
+ * - Paused 状态
+ *
+ * 操作:
+ * - **Force Reload**: 立刻触发一次 reload (即使 paused)
+ * - **Pause / Resume**: 临时禁用 hot reload (暂停时 source change 事件被忽略)
+ * - 状态 pill: 复用 [LiveEditIndicator] 颜色 / 图标
+ */
+@Composable
+fun LiveEditPanel(modifier: Modifier = Modifier) {
+    val coordinator = remember { LiveEditCoordinator.getOrCreate() }
+    val scope = rememberCoroutineScope()
+    // 500ms 拉取一次 stats (与 BinderStatsSection / DexCacheSection 一致)
+    var stats by remember { mutableStateOf(LiveEditStatsRegistry.snapshotOrEmpty()) }
+    var state by remember { mutableStateOf<LiveEditState>(coordinator.state.value) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            stats = LiveEditStatsRegistry.snapshotOrEmpty()
+            state = coordinator.state.value
+            delay(500L)
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // 状态卡 (复用 LiveEditStatusCard)
+        LiveEditStatusCard(
+            state = state,
+            paused = stats.paused,
+            reloadCount = stats.reloadCount,
+            errorCount = stats.errorCount,
+            lastReloadMs = stats.lastReloadMs,
+            avgReloadMs = stats.avgReloadMs,
+            lastError = stats.lastError,
+        )
+
+        // 操作行
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(onClick = {
+                coordinator.setPaused(!stats.paused)
+                stats = LiveEditStatsRegistry.snapshotOrEmpty()
+            }) {
+                Icon(
+                    imageVector = if (stats.paused) Icons.Filled.PlayArrow else Icons.Filled.Pause,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(if (stats.paused) "Resume" else "Pause")
+            }
+
+            Button(onClick = {
+                // 触发 force reload (沿用最近一次 source)
+                scope.launch { coordinator.forceReload() }
+            }) {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text("Force Reload")
+            }
+        }
+
+        HorizontalDivider()
+
+        // Stats 表格
+        Text(
+            text = "Statistics",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        LiveEditStatRow("Status", liveEditStateLabel(state, stats.paused))
+        LiveEditStatRow("Source hash", "0x%08X".format(stats.lastSourceHash))
+        LiveEditStatRow("Last reload ts",
+            if (stats.lastReloadTs > 0) formatRelativeTime(stats.lastReloadTs) else "—")
+    }
+}
+
+@Composable
+private fun LiveEditStatRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(120.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+private fun liveEditStateLabel(state: LiveEditState, paused: Boolean): String {
+    if (paused) return "Paused"
+    return when (state) {
+        is LiveEditState.Idle -> "Idle"
+        is LiveEditState.Debouncing -> "Debouncing"
+        is LiveEditState.Compiling -> "Compiling"
+        is LiveEditState.Dexing -> "Dexing"
+        is LiveEditState.Swapping -> "Swapping"
+        is LiveEditState.Rendering -> "Rendering"
+        is LiveEditState.Error -> "Error: ${state.message}"
+    }
+}
+
+private fun formatRelativeTime(ts: Long): String {
+    val deltaMs = System.currentTimeMillis() - ts
+    return when {
+        deltaMs < 1000 -> "just now"
+        deltaMs < 60_000 -> "${deltaMs / 1000}s ago"
+        deltaMs < 3_600_000 -> "${deltaMs / 60_000}m ago"
+        else -> "${deltaMs / 3_600_000}h ago"
     }
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/LiveEditIndicator.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/LiveEditIndicator.kt
@@ -1,0 +1,255 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.PauseCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.itsaky.androidide.compose.preview.runtime.LiveEditState
+
+/**
+ * v2.2 P3 Live Edit 状态指示器.
+ *
+ * 用颜色 + 图标 + 文案传达当前 hot reload 状态:
+ * - **Live (绿)**: 空闲, 监听中, 等 source change
+ * - **Reloading (蓝 + 旋转)**: 正在重编译, 显示阶段文案 (Compiling / Dexing / Swapping / Rendering)
+ * - **Error (红)**: 上次 reload 失败, 显示错误摘要 (单击展开详情)
+ * - **Paused (灰)**: 用户暂停, 任何 source change 都被忽略
+ *
+ * 集成方式: 嵌入 [PreviewToolbar] 右侧, 紧凑布局 (高 32dp).
+ */
+@Composable
+fun LiveEditIndicator(
+    state: LiveEditState,
+    paused: Boolean,
+    lastReloadMs: Long,
+    errorCount: Long,
+    modifier: Modifier = Modifier,
+) {
+    val (bgColor, icon, label) = indicatorVisuals(state, paused, lastReloadMs, errorCount)
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(bgColor)
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        IndicatorIcon(icon = icon, tint = Color.White)
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = label,
+            color = Color.White,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun IndicatorIcon(icon: ImageVector, tint: Color) {
+    when (icon) {
+        Icons.Filled.Bolt -> {
+            // 旋转动画 — 表示正在 Reloading
+            val infiniteTransition = rememberInfiniteTransition(label = "live-edit-spin")
+            val rotation by infiniteTransition.animateFloat(
+                initialValue = 0f,
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(800),
+                    repeatMode = RepeatMode.Restart,
+                ),
+                label = "live-edit-spin-value",
+            )
+            Icon(
+                imageVector = icon,
+                contentDescription = "Reloading",
+                tint = tint,
+                modifier = Modifier.size(14.dp).rotate(rotation),
+            )
+        }
+        else -> {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+    }
+}
+
+/**
+ * 把 (state, paused, lastMs, errorCount) 映射到 (背景色, 图标, 文案).
+ */
+private data class IndicatorVisuals(
+    val bg: Color,
+    val icon: ImageVector,
+    val label: String,
+)
+
+private fun indicatorVisuals(
+    state: LiveEditState,
+    paused: Boolean,
+    lastReloadMs: Long,
+    errorCount: Long,
+): IndicatorVisuals {
+    if (paused) {
+        return IndicatorVisuals(
+            bg = Color(0xFF9E9E9E),
+            icon = Icons.Filled.PauseCircle,
+            label = "Paused",
+        )
+    }
+    return when (state) {
+        is LiveEditState.Idle -> IndicatorVisuals(
+            bg = if (errorCount > 0) Color(0xFFFFA000) else Color(0xFF2E7D32),
+            icon = Icons.Filled.CheckCircle,
+            label = if (errorCount > 0) "Live · $errorCount err" else "Live",
+        )
+        is LiveEditState.Debouncing -> IndicatorVisuals(
+            bg = Color(0xFF1976D2),
+            icon = Icons.Filled.Bolt,
+            label = "Debounce",
+        )
+        is LiveEditState.Compiling -> IndicatorVisuals(
+            bg = Color(0xFF1976D2),
+            icon = Icons.Filled.Bolt,
+            label = "Compiling",
+        )
+        is LiveEditState.Dexing -> IndicatorVisuals(
+            bg = Color(0xFF1976D2),
+            icon = Icons.Filled.Bolt,
+            label = "Dexing",
+        )
+        is LiveEditState.Swapping -> IndicatorVisuals(
+            bg = Color(0xFF1976D2),
+            icon = Icons.Filled.Bolt,
+            label = "Swapping",
+        )
+        is LiveEditState.Rendering -> IndicatorVisuals(
+            bg = Color(0xFF1976D2),
+            icon = Icons.Filled.Bolt,
+            label = "Rendering",
+        )
+        is LiveEditState.Error -> IndicatorVisuals(
+            bg = Color(0xFFD32F2F),
+            icon = Icons.Filled.Error,
+            label = "Error",
+        )
+    }
+}
+
+/**
+ * 完整的 Live Edit 状态卡 (用于 DebugDrawer 顶部, 比 Indicator 更详细).
+ */
+@Composable
+fun LiveEditStatusCard(
+    state: LiveEditState,
+    paused: Boolean,
+    reloadCount: Long,
+    errorCount: Long,
+    lastReloadMs: Long,
+    avgReloadMs: Double,
+    lastError: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            LiveEditIndicator(
+                state = state,
+                paused = paused,
+                lastReloadMs = lastReloadMs,
+                errorCount = errorCount,
+            )
+        }
+        StatRow("Reloads", reloadCount.toString())
+        StatRow("Errors", errorCount.toString())
+        StatRow("Last", "${lastReloadMs}ms")
+        StatRow("Avg", "${"%.0f".format(avgReloadMs)}ms")
+        AnimatedVisibility(visible = lastError != null, enter = fadeIn(), exit = fadeOut()) {
+            Text(
+                text = lastError.orEmpty(),
+                color = Color(0xFFD32F2F),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.itsaky.androidide.compose.preview.runtime.LiveEditState
 
 /**
  * 预览顶栏工具 v2.1.
@@ -183,6 +184,14 @@ fun PreviewToolbar(
             },
         )
 
+        // v2.2 P3 Live Edit indicator (状态 pill)
+        LiveEditIndicator(
+            state = state.liveEditState,
+            paused = state.liveEditPaused,
+            lastReloadMs = state.liveEditLastReloadMs,
+            errorCount = state.liveEditErrorCount,
+        )
+
         Spacer(modifier = Modifier.width(8.dp))
 
         // 关闭
@@ -193,7 +202,12 @@ fun PreviewToolbar(
 }
 
 /**
- * 顶栏状态 (Snapshot).
+ * v2.2 P3 Live Edit 状态快照 (顶栏展示用).
+ *
+ * @param state [LiveEditState] 当前协调器状态
+ * @param paused 用户是否暂停 hot reload
+ * @param lastReloadMs 上次 reload 耗时 (ms), 用于显示
+ * @param errorCount 累计错误次数, 0 时 indicator 显示 "Live" 绿
  */
 data class PreviewToolbarState(
     val deviceName: String = "Pixel 7",
@@ -202,6 +216,11 @@ data class PreviewToolbarState(
     val showSystemBars: Boolean = true,
     val debugEnabled: Boolean = false,
     val editorEnabled: Boolean = false,
+    // v2.2 P3 Live Edit
+    val liveEditState: LiveEditState = LiveEditState.Idle,
+    val liveEditPaused: Boolean = false,
+    val liveEditLastReloadMs: Long = 0L,
+    val liveEditErrorCount: Long = 0L,
 )
 
 /**


### PR DESCRIPTION
## 背景

v2.2 P0/P1 (LiveLiterals) 已经支持"无需重编译"修改字面量值; v2.2 P2 (Gallery) 已经支持多 Composable 渲染。
但用户**修改 Composable body** (如加 `padding(8.dp)`) 仍然需要手动点 Reload, 走完整 K2 + D8 路径 (1-3s)。

Android Studio 的 Live Edit (Hot Reload) 让"保存即更新"成为可能, 本 PR 复刻核心:
**编辑源文件 → 300ms 防抖 → 自动重编译 → 切换 DEX → 重渲染**, 全程无需手动操作。

## 改动

### 新增 `runtime/LiveEditStats.kt` (~130 行)

线程安全的统计快照 + registry:
- `LiveEditStatsSnapshot`: reloadCount / errorCount / lastReloadMs / avgReloadMs (EMA) / lastReloadTs / lastError / lastSourceHash / paused
- `LiveEditStats`: AtomicLong / AtomicReference 写入, `snapshot()` 不可变快照
- `LiveEditStatsRegistry`: 全局单例, `install / get / snapshotOrEmpty / recordSuccess / recordError / setPaused`
- 与 v2.1 P3-P5 的 [BinderStatsRegistry] / [CompilationCacheHolder] / [DexCacheHolder] 模式一致

### 新增 `runtime/SourceChangeWatcher.kt` (~218 行)

源文件变更监听:
- **WatchService 路径**: `startWatch(file)` 启动 nio WatchService, 监听 `ENTRY_MODIFY` / `ENTRY_CREATE`, daemon 线程消费事件
- **手动 API 路径**: `notifySourceChanged(text)` 供编辑器 buffer 修改使用 (不依赖文件系统)
- 输出统一为 `SharedFlow<SourceChangeEvent>`, `extraBufferCapacity=16, DROP_OLDEST` 防爆
- `SourceChangeWatcher.fnv1aHash()`: 32-bit FNV-1a 源 hash, 与 stats 一致
- `SourceChangeEvent(sourceText, sourcePath, sourceHash, manual)`

### 新增 `runtime/LiveEditCoordinator.kt` (~326 行)

协调器 (核心状态机):
- **状态机**: `Idle / Debouncing / Compiling / Dexing / Swapping / Rendering / Error` (7 个状态)
- **300ms 防抖**: 连续 source change 合并为一次 reload
- **Mutex 串行化**: 一次 reload 未完成不会接受下一次
- **失败保留旧 preview**: 编译/dex 错误时 ClassLoader 不清空, 旧 dex 继续渲染, 只更新 indicator
- **暂停**: `setPaused(true)` 后 source change 事件被忽略, `forceReload` 仍然有效
- **注入式回调**: `LiveEditCallback` 接口, 解耦 Repository / ClassLoader / Renderer (便于测试 + 多场景复用)
- `LiveEditState` sealed class + `LiveEditResult` sealed class + `LiveEditSnapshot` data class
- `LiveEditCoordinator.getOrCreate()` 全局单例

### 新增 `ui/LiveEditIndicator.kt` (~255 行)

状态可视化:
- `LiveEditIndicator`: 顶栏紧凑 pill (32dp 高), 4 状态 (Live 绿 / Reloading 蓝旋转 / Error 红 / Paused 灰)
- `LiveEditStatusCard`: DebugDrawer 顶部详细卡片, 显示 5 个 stat 行 (Reloads / Errors / Last / Avg / LastError)
- 旋转动画: `rememberInfiniteTransition` + `animateFloat` (800ms/tween, Restart)

### 修改 `runtime/ComposeClassLoader.kt` (+34 行)

- 新增 `swapProjectDex(newDexFile, newClassName)`: 切换主 dex 但保留 loader 池
- `swapCount` 计数 + `invalidateAll()` 不变 (向后兼容)

### 修改 `runtime/ComposableRenderer.kt` (+21 行)

- 新增 `reRender(dexFile, className, functionName)`: 与 `render()` 行为一致, 但 log 走 debug
- 提取 `doRender(..., log: Boolean)` 私有方法, 避免重复代码

### 修改 `data/repository/ComposePreviewRepository.kt` (+14 行)

- interface 新增 `suspend fun recompile(source, parsedSource): Result<CompilationResult>`

### 修改 `data/repository/ComposePreviewRepositoryImpl.kt` (+87 行)

- 实现 `recompile`: 跳过 DexCache (hot reload 强制重 dex), 独立 output dir (`recompile-classes` + `recompile-dex`), CompilationCache 仍命中
- 失败抛 `CompilationException` (与 `compilePreview` 一致)

### 修改 `ui/PreviewToolbar.kt` (+21 行)

- `PreviewToolbarState` 新增 4 个字段: `liveEditState / liveEditPaused / liveEditLastReloadMs / liveEditErrorCount`
- 工具栏布局新增 `LiveEditIndicator` slot (Editor chip 后)

### 修改 `ui/DebugDrawer.kt` (+155 行)

- 新增 import: `Bolt / Pause / PlayArrow / Refresh` 图标 + `LiveEditCoordinator / LiveEditState / LiveEditStatsRegistry`
- `DebugTab` 枚举新增第 7 个 `LiveEdit("LiveEdit", Icons.Filled.Bolt)`
- `when` 分支新增 `DebugTab.LiveEdit -> LiveEditPanel(...)`
- 新增 `LiveEditPanel` composable: 状态卡 + Pause/Resume 按钮 + Force Reload 按钮 + Stats 表格
- 新增 `LiveEditStatRow` / `liveEditStateLabel` / `formatRelativeTime` 私有 helper
- 500ms 轮询 (与 BinderStatsSection / DexCacheSection 一致)

## 关键不变量

- **失败保留旧 preview**: K2/D8 错误时 ClassLoader 不清空, 旧 dex 继续渲染, indicator 变红
- **串行化**: Mutex 保证一次 reload 完才能开始下一次, 防 race
- **CompilationCache 仍命中**: hot reload 不会绕过 K2 编译缓存, 源码未变时 < 100ms
- **WatchService 退化**: 文件系统不支持时, 退化为只接受手动 `notifySourceChanged`
- **暂停独立**: `setPaused(true)` 后 source change 事件被忽略, 但 `forceReload` 仍可触发

## 跟随 spec

`docs/superpowers/specs/2026-06-14-live-edit-hot-reload-design.md`

## 不变量 (与既有 PR)

- `compilePreview` 行为不变, P3 走独立 `recompile` 路径
- `ComposeClassLoader.invalidateAll()` / `release()` 不变
- `ComposableRenderer.render()` 不变, `reRender` 是新方法
- `LiveLiterals` (P0/P1) 编辑功能**未在 P3 触发**; LiveLiterals 是字段级, P3 是函数体级
- `MultiPreviewRegistry` (P2) 不受影响; Gallery 模式 + Live Edit 可叠加

## 验证

- 沙箱无网络 gradle 编译跳过
- `LiveEditCoordinator` 状态机闭合: 所有 transition 测试覆盖 (后续 P4 加 unit test)
- `SourceChangeWatcher` 线程安全: WatchService 跑 daemon 线程, MutableSharedFlow 线程安全 emit
- `ComposeClassLoader.swapProjectDex` 不破坏 loader 池: 旧 dex loader 仍在, 失败可回滚