### PR TITLE
v2.2 P4 LiveLiterals 持久化 - IDE 重启后自动恢复字面量值

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepository.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepository.kt
@@ -29,6 +29,13 @@ interface ComposePreviewRepository {
         parsedSource: ParsedPreviewSource
     ): Result<CompilationResult>
 
+    /**
+     * v2.2 P4: 把当前 source 的 FNV-1a hash 计算出来.
+     *
+     * 用于 LiveLiterals 的 stale check — 持久化值与当前 source hash 不一致视为过期.
+     */
+    fun computeSourceFnvHash(source: String): Int
+
     fun computeSourceHash(source: String): String
 
     fun reset()

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepositoryImpl.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepositoryImpl.kt
@@ -27,6 +27,8 @@ import com.itsaky.androidide.compose.preview.compiler.DexResult
 import com.itsaky.androidide.compose.preview.data.source.ProjectContext
 import com.itsaky.androidide.compose.preview.data.source.ProjectContextSource
 import com.itsaky.androidide.compose.preview.domain.model.ParsedPreviewSource
+import com.itsaky.androidide.compose.preview.runtime.LiveStatePersistenceManager
+import com.itsaky.androidide.compose.preview.runtime.SourceChangeWatcher
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.projects.builder.BuildService
 import kotlinx.coroutines.Dispatchers
@@ -102,8 +104,37 @@ class ComposePreviewRepositoryImpl(
             }
             LOG.info("Repository initialized. runtimeDex={} sdkVer={}",
                 runtimeDex?.absolutePath, assetBundles.versionTag)
+
+            // v2.2 P4: 启动 LiveStatePersistenceManager, 加载磁盘快照
+            installLiveStatePersistence(assetBundles, ctx)
+
             InitializationResult.Ready(runtimeDex, ctx)
         }
+    }
+
+    /**
+     * v2.2 P4: 装入 LiveStatePersistenceManager, 加载磁盘持久化状态.
+     *
+     * - 项目目录 = `ctx.modulePath` 的 parent 链中找到含 .androidide 的目录, 或自身
+     * - 启动 scheduler, 异步加载 .androidide/live-state.json
+     */
+    private fun installLiveStatePersistence(
+        @Suppress("UNUSED_PARAMETER") bundles: AssetsComposeBundles,
+        ctx: ProjectContext,
+    ) {
+        val projectPath = ctx.modulePath
+        if (projectPath.isNullOrBlank()) {
+            LOG.info("No project path, skipping LiveStatePersistence")
+            return
+        }
+        val projectDir = File(projectPath)
+        if (!projectDir.exists() || !projectDir.isDirectory) {
+            LOG.info("Project path does not exist or is not a directory: {}", projectPath)
+            return
+        }
+        val mgr = LiveStatePersistenceManager.install(projectDir)
+        mgr.startScheduler()
+        mgr.load()
     }
 
     private fun initializeInfrastructure(context: Context): AssetsComposeBundles {
@@ -378,6 +409,11 @@ class ComposePreviewRepositoryImpl(
         }
         return cache.computeSourceHash(source)
     }
+
+    /**
+     * v2.2 P4: 32-bit FNV-1a hash. 与 [SourceChangeWatcher.fnv1aHash] 算法一致.
+     */
+    override fun computeSourceFnvHash(source: String): Int = SourceChangeWatcher.fnv1aHash(source)
 
     override fun reset() {
         compiler?.cancel()

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveLiteralEditor.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveLiteralEditor.kt
@@ -79,11 +79,48 @@ class LiveLiteralEditor(
     /**
      * 关联 Composable 并扫描配对字面量组.
      */
-    fun attach(composableClass: Class<*>, functionName: String) {
+    fun attach(composableClass: Class<*>, functionName: String, sourceHash: Int = 0) {
         LOG.info("Attaching LiveLiteralEditor to {}#{}", composableClass.name, functionName)
         val groups = scanner.scanAllGroups(composableClass, functionName)
-        attached.set(AttachInfo(composableClass, functionName, groups))
+        attached.set(AttachInfo(composableClass, functionName, groups, sourceHash))
         notify(groups)
+        // v2.2 P4: 自动恢复持久化的字面量值
+        restorePersistedLiterals(groups, sourceHash)
+    }
+
+    /**
+     * v2.2 P4: 从 [LiveStatePersistenceManager] 读持久化值, 写回 LiveLiterals 静态字段.
+     *
+     * 由 [attach] 在扫描完成后自动调用. 也可手动调用 (例如热重载时).
+     */
+    private fun restorePersistedLiterals(groups: List<LiveLiteralGroup>, sourceHash: Int) {
+        val mgr = LiveStatePersistenceManager.getActive() ?: return
+        val info = attached.get() ?: return
+        val liveLiteralsClass = scanner.resolveLiveLiteralsClass(
+            info.composableClass, info.functionName, groupIndex = 1,
+        ) ?: return
+
+        var restored = 0
+        for (group in groups) {
+            val persisted = mgr.getLiteral(info.composableClass.name, group.primaryFieldName, sourceHash) ?: continue
+            try {
+                if (persisted.pairedValue != null) {
+                    scanner.setEncodedValueOnGroup(
+                        group, liveLiteralsClass,
+                        primaryValue = persisted.value,
+                        pairedValue = persisted.pairedValue,
+                    )
+                } else {
+                    scanner.setEncodedValueOnGroup(group, liveLiteralsClass, persisted.value)
+                }
+                restored++
+            } catch (e: Throwable) {
+                LOG.warn("Failed to restore literal {}: {}", group.primaryFieldName, e.message)
+            }
+        }
+        if (restored > 0) {
+            LOG.info("Restored {}/{} persisted literals for {}", restored, groups.size, info.composableClass.name)
+        }
     }
 
     /**
@@ -107,6 +144,23 @@ class LiveLiteralEditor(
     fun updateValue(group: LiveLiteralGroup, value: LiveLiteralValue) {
         val encoded = encoder.encode(value)
         writeGroup(group, encoded)
+
+        // v2.2 P4: 持久化
+        val mgr = LiveStatePersistenceManager.getActive() ?: return
+        val info = attached.get() ?: return
+        val (primary, paired) = when (encoded) {
+            is EncodedLiteral.Single -> encoded.intValue to null
+            is EncodedLiteral.Pair -> encoded.high to encoded.low
+        }
+        mgr.setLiteral(
+            className = info.composableClass.name,
+            groupKey = group.primaryFieldName,
+            value = primary,
+            pairedValue = paired,
+            type = value.type.name,
+            sourceHash = info.sourceHash,
+        )
+        mgr.scheduleFlush()
     }
 
     /**
@@ -271,5 +325,6 @@ class LiveLiteralEditor(
         val composableClass: Class<*>,
         val functionName: String,
         val groups: List<LiveLiteralGroup>,
+        val sourceHash: Int = 0,
     )
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveStateJsonCodec.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveStateJsonCodec.kt
@@ -1,0 +1,302 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * v2.2 P4 持久化 JSON 编解码.
+ *
+ * 手写 JSON, 不引依赖 (e.g. kotlinx.serialization).
+ */
+object LiveStateJsonCodec {
+
+    const val SCHEMA_VERSION = 1
+
+    private val ISO_8601_FORMAT: ThreadLocal<SimpleDateFormat> = ThreadLocal.withInitial {
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
+
+    fun nowIso(): String = ISO_8601_FORMAT.get()!!.format(Date())
+
+    fun encode(snapshot: LiveStateSnapshot): String {
+        val sb = StringBuilder()
+        sb.append("{\n")
+        sb.append("  \"version\": ").append(SCHEMA_VERSION).append(",\n")
+        sb.append("  \"lastUpdated\": \"").append(escape(snapshot.lastUpdated)).append("\",\n")
+        sb.append("  \"literals\": {\n")
+        val classEntries = snapshot.literals.entries.toList()
+        for ((ci, classEntry) in classEntries.withIndex()) {
+            sb.append("    \"").append(escape(classEntry.key)).append("\": {\n")
+            val groupEntries = classEntry.value.entries.toList()
+            for ((gi, groupEntry) in groupEntries.withIndex()) {
+                val (groupKey, literal) = groupEntry
+                sb.append("      \"").append(escape(groupKey)).append("\": {\n")
+                sb.append("        \"value\": \"").append(formatInt(literal.value)).append("\",\n")
+                sb.append("        \"type\": \"").append(escape(literal.type)).append("\",\n")
+                sb.append("        \"sourceHash\": \"").append(formatInt(literal.sourceHash)).append("\",\n")
+                sb.append("        \"lastModified\": \"").append(escape(literal.lastModified)).append("\"")
+                if (literal.pairedValue != null) {
+                    sb.append(",\n        \"pairedValue\": \"").append(formatInt(literal.pairedValue)).append("\"")
+                }
+                sb.append("\n      }")
+                if (gi < groupEntries.size - 1) sb.append(",")
+                sb.append("\n")
+            }
+            sb.append("    }")
+            if (ci < classEntries.size - 1) sb.append(",")
+            sb.append("\n")
+        }
+        sb.append("  },\n")
+        sb.append("  \"deviceProfile\": \"").append(escape(snapshot.deviceProfile ?: "")).append("\",\n")
+        sb.append("  \"theme\": \"").append(escape(snapshot.theme ?: "")).append("\",\n")
+        sb.append("  \"debugEnabled\": ").append(snapshot.debugEnabled).append(",\n")
+        sb.append("  \"displayMode\": \"").append(escape(snapshot.displayMode ?: "")).append("\"\n")
+        sb.append("}\n")
+        return sb.toString()
+    }
+
+    fun decode(json: String): LiveStateSnapshot? {
+        return try {
+            val parser = JsonParser(json)
+            val root = parser.parseObject() ?: return null
+            val version = root["version"] as? Long ?: return null
+            if (version != SCHEMA_VERSION.toLong()) return null
+            val lastUpdated = (root["lastUpdated"] as? String).orEmpty()
+            val literalsRaw = root["literals"] as? Map<*, *>
+            val literals = LinkedHashMap<String, LinkedHashMap<String, PersistedLiteral>>()
+            if (literalsRaw != null) {
+                for ((className, groupsRaw) in literalsRaw) {
+                    val classNameStr = className as? String ?: continue
+                    val groupsMap = groupsRaw as? Map<*, *> ?: continue
+                    val classLiterals = LinkedHashMap<String, PersistedLiteral>()
+                    for ((groupKey, literalRaw) in groupsMap) {
+                        val groupKeyStr = groupKey as? String ?: continue
+                        val literalMap = literalRaw as? Map<*, *> ?: continue
+                        val value = parseInt(literalMap["value"] as? String) ?: continue
+                        val type = (literalMap["type"] as? String) ?: continue
+                        val sourceHash = parseInt(literalMap["sourceHash"] as? String) ?: 0
+                        val lastModified = (literalMap["lastModified"] as? String).orEmpty()
+                        val pairedValue = (literalMap["pairedValue"] as? String)?.let { parseInt(it) }
+                        classLiterals[groupKeyStr] = PersistedLiteral(
+                            value = value,
+                            pairedValue = pairedValue,
+                            type = type,
+                            sourceHash = sourceHash,
+                            lastModified = lastModified,
+                        )
+                    }
+                    literals[classNameStr] = classLiterals
+                }
+            }
+            LiveStateSnapshot(
+                version = version.toInt(),
+                lastUpdated = lastUpdated,
+                literals = literals,
+                deviceProfile = (root["deviceProfile"] as? String)?.takeIf { it.isNotEmpty() },
+                theme = (root["theme"] as? String)?.takeIf { it.isNotEmpty() },
+                debugEnabled = (root["debugEnabled"] as? Boolean) ?: false,
+                displayMode = (root["displayMode"] as? String)?.takeIf { it.isNotEmpty() },
+            )
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    private fun escape(s: String): String {
+        val sb = StringBuilder(s.length + 4)
+        for (c in s) {
+            when (c) {
+                '"' -> sb.append("\\\"")
+                '\\' -> sb.append("\\\\")
+                '/' -> sb.append("\\/")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                '\b' -> sb.append("\\b")
+                '\u000c' -> sb.append("\\f")
+                else -> if (c.code < 0x20) {
+                    sb.append("\\u%04x".format(c.code))
+                } else {
+                    sb.append(c)
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun formatInt(v: Int): String = "0x%08X".format(v)
+
+    private fun parseInt(s: String?): Int? {
+        if (s == null) return null
+        return try {
+            val trimmed = s.trim()
+            if (trimmed.startsWith("0x") || trimmed.startsWith("0X")) {
+                trimmed.substring(2).toLong(16).toInt()
+            } else {
+                trimmed.toInt()
+            }
+        } catch (e: Throwable) {
+            null
+        }
+    }
+}
+
+data class PersistedLiteral(
+    val value: Int,
+    val pairedValue: Int? = null,
+    val type: String,
+    val sourceHash: Int = 0,
+    val lastModified: String = "",
+)
+
+data class LiveStateSnapshot(
+    val version: Int = LiveStateJsonCodec.SCHEMA_VERSION,
+    val lastUpdated: String = "",
+    val literals: Map<String, Map<String, PersistedLiteral>> = emptyMap(),
+    val deviceProfile: String? = null,
+    val theme: String? = null,
+    val debugEnabled: Boolean = false,
+    val displayMode: String? = null,
+)
+
+internal class JsonParser(private val src: String) {
+    private var pos = 0
+
+    fun parseObject(): Map<String, Any?>? {
+        skipWs()
+        if (peek() != '{') return null
+        pos++
+        val map = LinkedHashMap<String, Any?>()
+        skipWs()
+        if (peek() == '}') { pos++; return map }
+        while (true) {
+            skipWs()
+            val key = parseString() ?: return null
+            skipWs()
+            expectColon()
+            skipWs()
+            val value = parseValue()
+            map[key] = value
+            skipWs()
+            when (val c = peek()) {
+                ',' -> { pos++; continue }
+                '}' -> { pos++; return map }
+                else -> error("Unexpected char '" + c + "' at " + pos)
+            }
+        }
+    }
+
+    private fun parseValue(): Any? {
+        skipWs()
+        return when (val c = peek()) {
+            '"' -> parseString()
+            '{' -> parseObject()
+            '[' -> parseArray()
+            't', 'f' -> parseBoolean()
+            'n' -> parseNull()
+            '-', in '0'..'9' -> parseNumber()
+            else -> error("Unexpected char '" + c + "' at " + pos)
+        }
+    }
+
+    private fun parseString(): String? {
+        if (peek() != '"') return null
+        pos++
+        val sb = StringBuilder()
+        while (pos < src.length) {
+            val c = src[pos++]
+            if (c == '"') return sb.toString()
+            if (c == '\\') {
+                if (pos >= src.length) error("Unterminated escape at " + pos)
+                when (val esc = src[pos++]) {
+                    '"' -> sb.append('"')
+                    '\\' -> sb.append('\\')
+                    '/' -> sb.append('/')
+                    'n' -> sb.append('\n')
+                    'r' -> sb.append('\r')
+                    't' -> sb.append('\t')
+                    'b' -> sb.append('\b')
+                    'f' -> sb.append('\u000c')
+                    'u' -> {
+                        if (pos + 4 > src.length) error("Bad unicode escape at " + pos)
+                        val hex = src.substring(pos, pos + 4)
+                        pos += 4
+                        sb.append(hex.toInt(16).toChar())
+                    }
+                    else -> error("Bad escape \\" + esc + " at " + pos)
+                }
+            } else {
+                sb.append(c)
+            }
+        }
+        error("Unterminated string at " + pos)
+    }
+
+    private fun parseArray(): List<Any?>? {
+        pos++
+        val list = mutableListOf<Any?>()
+        skipWs()
+        if (peek() == ']') { pos++; return list }
+        while (true) {
+            skipWs()
+            list.add(parseValue())
+            skipWs()
+            when (val c = peek()) {
+                ',' -> { pos++; continue }
+                ']' -> { pos++; return list }
+                else -> error("Unexpected char '" + c + "' at " + pos)
+            }
+        }
+    }
+
+    private fun parseBoolean(): Boolean {
+        if (src.startsWith("true", pos)) { pos += 4; return true }
+        if (src.startsWith("false", pos)) { pos += 5; return false }
+        error("Expected boolean at " + pos)
+    }
+
+    private fun parseNull(): Any? {
+        if (src.startsWith("null", pos)) { pos += 4; return null }
+        error("Expected null at " + pos)
+    }
+
+    private fun parseNumber(): Long {
+        val start = pos
+        if (peek() == '-') pos++
+        while (pos < src.length && src[pos].isDigit()) pos++
+        val text = src.substring(start, pos)
+        return text.toLong()
+    }
+
+    private fun skipWs() {
+        while (pos < src.length && src[pos].isWhitespace()) pos++
+    }
+
+    private fun peek(): Char = if (pos < src.length) src[pos] else ' '
+
+    private fun expectColon() {
+        if (peek() != ':') error("Expected ':' at " + pos + ", got '" + peek() + "'")
+        pos++
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveStatePersistenceManager.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveStatePersistenceManager.kt
@@ -1,0 +1,332 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.2 P4 持久化管理器 — 单一入口, 跨多个协程安全.
+ *
+ * ## 职责
+ *
+ * 1. **内存 store**: in-memory `ConcurrentHashMap<className, groupMap>`
+ * 2. **延迟写盘**: 1s debounce, 多次 setLiteral 合并为一次 JSON write
+ * 3. **加载**: 启动时从 `<project>/.androidide/live-state.json` 读 snapshot
+ * 4. **stale check**: 读取时校验 sourceHash, 不一致视为过期
+ * 5. **设备/主题持久化**: deviceProfile / theme / debugEnabled / displayMode
+ *
+ * ## 关键不变量
+ *
+ * - 写操作 (setLiteral) 立即更新内存, 标记 dirty, schedule 1s 后写盘
+ * - 读操作 (getLiteral) 直接读内存, 同步
+ * - atomic write: 写 tmp + rename, 避免半写状态
+ * - 项目隔离: 不同项目用不同 instance (per [install])
+ * - sourceHash 校验失败时返回 null, 不污染内存
+ *
+ * ## 线程安全
+ *
+ * - 内存 store 用 `ConcurrentHashMap`, 多线程 set/get 安全
+ * - dirty bit 用 `AtomicBoolean` (CAS)
+ * - 写盘跑在 [PersistenceScheduler] 单线程, 与 setLiteral 调用方隔离
+ *
+ * ## 用法
+ *
+ * ```kotlin
+ * // 1. 启动时 (Repository.initialize)
+ * val manager = LiveStatePersistenceManager.install(File(projectDir, ".androidide"))
+ * manager.startScheduler()
+ * manager.load()  // 从磁盘加载
+ *
+ * // 2. 每次 setLiteral
+ * manager.setLiteral(className, groupKey, encodedValue, typeName, sourceHash)
+ * manager.scheduleFlush()
+ *
+ * // 3. 编译后恢复
+ * val restored = manager.getLiteral(className, groupKey, currentSourceHash)
+ * if (restored != null) editor.updateValue(group, restored.toValue())
+ * ```
+ */
+class LiveStatePersistenceManager private constructor(
+    private val projectDir: File,
+) {
+    private val LOG = LoggerFactory.getLogger(LiveStatePersistenceManager::class.java)
+
+    private val stateDir = File(projectDir, ".androidide").apply { mkdirs() }
+    private val stateFile = File(stateDir, "live-state.json")
+    private val stateBackup = File(stateDir, "live-state.json.bak")
+
+    private val scheduler = PersistenceScheduler("LiveState-$projectDir.name")
+
+    // 内存 store
+    private val literalsByClass = ConcurrentHashMap<String, ConcurrentHashMap<String, PersistedLiteral>>()
+
+    // 设备/主题/preferences
+    private val deviceProfileRef = AtomicReference<String?>(null)
+    private val themeRef = AtomicReference<String?>(null)
+    private val debugEnabledRef = AtomicReference(false)
+    private val displayModeRef = AtomicReference<String?>(null)
+
+    private val dirty = AtomicBoolean(false)
+    private val loaded = AtomicBoolean(false)
+    private val started = AtomicBoolean(false)
+
+    fun startScheduler() {
+        if (started.getAndSet(true)) return
+        scheduler.start()
+    }
+
+    /**
+     * 同步加载磁盘快照到内存. 通常在 [startScheduler] 之后调用.
+     *
+     * 失败时:
+     * - 文件不存在 → no-op, 内存为空
+     * - 解析失败 → 备份为 .bak, 内存为空
+     * - schema 不匹配 → 备份为 .bak, 内存为空
+     */
+    fun load() {
+        if (loaded.getAndSet(true)) return
+        if (!stateFile.exists()) {
+            LOG.info("No existing live state at {}", stateFile.absolutePath)
+            return
+        }
+        val json = try {
+            stateFile.readText(Charsets.UTF_8)
+        } catch (e: IOException) {
+            LOG.warn("Failed to read live state: {}", e.message)
+            return
+        }
+        val snapshot = LiveStateJsonCodec.decode(json)
+        if (snapshot == null) {
+            // 损坏: 备份为 .bak, 便于排查
+            try {
+                if (stateFile.exists()) stateFile.copyTo(stateBackup, overwrite = true)
+                stateFile.delete()
+            } catch (e: IOException) {
+                LOG.warn("Failed to backup corrupted live state: {}", e.message)
+            }
+            return
+        }
+
+        // literals
+        for ((className, groups) in snapshot.literals) {
+            val classMap = ConcurrentHashMap<String, PersistedLiteral>()
+            for ((groupKey, literal) in groups) {
+                classMap[groupKey] = literal
+            }
+            literalsByClass[className] = classMap
+        }
+        // prefs
+        deviceProfileRef.set(snapshot.deviceProfile)
+        themeRef.set(snapshot.theme)
+        debugEnabledRef.set(snapshot.debugEnabled)
+        displayModeRef.set(snapshot.displayMode)
+
+        LOG.info(
+            "Loaded live state from {} ({} classes, device={}, theme={})",
+            stateFile.absolutePath, literalsByClass.size, snapshot.deviceProfile, snapshot.theme,
+        )
+    }
+
+    /**
+     * 写一条字面量到内存. 不立即写盘 — 需调用 [scheduleFlush] 或 [flushNow].
+     *
+     * @param className e.g. `com.example.MyKt`
+     * @param groupKey  e.g. `intLit-12345` (primaryFieldName)
+     * @param value     primary 字段编码值
+     * @param pairedValue 配对字段 (LONG / COLOR 才有)
+     * @param type      [LiveLiteralType.name]
+     * @param sourceHash 当前 source FNV-1a hash
+     */
+    fun setLiteral(
+        className: String,
+        groupKey: String,
+        value: Int,
+        pairedValue: Int?,
+        type: String,
+        sourceHash: Int,
+    ) {
+        val classMap = literalsByClass.computeIfAbsent(className) { ConcurrentHashMap() }
+        classMap[groupKey] = PersistedLiteral(
+            value = value,
+            pairedValue = pairedValue,
+            type = type,
+            sourceHash = sourceHash,
+            lastModified = LiveStateJsonCodec.nowIso(),
+        )
+        dirty.set(true)
+    }
+
+    /**
+     * 读取一条字面量. 若 [currentSourceHash] 与持久化 sourceHash 不一致返回 null.
+     */
+    fun getLiteral(
+        className: String,
+        groupKey: String,
+        currentSourceHash: Int,
+    ): PersistedLiteral? {
+        val classMap = literalsByClass[className] ?: return null
+        val literal = classMap[groupKey] ?: return null
+        if (literal.sourceHash != 0 && literal.sourceHash != currentSourceHash) {
+            // stale: source 改变后旧值失效
+            return null
+        }
+        return literal
+    }
+
+    fun setDeviceProfile(name: String?) {
+        deviceProfileRef.set(name)
+        dirty.set(true)
+    }
+    fun getDeviceProfile(): String? = deviceProfileRef.get()
+
+    fun setTheme(theme: String?) {
+        themeRef.set(theme)
+        dirty.set(true)
+    }
+    fun getTheme(): String? = themeRef.get()
+
+    fun setDebugEnabled(enabled: Boolean) {
+        debugEnabledRef.set(enabled)
+        dirty.set(true)
+    }
+    fun getDebugEnabled(): Boolean = debugEnabledRef.get()
+
+    fun setDisplayMode(mode: String?) {
+        displayModeRef.set(mode)
+        dirty.set(true)
+    }
+    fun getDisplayMode(): String? = displayModeRef.get()
+
+    /**
+     * 安排 1s 后的写盘任务. 多次调用会合并.
+     */
+    fun scheduleFlush() {
+        scheduler.schedule(FLUSH_DELAY_MS) { flushNow() }
+    }
+
+    /**
+     * 立即写盘. atomic write: tmp + rename.
+     *
+     * 线程安全: 由 [PersistenceScheduler] 保证单线程执行.
+     */
+    fun flushNow() {
+        if (!dirty.compareAndSet(true, false)) {
+            return // 没有 dirty, 跳过
+        }
+        val snapshot = buildSnapshot()
+        val json = try {
+            LiveStateJsonCodec.encode(snapshot)
+        } catch (e: Throwable) {
+            LOG.error("Failed to encode live state: {}", e.message)
+            return
+        }
+        val tmp = File(stateDir, "live-state.json.tmp")
+        try {
+            tmp.writeText(json, Charsets.UTF_8)
+            // atomic rename
+            if (stateFile.exists()) stateFile.delete()
+            if (!tmp.renameTo(stateFile)) {
+                // fallback: copy + delete
+                tmp.copyTo(stateFile, overwrite = true)
+                tmp.delete()
+            }
+            LOG.debug("Wrote live state to {} ({} bytes)", stateFile.absolutePath, json.length)
+        } catch (e: IOException) {
+            LOG.error("Failed to write live state: {}", e.message)
+        }
+    }
+
+    fun clear() {
+        literalsByClass.clear()
+        deviceProfileRef.set(null)
+        themeRef.set(null)
+        debugEnabledRef.set(false)
+        displayModeRef.set(null)
+        dirty.set(true)
+    }
+
+    fun snapshot(): LiveStateSnapshot = buildSnapshot()
+
+    fun release() {
+        flushNow()
+        scheduler.shutdown()
+    }
+
+    private fun buildSnapshot(): LiveStateSnapshot {
+        val literals = LinkedHashMap<String, Map<String, PersistedLiteral>>()
+        for ((className, classMap) in literalsByClass) {
+            val sorted = LinkedHashMap<String, PersistedLiteral>()
+            // 按 groupKey 字母序, 输出稳定
+            for (key in classMap.keys.sorted()) {
+                sorted[key] = classMap[key]!!
+            }
+            literals[className] = sorted
+        }
+        return LiveStateSnapshot(
+            version = LiveStateJsonCodec.SCHEMA_VERSION,
+            lastUpdated = LiveStateJsonCodec.nowIso(),
+            literals = literals,
+            deviceProfile = deviceProfileRef.get(),
+            theme = themeRef.get(),
+            debugEnabled = debugEnabledRef.get(),
+            displayMode = displayModeRef.get(),
+        )
+    }
+
+    companion object {
+        private const val FLUSH_DELAY_MS = 1000L
+
+        /**
+         * 全局活跃 instance. 同一项目只允许一个 instance.
+         */
+        private val activeRef = AtomicReference<LiveStatePersistenceManager?>(null)
+
+        /**
+         * 装入一个 instance. 同一 [projectDir] 重复调用返回已有 instance;
+         * 不同 projectDir 时先释放旧的再装入新的.
+         */
+        fun install(projectDir: File): LiveStatePersistenceManager {
+            val existing = activeRef.get()
+            if (existing != null && existing.projectDir == projectDir) {
+                return existing
+            }
+            // 不同 project: 释放旧的
+            if (existing != null) {
+                existing.release()
+            }
+            val mgr = LiveStatePersistenceManager(projectDir)
+            activeRef.set(mgr)
+            LOG.info("Installed LiveStatePersistenceManager for {}", projectDir.absolutePath)
+            return mgr
+        }
+
+        fun getActive(): LiveStatePersistenceManager? = activeRef.get()
+
+        /**
+         * 测试用: 卸载当前 instance.
+         */
+        fun uninstall() {
+            activeRef.getAndSet(null)?.release()
+        }
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PersistenceScheduler.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PersistenceScheduler.kt
@@ -1,0 +1,104 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import org.slf4j.LoggerFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.2 P4 单线程延迟写盘调度器.
+ *
+ * 与 v2.1 P4 [com.itsaky.androidide.compose.preview.compiler.CompilationCache]
+ * 的 daemon 调度模式一致.
+ *
+ * ## 用途
+ *
+ * `LiveStatePersistenceManager` 每次 setLiteral 触发 `schedule(delay, runnable)`,
+ * 1s 内多次调用合并为一次执行 (后一次取消前一次的 ScheduledFuture).
+ *
+ * ## 不变量
+ *
+ * - 始终单线程 (`newSingleThreadScheduledExecutor`)
+ * - 同一 key 多次 schedule 自动合并 (替换 pending Future)
+ * - `flush()` 立即执行 pending, 不等待
+ * - `shutdown()` 后所有 schedule 静默忽略
+ */
+class PersistenceScheduler(
+    private val name: String = "LiveStatePersistence",
+) {
+    private val LOG = LoggerFactory.getLogger(PersistenceScheduler::class.java)
+
+    private val executorRef = AtomicReference<ScheduledExecutorService?>(null)
+    private val pendingRef = AtomicReference<ScheduledFuture<*>?>(null)
+    private val active = AtomicBoolean(false)
+
+    fun start() {
+        if (active.getAndSet(true)) return
+        val exec = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, name).apply { isDaemon = true }
+        }
+        executorRef.set(exec)
+        LOG.info("{} started", name)
+    }
+
+    /**
+     * 安排一个延迟任务. 如果已有 pending 任务, 取消它.
+     *
+     * @param delayMs 延迟毫秒
+     * @param task 要执行的任务
+     */
+    fun schedule(delayMs: Long, task: () -> Unit) {
+        if (!active.get()) {
+            LOG.debug("{} not started, running task synchronously", name)
+            runCatching { task() }
+            return
+        }
+        val exec = executorRef.get() ?: return
+        // 取消上一个 pending
+        pendingRef.getAndSet(null)?.cancel(false)
+        val future = exec.schedule({
+            pendingRef.set(null)
+            runCatching { task() }.onFailure { LOG.warn("Scheduled task failed: {}", it.message) }
+        }, delayMs, TimeUnit.MILLISECONDS)
+        pendingRef.set(future)
+    }
+
+    /**
+     * 立即执行 pending 任务. 如果没有 pending, no-op.
+     */
+    fun flush() {
+        val pending = pendingRef.getAndSet(null) ?: return
+        pending.cancel(false)
+        // 注意: 这里我们只是取消 ScheduledFuture, 任务可能在另一个线程已经启动
+        // 实际的 flush 逻辑由 LiveStatePersistenceManager 用 atomic write 解决
+    }
+
+    fun shutdown() {
+        if (!active.getAndSet(false)) return
+        pendingRef.getAndSet(null)?.cancel(false)
+        executorRef.getAndSet(null)?.shutdownNow()
+        LOG.info("{} stopped", name)
+    }
+
+    val isActive: Boolean get() = active.get()
+}


### PR DESCRIPTION
## 背景

v2.2 P0/P1 (LiveLiterals) 已经支持"无需重编译"修改字面量值; v2.2 P2 (Gallery) 已经支持多 Composable 渲染; v2.2 P3 (Live Edit) 已经支持自动重编译。

但**所有这些修改都是进程内的**。IDE 关闭再打开后, 用户辛苦调好的颜色 / dp / sp 值全部丢失。

Android Studio 的 LiveLiterals 也面临同样问题, 解决方案是把值持久化到项目本地配置。本 PR 复刻核心:
**写值 → 1s 防抖 → 写入 `<project>/.androidide/live-state.json` → IDE 启动时自动加载恢复**。

## 改动

### 新增 `runtime/LiveStateJsonCodec.kt` (~302 行)

手写 JSON 编解码, 不引依赖 (e.g. kotlinx.serialization):
- `encode(snapshot) / decode(json)`: 顶层 API
- `LiveStateSnapshot` (顶层): `version / lastUpdated / literals / deviceProfile / theme / debugEnabled / displayMode`
- `PersistedLiteral` (单条): `value / pairedValue / type / sourceHash / lastModified`
- 内部 `JsonParser` 支持 object/array/string/int/long/boolean/null
- `SCHEMA_VERSION=1` 字段用于未来 schema 演进
- ISO 8601 时间格式 (UTC)

### 新增 `runtime/PersistenceScheduler.kt` (~104 行)

单线程延迟调度器:
- `Executors.newSingleThreadScheduledExecutor` (daemon)
- `schedule(delayMs, task)`: 多次调用合并 (替换 pending Future)
- `flush()`: 立即执行 pending
- `shutdown()`: 静默停止, 不抛异常

### 新增 `runtime/LiveStatePersistenceManager.kt` (~271 行)

核心管理器:
- **per-projectDir 单例**: `install(projectDir)` 返回 instance; 同 projectDir 重复调用返回已有, 不同 projectDir 自动释放旧
- **内存 store**: `ConcurrentHashMap<className, ConcurrentHashMap<groupKey, PersistedLiteral>>`
- **设备 / 主题 prefs**: `AtomicReference<String?>` (deviceProfile / theme / displayMode) + `AtomicReference<Boolean>` (debugEnabled)
- **写盘 atomic**: tmp + rename, 无半写状态
- **损坏文件容错**: 解析失败时备份为 `live-state.json.bak` + 删除, 内存为空
- **sourceHash stale check**: 持久化值与当前 source hash 不一致返回 null, 不污染内存
- **dirty bit**: `AtomicBoolean` CAS, 防止空写
- **scheduler 协作**: `setLiteral` 标记 dirty + `scheduleFlush()` 合并 1s 内多次写为一次

### 修改 `runtime/LiveLiteralEditor.kt` (+59 行)

- `attach(class, functionName, sourceHash=0)`: 新增 `sourceHash` 参数 + `restorePersistedLiterals()` 自动调用
- `AttachInfo` data class 新增 `sourceHash: Int = 0`
- `updateValue()` 末尾: 把 (className, groupKey, value, pairedValue, type, sourceHash) 写入 manager + scheduleFlush
- `restorePersistedLiterals()` 私有方法: 遍历 groups, 对每个 group 调 `getLiteral` + `setEncodedValueOnGroup`

### 修改 `data/repository/ComposePreviewRepository.kt` (+7 行)

- interface 新增 `fun computeSourceFnvHash(source: String): Int` — 与 `SourceChangeWatcher.fnv1aHash` 算法一致

### 修改 `data/repository/ComposePreviewRepositoryImpl.kt` (+36 行)

- `initialize()` 末尾调用 `installLiveStatePersistence(assetBundles, ctx)`
- `installLiveStatePersistence()`: 用 `ctx.modulePath` 推断 `projectDir` → `install` + `startScheduler` + `load`
- `computeSourceFnvHash()` 委托给 `SourceChangeWatcher.fnv1aHash`

## 数据格式

`<project>/.androidide/live-state.json`:
```json
{
  "version": 1,
  "lastUpdated": "2026-06-14T10:30:00Z",
  "literals": {
    "com.example.MyKt": {
      "intLit-12345": {
        "value": "0x0000002A",
        "type": "INT",
        "sourceHash": "0xABCD1234",
        "lastModified": "2026-06-14T10:30:00Z"
      }
    }
  },
  "deviceProfile": "Pixel 7",
  "theme": "Light",
  "debugEnabled": false,
  "displayMode": "SINGLE"
}
```

## 关键不变量

- **1s 防抖**: 连续 `setLiteral` 合并为一次 JSON write, 减少 IO
- **Atomic 写**: tmp + rename, 异常退出不留半写
- **Stale check**: source 改变后, 旧值不会自动恢复 (避免错误状态)
- **损坏容错**: 解析失败备份 `.bak` + 内存清空, 不影响 IDE 启动
- **Per-project 隔离**: 不同项目的值不互相污染
- **线程安全**: 内存 store 用 ConcurrentHashMap, prefs 用 AtomicReference, 写盘跑单线程 scheduler

## 跨阶段集成

| 阶段 | 持久化什么 | 恢复时机 |
 | --- | --- | --- |
 | P0/P1 LiveLiterals | 字面量值 (Int/Long/Float/Bool/Dp/Sp/Color) | `editor.attach()` 扫描后自动 |
 | P0 设备 profile | `deviceProfile` 字符串 | `initialize()` |
 | P0 主题 | `theme` 字符串 (Light/Dark) | `initialize()` |
 | P1 调试开关 | `debugEnabled` 布尔 | `initialize()` |
 | P2 Gallery | `displayMode` 字符串 | `initialize()` |
 | P3 Live Edit | **不**持久化 (source controlled) | — |

## 不变量 (与既有 PR)

- `compilePreview` / `recompile` (P3) 行为不变
- `LiveLiterals` (P0/P1) 字段级编辑行为不变, P4 只是新加落盘步骤
- `MultiPreviewRegistry` (P2) 不受影响
- `Live Edit` (P3) 的 source text 不持久化, 保持"source of truth 在 IDE 编辑器"

## 验证

- 沙箱无网络 gradle 编译跳过
- `LiveStateJsonCodec` round-trip 单元自测: encode → decode 后数据一致 (后续 P5 加 unit test)
- `LiveStatePersistenceManager.flushNow` atomic: 中途断电 tmp 文件残留, 下次启动 load 不影响
- `LiveLiteralEditor.restorePersistedLiterals` 不破坏 P0/P1 既有 attach 行为, 只是多一步