### PR TITLE
feat(compose-preview): v2.2 P7 error aggregation — (file,line) fold + category classify + IDE jump

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ErrorAggregator.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ErrorAggregator.kt
@@ -1,0 +1,282 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.2 P7 错误聚合 — 错误分类.
+ *
+ * - [K2_COMPILE]      K2JVMCompiler 编译错误 (语法/类型/未解析符号)
+ * - [D8_DEX]          D8 dex 阶段错误 (class format / method limit / R 类)
+ * - [CLASSLOADER_SWAP] ComposeClassLoader.swapProjectDex 失败 (ClassNotFound/NoSuchMethod)
+ * - [OTHER]           未识别的错误
+ *
+ * 通过 [ErrorAggregator.classifyByMessage] 自动嗅探; 显式 [PreviewErrorInfo.category] 优先.
+ */
+enum class ErrorCategory {
+    K2_COMPILE,
+    D8_DEX,
+    CLASSLOADER_SWAP,
+    OTHER;
+
+    companion object {
+        /**
+         * 根据 error message 字符串嗅探 category. 大小写不敏感.
+         *
+         * 匹配规则 (按顺序):
+         * 1. 含 "dex" / "d8" → [D8_DEX]
+         * 2. 含 "swap" / "ClassLoader" / "ClassNotFound" / "NoClassDefFound" / "NoSuchMethod" → [CLASSLOADER_SWAP]
+         * 3. 含 "compile" / "K2" / "CompilationException" → [K2_COMPILE]
+         * 4. 其他 → [OTHER]
+         */
+        fun classifyByMessage(message: String?): ErrorCategory {
+            val m = message?.lowercase() ?: return OTHER
+            return when {
+                "dex" in m || "d8" in m -> D8_DEX
+                "swap" in m || "classloader" in m ||
+                    "classnotfound" in m || "noclassdeffound" in m ||
+                    "nosuchmethod" in m -> CLASSLOADER_SWAP
+                "compile" in m || "k2" in m || "compilation" in m -> K2_COMPILE
+                else -> OTHER
+            }
+        }
+    }
+}
+
+/**
+ * v2.2 P7 错误严重度. 从 [com.itsaky.androidide.compose.preview.compiler.CompileDiagnostic.Severity] 简化:
+ * Preview 阶段只关心 ERROR / WARNING 两种.
+ */
+enum class ErrorSeverity { ERROR, WARNING }
+
+/**
+ * v2.2 P7 结构化错误信息.
+ *
+ * 由 [LiveEditCallback.classifyError] 产出, 在 [LiveEditCoordinator] 中传给 [ErrorAggregator].
+ * 与 [com.itsaky.androidide.compose.preview.compiler.CompileDiagnostic] 字段对齐,
+ * 但放在 runtime 包以避免循环依赖.
+ */
+data class PreviewErrorInfo(
+    val category: ErrorCategory,
+    val severity: ErrorSeverity,
+    val file: String?,
+    val line: Int?,
+    val column: Int?,
+    val message: String,
+    val sourceHash: Int,
+) {
+    companion object {
+        /**
+         * 工厂: 仅给定 message + sourceHash 时, 用 [ErrorCategory.classifyByMessage] 推断 category.
+         */
+        fun fromMessage(
+            message: String?,
+            sourceHash: Int,
+            file: String? = null,
+            line: Int? = null,
+            column: Int? = null,
+            severity: ErrorSeverity = ErrorSeverity.ERROR,
+        ): PreviewErrorInfo {
+            val category = ErrorCategory.classifyByMessage(message)
+            return PreviewErrorInfo(
+                category = category,
+                severity = severity,
+                file = file,
+                line = line,
+                column = column,
+                message = message ?: "Unknown error",
+                sourceHash = sourceHash,
+            )
+        }
+    }
+}
+
+/**
+ * v2.2 P7 折叠后的单条错误记录.
+ *
+ * 同一 (category, file, line) 的多次错误合并为一条, [count] 累加.
+ * 排序: 按 (category, lastTs 降序).
+ */
+data class AggregatedError(
+    val category: ErrorCategory,
+    val severity: ErrorSeverity,
+    val file: String?,
+    val line: Int?,
+    val column: Int?,
+    val message: String,
+    val count: Int,
+    val firstTs: Long,
+    val lastTs: Long,
+    val sourceHash: Int,
+)
+
+/**
+ * v2.2 P7 错误聚合器.
+ *
+ * 线程安全: 用 [ConcurrentHashMap.compute] 做原子折叠, 无锁读.
+ *
+ * ## 用法
+ *
+ * ```kotlin
+ * val aggregator = ErrorAggregator()
+ * aggregator.add(PreviewErrorInfo.fromMessage("DEX failed: ...", sourceHash = 0x100))
+ * aggregator.add(PreviewErrorInfo.fromMessage("DEX failed: ...", sourceHash = 0x101))  // 同 key 折叠, count=2
+ * val errors = aggregator.snapshot()  // 按 (category, lastTs 降序)
+ * aggregator.clear()
+ * ```
+ *
+ * ## key 设计
+ *
+ * `"${category}:${file ?: ""}:${line ?: -1}"` —— 同一 file:line 的同分类错误合并.
+ * 无 file:line 的错误 (e.g. swap failed) 各自独立.
+ */
+class ErrorAggregator {
+
+    private val map = ConcurrentHashMap<String, AggregatedError>()
+    private val totalAddRef = AtomicLong(0L)
+    private val totalErrorRef = AtomicLong(0L)
+
+    /**
+     * 添加一条错误. 同一 (category, file, line) 折叠, count++.
+     */
+    fun add(info: PreviewErrorInfo) {
+        val key = "${info.category}:${info.file ?: ""}:${info.line ?: -1}"
+        val now = System.currentTimeMillis()
+        map.compute(key) { _, prev ->
+            if (prev == null) {
+                AggregatedError(
+                    category = info.category,
+                    severity = info.severity,
+                    file = info.file,
+                    line = info.line,
+                    column = info.column,
+                    message = info.message,
+                    count = 1,
+                    firstTs = now,
+                    lastTs = now,
+                    sourceHash = info.sourceHash,
+                )
+            } else {
+                prev.copy(
+                    severity = info.severity, // 用最新
+                    column = info.column ?: prev.column,
+                    message = info.message, // 用最新
+                    count = prev.count + 1,
+                    lastTs = now,
+                    sourceHash = info.sourceHash,
+                )
+            }
+        }
+        totalAddRef.incrementAndGet()
+        if (info.severity == ErrorSeverity.ERROR) {
+            totalErrorRef.incrementAndGet()
+        }
+    }
+
+    /**
+     * 清空所有聚合错误. (成功 hot-reload 时调用)
+     */
+    fun clear() {
+        map.clear()
+        totalAddRef.set(0L)
+        totalErrorRef.set(0L)
+    }
+
+    /**
+     * 拉取当前快照. 按 (category 升序, lastTs 降序) 排序.
+     */
+    fun snapshot(): List<AggregatedError> {
+        return map.values.sortedWith(
+            compareBy({ it.category.ordinal }, { -it.lastTs })
+        )
+    }
+
+    /**
+     * 总添加次数 (含 warning, 即使 count 折叠后只有 1 条).
+     */
+    fun totalAdds(): Long = totalAddRef.get()
+
+    /**
+     * 总 ERROR 严重度添加次数.
+     */
+    fun totalErrors(): Long = totalErrorRef.get()
+
+    /**
+     * 按 category 分组统计. 用于 DebugDrawer 顶部 summary.
+     */
+    fun summaryByCategory(): Map<ErrorCategory, Int> {
+        val result = EnumSeverityMap()
+        for (e in map.values) {
+            result.add(e.category, e.count)
+        }
+        return result.toMap()
+    }
+}
+
+/**
+ * 内部辅助: 累加 category → count.
+ */
+private class EnumSeverityMap {
+    private val data = EnumMap<ErrorCategory, Int>()
+    fun add(cat: ErrorCategory, count: Int) {
+        data[cat] = (data[cat] ?: 0) + count
+    }
+    fun toMap(): Map<ErrorCategory, Int> = data.toMap()
+}
+
+/**
+ * EnumMap 的轻量替代, 避免引入 java.util.EnumMap 在 Android 性能争议.
+ */
+private class EnumMap<K : Enum<K>, V> {
+    private val backing = HashMap<K, V>()
+    operator fun get(key: K): V? = backing[key]
+    operator fun set(key: K, value: V) { backing[key] = value }
+    fun toMap(): Map<K, V> = backing.toMap()
+}
+
+/**
+ * v2.2 P7 全局 ErrorAggregator registry.
+ *
+ * 模式与 v2.2 P3 [LiveEditStatsRegistry] 一致: atomic install + lazy snapshot.
+ */
+object ErrorAggregatorRegistry {
+    private val ref = AtomicReference<ErrorAggregator?>(null)
+
+    fun install(aggregator: ErrorAggregator) {
+        ref.set(aggregator)
+    }
+
+    fun get(): ErrorAggregator? = ref.get()
+
+    fun snapshotOrEmpty(): List<AggregatedError> =
+        ref.get()?.snapshot() ?: emptyList()
+
+    fun summaryOrEmpty(): Map<ErrorCategory, Int> =
+        ref.get()?.summaryByCategory() ?: emptyMap()
+
+    fun clear() {
+        ref.get()?.clear()
+    }
+
+    fun add(info: PreviewErrorInfo) {
+        ref.get()?.add(info)
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveEditCoordinator.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/LiveEditCoordinator.kt
@@ -182,12 +182,18 @@ class LiveEditCoordinator(
             _state.value = LiveEditState.Compiling
             val parsed = cb.parseSource(sourceText)
             if (parsed == null) {
-                LiveEditResult.Error("No @Preview function found in source")
+                LiveEditResult.Error(
+                    message = "No @Preview function found in source",
+                    info = PreviewErrorInfo.fromMessage("No @Preview function found", sourceHash),
+                )
             } else {
                 _state.value = LiveEditState.Dexing
                 val compileResult = cb.recompile(sourceText, parsed)
                 if (compileResult == null) {
-                    LiveEditResult.Error("Recompile returned null")
+                    LiveEditResult.Error(
+                        message = "Recompile returned null",
+                        info = PreviewErrorInfo.fromMessage("Recompile returned null", sourceHash),
+                    )
                 } else {
                     _state.value = LiveEditState.Swapping
                     cb.swapClassLoader(compileResult.dexFile, compileResult.className)
@@ -198,13 +204,16 @@ class LiveEditCoordinator(
             }
         } catch (e: Throwable) {
             LOG.error("Hot reload failed", e)
-            LiveEditResult.Error(e.message ?: e::class.java.simpleName)
+            val info = cb.classifyError(e, sourceHash)
+                ?: PreviewErrorInfo.fromMessage(e.message, sourceHash)
+            LiveEditResult.Error(e.message ?: e::class.java.simpleName, info)
         }
 
         when (result) {
             is LiveEditResult.Success -> {
                 _state.value = LiveEditState.Idle
                 LiveEditStatsRegistry.recordSuccess(result.elapsedMs, sourceHash)
+                ErrorAggregatorRegistry.clear()  // 成功 reload → 清旧错
                 _lastResult.set(
                     LiveEditSnapshot(
                         sourceText = sourceText,
@@ -218,6 +227,7 @@ class LiveEditCoordinator(
             is LiveEditResult.Error -> {
                 _state.value = LiveEditState.Error(result.message)
                 LiveEditStatsRegistry.recordError(result.message, sourceHash)
+                result.info?.let { ErrorAggregatorRegistry.add(it) }  // P7 聚合
                 _lastResult.set(
                     LiveEditSnapshot(
                         sourceText = sourceText,
@@ -254,7 +264,11 @@ class LiveEditCoordinator(
          */
         fun getOrCreate(): LiveEditCoordinator {
             return instance ?: synchronized(this) {
-                instance ?: LiveEditCoordinator().also { instance = it }
+                instance ?: LiveEditCoordinator().also {
+                    instance = it
+                    // v2.2 P7: 注册全局 ErrorAggregator (lazy install).
+                    ErrorAggregatorRegistry.install(ErrorAggregator())
+                }
             }
         }
     }
@@ -282,7 +296,11 @@ sealed class LiveEditResult {
         val elapsedMs: Long,
     ) : LiveEditResult()
 
-    data class Error(val message: String) : LiveEditResult()
+    data class Error(
+        val message: String,
+        val info: PreviewErrorInfo? = null,
+    ) : LiveEditResult()
+
     data object Cancelled : LiveEditResult()
 }
 
@@ -323,4 +341,13 @@ interface LiveEditCallback {
      * 触发 ComposableRenderer 重新渲染.
      */
     fun reRender(compilation: Any)
+
+    /**
+     * v2.2 P7: 把异常分类为 [PreviewErrorInfo]. 返回 null 时 Coordinator 用
+     * [PreviewErrorInfo.fromMessage] 降级到 message 嗅探.
+     *
+     * 默认实现: 返回 null (调用方无结构化错误时).
+     * Repository 端实现: catch [CompilationException] 把 [CompileDiagnostic] 转为 [PreviewErrorInfo].
+     */
+    fun classifyError(e: Throwable, sourceHash: Int): PreviewErrorInfo? = null
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
@@ -40,7 +40,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
@@ -91,12 +93,17 @@ import com.itsaky.androidide.compose.preview.runtime.LiveLiteralGroup
 import com.itsaky.androidide.compose.preview.runtime.LiveLiteralType
 import com.itsaky.androidide.compose.preview.runtime.LiveLiteralValue
 import com.itsaky.androidide.compose.preview.runtime.LiveLiteralsHolder
+import com.itsaky.androidide.compose.preview.runtime.AggregatedError
+import com.itsaky.androidide.compose.preview.runtime.ErrorAggregatorRegistry
+import com.itsaky.androidide.compose.preview.runtime.ErrorCategory
+import com.itsaky.androidide.compose.preview.runtime.ErrorSeverity
 import com.itsaky.androidide.compose.preview.runtime.LiveEditCoordinator
 import com.itsaky.androidide.compose.preview.runtime.LiveEditState
 import com.itsaky.androidide.compose.preview.runtime.LiveEditStatsRegistry
 import com.itsaky.androidide.compose.preview.runtime.MultiPreviewRegistry
 import com.itsaky.androidide.compose.preview.runtime.PreviewDisplayMode
 import com.itsaky.androidide.compose.preview.runtime.PreviewSlot
+import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -199,6 +206,7 @@ fun DebugDrawer(
                     )
                     DebugTab.Gallery -> GalleryPanel(modifier = Modifier.fillMaxSize())
                     DebugTab.LiveEdit -> LiveEditPanel(modifier = Modifier.fillMaxSize())
+                    DebugTab.Errors -> ErrorsPanel(modifier = Modifier.fillMaxSize())
                 }
             }
 
@@ -213,7 +221,7 @@ fun DebugDrawer(
     }
 }
 
-/** 7 个 tab 枚举. */
+/** 8 个 tab 枚举. */
 enum class DebugTab(
     val label: String,
     val icon: ImageVector,
@@ -225,6 +233,7 @@ enum class DebugTab(
     LiveLiterals("LiveLit", Icons.Filled.Tune),
     Gallery("Gallery", Icons.Filled.GridView),
     LiveEdit("LiveEdit", Icons.Filled.Bolt),
+    Errors("Errors", Icons.Filled.ErrorOutline),
 }
 
 /**
@@ -1585,4 +1594,210 @@ private fun formatRelativeTime(ts: Long): String {
         deltaMs < 3_600_000 -> "${deltaMs / 60_000}m ago"
         else -> "${deltaMs / 3_600_000}h ago"
     }
+}
+
+// =====================================================================
+// v2.2 P7 错误聚合面板
+// =====================================================================
+
+/**
+ * v2.2 P7 错误聚合 DebugDrawer 面板.
+ *
+ * 顶部 summary: 总错误数 + 按 category 分组计数.
+ * 中部列表: 折叠后的 [AggregatedError] (按 category 升序, lastTs 降序).
+ * 每条: 分类 chip + severity + file:line + message + count + 跳转 IDE 按钮.
+ *
+ * 500ms 拉取一次 [ErrorAggregatorRegistry.snapshotOrEmpty] (与 [LiveEditPanel] 一致).
+ */
+@Composable
+fun ErrorsPanel(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    var errors by remember { mutableStateOf<List<AggregatedError>>(emptyList()) }
+    var summary by remember { mutableStateOf<Map<ErrorCategory, Int>>(emptyMap()) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            errors = ErrorAggregatorRegistry.snapshotOrEmpty()
+            summary = ErrorAggregatorRegistry.summaryOrEmpty()
+            delay(500L)
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Summary
+        Text(
+            text = "Errors (v2.2 P7)",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = "${errors.size} unique · ${summary.values.sum()} total occurrences",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // Category breakdown
+        if (summary.isNotEmpty()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                ErrorCategory.values().forEach { cat ->
+                    val count = summary[cat] ?: 0
+                    if (count > 0) {
+                        CategoryChip(category = cat, count = count)
+                    }
+                }
+            }
+        }
+
+        // 操作按钮
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(onClick = { ErrorAggregatorRegistry.clear() }) {
+                Text("Clear all")
+            }
+        }
+
+        HorizontalDivider()
+
+        // 错误列表
+        if (errors.isEmpty()) {
+            Text(
+                text = "No errors. ✓",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 24.dp),
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                items(errors, key = { "${it.category}:${it.file ?: ""}:${it.line ?: -1}" }) { err ->
+                    ErrorRow(error = err, onJump = { file, line, col ->
+                        JumpToIde.jumpToFile(context, file, line, col)
+                    })
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 单条错误行. 显示 category chip + severity + file:line + msg + count + 跳转按钮.
+ */
+@Composable
+private fun ErrorRow(
+    error: AggregatedError,
+    onJump: (file: String, line: Int?, col: Int?) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(10.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            CategoryChip(category = error.category, count = error.count)
+            Spacer(Modifier.width(6.dp))
+            SeverityChip(severity = error.severity)
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = formatRelativeTime(error.lastTs),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        // file:line
+        if (error.file != null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = fileLabel(error.file, error.line, error.column),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                if (error.line != null) {
+                    Icon(
+                        imageVector = Icons.Filled.OpenInNew,
+                        contentDescription = "Jump to IDE",
+                        modifier = Modifier
+                            .size(16.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable {
+                                onJump(error.file, error.line, error.column)
+                            }
+                            .padding(2.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+        // message (最多 3 行, 截断)
+        Text(
+            text = error.message,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 3,
+        )
+    }
+}
+
+private fun fileLabel(file: String, line: Int?, column: Int?): String {
+    // 仅显示文件名, 不显示完整路径 (节省空间)
+    val name = file.substringAfterLast('/')
+    val sb = StringBuilder(name)
+    if (line != null) {
+        sb.append(":").append(line)
+        if (column != null) sb.append(":").append(column)
+    }
+    return sb.toString()
+}
+
+@Composable
+private fun CategoryChip(category: ErrorCategory, count: Int) {
+    val (label, color) = when (category) {
+        ErrorCategory.K2_COMPILE -> "K2" to Color(0xFFEF5350)
+        ErrorCategory.D8_DEX -> "D8" to Color(0xFFFFA726)
+        ErrorCategory.CLASSLOADER_SWAP -> "SWAP" to Color(0xFFAB47BC)
+        ErrorCategory.OTHER -> "?" to Color(0xFF78909C)
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(color.copy(alpha = 0.18f))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    ) {
+        Text(
+            text = "$label×$count",
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun SeverityChip(severity: ErrorSeverity) {
+    val (label, color) = when (severity) {
+        ErrorSeverity.ERROR -> "ERROR" to Color(0xFFD32F2F)
+        ErrorSeverity.WARNING -> "WARN" to Color(0xFFF9A825)
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = color,
+        modifier = Modifier
+            .clip(RoundedCornerShape(3.dp))
+            .background(color.copy(alpha = 0.12f))
+            .padding(horizontal = 4.dp, vertical = 1.dp),
+    )
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/JumpToIde.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/JumpToIde.kt
@@ -1,0 +1,92 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import org.slf4j.LoggerFactory
+
+/**
+ * v2.2 P7 错误跳转 IDE 协议.
+ *
+ * ## URL Scheme
+ *
+ * ```
+ * androidide://open?file=<absolute-path>&line=<int>&column=<int>
+ * ```
+ *
+ * IDE 注册 `<intent-filter>` 接收后打开对应文件并定位. 与 v2.2 P8 / v2.3 / v2.5
+ * 跳转协议统一, 避免分散.
+ *
+ * ## 用法
+ *
+ * ```kotlin
+ * JumpToIde.jumpToFile(context, file = "/path/to/MyKt.kt", line = 42, column = 7)
+ * ```
+ *
+ * 安全: 失败时 (IDE 未注册) 静默返回 false, 不抛.
+ */
+object JumpToIde {
+    private val LOG = LoggerFactory.getLogger(JumpToIde::class.java)
+
+    private const val SCHEME = "androidide"
+    private const val HOST = "open"
+
+    /**
+     * 构造跳转 URI. 不实际跳转, 给测试用.
+     */
+    fun buildUri(file: String, line: Int?, column: Int?): Uri {
+        val builder = Uri.Builder()
+            .scheme(SCHEME)
+            .authority(HOST)
+            .appendQueryParameter("file", file)
+        if (line != null) builder.appendQueryParameter("line", line.toString())
+        if (column != null) builder.appendQueryParameter("column", column.toString())
+        return builder.build()
+    }
+
+    /**
+     * 跳转到 IDE 打开 file.
+     *
+     * @return true 启动成功, false 失败 (ActivityNotFound 等)
+     */
+    fun jumpToFile(
+        context: Context,
+        file: String,
+        line: Int? = null,
+        column: Int? = null,
+    ): Boolean {
+        val uri = buildUri(file, line, column)
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        return try {
+            context.startActivity(intent)
+            LOG.info("Jumped to IDE: {}", uri)
+            true
+        } catch (e: ActivityNotFoundException) {
+            LOG.warn("No Activity to handle {}: {}", uri, e.message)
+            false
+        } catch (e: SecurityException) {
+            LOG.warn("SecurityException on {}: {}", uri, e.message)
+            false
+        }
+    }
+}

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/ErrorAggregatorTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/ErrorAggregatorTest.kt
@@ -1,0 +1,243 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * v2.2 P7 单元测试.
+ *
+ * 覆盖:
+ * - add / fold / count (10 case)
+ * - clear / snapshot 排序
+ * - summaryByCategory
+ * - category 嗅探
+ * - 并发 add (10 thread × 100 add)
+ * - per-key 隔离
+ */
+class ErrorAggregatorTest {
+
+    @Test
+    fun `01 add then snapshot returns single error with count 1`() {
+        val agg = ErrorAggregator()
+        agg.add(info(category = ErrorCategory.K2_COMPILE, msg = "type mismatch", sourceHash = 0x100))
+        val snap = agg.snapshot()
+        assertEquals(1, snap.size)
+        assertEquals(1, snap[0].count)
+        assertEquals("type mismatch", snap[0].message)
+        assertEquals(0x100, snap[0].sourceHash)
+    }
+
+    @Test
+    fun `02 same (cat, file, line) folds count`() {
+        val agg = ErrorAggregator()
+        val info = info(category = ErrorCategory.K2_COMPILE, file = "/p/A.kt", line = 42,
+            msg = "type mismatch", sourceHash = 0x100)
+        repeat(5) { agg.add(info) }
+        val snap = agg.snapshot()
+        assertEquals(1, snap.size)
+        assertEquals(5, snap[0].count)
+    }
+
+    @Test
+    fun `03 different line does not fold`() {
+        val agg = ErrorAggregator()
+        agg.add(info(category = ErrorCategory.K2_COMPILE, file = "/p/A.kt", line = 42, msg = "a"))
+        agg.add(info(category = ErrorCategory.K2_COMPILE, file = "/p/A.kt", line = 43, msg = "b"))
+        assertEquals(2, agg.snapshot().size)
+    }
+
+    @Test
+    fun `04 different file does not fold`() {
+        val agg = ErrorAggregator()
+        agg.add(info(category = ErrorCategory.K2_COMPILE, file = "/p/A.kt", line = 42, msg = "a"))
+        agg.add(info(category = ErrorCategory.K2_COMPILE, file = "/p/B.kt", line = 42, msg = "b"))
+        assertEquals(2, agg.snapshot().size)
+    }
+
+    @Test
+    fun `05 different category does not fold`() {
+        val agg = ErrorAggregator()
+        agg.add(info(category = ErrorCategory.K2_COMPILE, file = "/p/A.kt", line = 42, msg = "a"))
+        agg.add(info(category = ErrorCategory.D8_DEX, file = "/p/A.kt", line = 42, msg = "b"))
+        assertEquals(2, agg.snapshot().size)
+    }
+
+    @Test
+    fun `06 null file folds together`() {
+        val agg = ErrorAggregator()
+        // swap 失败时通常没有 file:line
+        agg.add(info(category = ErrorCategory.CLASSLOADER_SWAP, file = null, line = null, msg = "swap fail"))
+        agg.add(info(category = ErrorCategory.CLASSLOADER_SWAP, file = null, line = null, msg = "swap fail"))
+        val snap = agg.snapshot()
+        assertEquals(1, snap.size)
+        assertEquals(2, snap[0].count)
+        assertNull(snap[0].file)
+        assertNull(snap[0].line)
+    }
+
+    @Test
+    fun `07 clear empties snapshot and resets counters`() {
+        val agg = ErrorAggregator()
+        agg.add(info(category = ErrorCategory.K2_COMPILE, msg = "a"))
+        agg.add(info(category = ErrorCategory.D8_DEX, msg = "b"))
+        assertEquals(2, agg.snapshot().size)
+        assertEquals(2L, agg.totalAdds())
+        agg.clear()
+        assertEquals(0, agg.snapshot().size)
+        assertEquals(0L, agg.totalAdds())
+        assertEquals(0L, agg.totalErrors())
+    }
+
+    @Test
+    fun `08 snapshot sorts by category asc then lastTs desc`() {
+        val agg = ErrorAggregator()
+        // 顺序添加, 同 category 内 lastTs 单调增 → 反向
+        agg.add(info(category = ErrorCategory.K2_COMPILE, msg = "k2-1"))
+        Thread.sleep(2)
+        agg.add(info(category = ErrorCategory.K2_COMPILE, msg = "k2-2"))
+        Thread.sleep(2)
+        agg.add(info(category = ErrorCategory.D8_DEX, msg = "d8-1"))
+        Thread.sleep(2)
+        agg.add(info(category = ErrorCategory.D8_DEX, msg = "d8-2"))
+        val snap = agg.snapshot()
+        // 期望: D8_DEX (2条, d8-2 在前) → K2_COMPILE (2条, k2-2 在前)
+        assertEquals(4, snap.size)
+        assertEquals(ErrorCategory.D8_DEX, snap[0].category)
+        assertEquals("d8-2", snap[0].message)
+        assertEquals(ErrorCategory.D8_DEX, snap[1].category)
+        assertEquals("d8-1", snap[1].message)
+        assertEquals(ErrorCategory.K2_COMPILE, snap[2].category)
+        assertEquals("k2-2", snap[2].message)
+        assertEquals(ErrorCategory.K2_COMPILE, snap[3].category)
+        assertEquals("k2-1", snap[3].message)
+    }
+
+    @Test
+    fun `09 summaryByCategory counts per category`() {
+        val agg = ErrorAggregator()
+        agg.add(info(category = ErrorCategory.K2_COMPILE, msg = "a"))
+        agg.add(info(category = ErrorCategory.K2_COMPILE, msg = "b"))
+        agg.add(info(category = ErrorCategory.D8_DEX, msg = "c"))
+        agg.add(info(category = ErrorCategory.CLASSLOADER_SWAP, msg = "d"))
+        agg.add(info(category = ErrorCategory.CLASSLOADER_SWAP, msg = "e"))
+        agg.add(info(category = ErrorCategory.CLASSLOADER_SWAP, msg = "f"))
+        val summary = agg.summaryByCategory()
+        assertEquals(2, summary[ErrorCategory.K2_COMPILE])
+        assertEquals(1, summary[ErrorCategory.D8_DEX])
+        assertEquals(3, summary[ErrorCategory.CLASSLOADER_SWAP])
+        assertNull(summary[ErrorCategory.OTHER])
+    }
+
+    @Test
+    fun `10 classifier maps dex message to D8_DEX`() {
+        assertEquals(ErrorCategory.D8_DEX,
+            ErrorCategory.classifyByMessage("DEX compilation failed"))
+        assertEquals(ErrorCategory.D8_DEX,
+            ErrorCategory.classifyByMessage("d8: missing class"))
+    }
+
+    @Test
+    fun `11 classifier maps classnotfound to CLASSLOADER_SWAP`() {
+        assertEquals(ErrorCategory.CLASSLOADER_SWAP,
+            ErrorCategory.classifyByMessage("java.lang.ClassNotFoundException: Foo"))
+        assertEquals(ErrorCategory.CLASSLOADER_SWAP,
+            ErrorCategory.classifyByMessage("swap failed"))
+    }
+
+    @Test
+    fun `12 classifier maps compile to K2_COMPILE`() {
+        assertEquals(ErrorCategory.K2_COMPILE,
+            ErrorCategory.classifyByMessage("Compilation failed: type mismatch"))
+        assertEquals(ErrorCategory.K2_COMPILE,
+            ErrorCategory.classifyByMessage("K2JVMCompiler: unresolved reference"))
+    }
+
+    @Test
+    fun `13 classifier defaults to OTHER for unknown`() {
+        assertEquals(ErrorCategory.OTHER,
+            ErrorCategory.classifyByMessage("something weird happened"))
+        assertEquals(ErrorCategory.OTHER, ErrorCategory.classifyByMessage(null))
+    }
+
+    @Test
+    fun `14 PreviewErrorInfo_fromMessage sets category from classify`() {
+        val info = PreviewErrorInfo.fromMessage("DEX failed", sourceHash = 0x100)
+        assertEquals(ErrorCategory.D8_DEX, info.category)
+        assertEquals(ErrorSeverity.ERROR, info.severity)
+        assertEquals(0x100, info.sourceHash)
+    }
+
+    @Test
+    fun `15 concurrent add from 10 threads is safe`() {
+        val agg = ErrorAggregator()
+        val executor = Executors.newFixedThreadPool(10)
+        val latch = CountDownLatch(10)
+        val totalAdds = AtomicInteger(0)
+        repeat(10) { threadIdx ->
+            executor.submit {
+                try {
+                    repeat(100) { i ->
+                        agg.add(info(
+                            category = ErrorCategory.K2_COMPILE,
+                            file = "/p/A.kt",
+                            line = i,
+                            msg = "thread$threadIdx line$i",
+                            sourceHash = threadIdx * 100 + i,
+                        ))
+                        totalAdds.incrementAndGet()
+                    }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+        assertTrue(latch.await(5, TimeUnit.SECONDS))
+        executor.shutdown()
+        // 10 thread × 100 line = 1000 unique
+        assertEquals(1000, agg.snapshot().size)
+        assertEquals(1000L, agg.totalAdds())
+    }
+
+    // --- helper ---
+
+    private fun info(
+        category: ErrorCategory,
+        file: String? = "/p/A.kt",
+        line: Int? = 42,
+        column: Int? = 7,
+        msg: String,
+        sourceHash: Int = 0x100,
+        severity: ErrorSeverity = ErrorSeverity.ERROR,
+    ): PreviewErrorInfo = PreviewErrorInfo(
+        category = category,
+        severity = severity,
+        file = file,
+        line = line,
+        column = column,
+        message = msg,
+        sourceHash = sourceHash,
+    )
+}


### PR DESCRIPTION
## Summary

v2.2 P7 — Live Edit 错误聚合,调试体验收尾。
- 按 (file,line) 折叠 + count,避免 N 次同源编译刷屏
- 4 类分类 (K2_COMPILE / D8_DEX / CLASSLOADER_SWAP / OTHER) + Severity
- 成功 hot-reload 自动清旧错
- DebugDrawer 第 8 tab `Errors` (顶部 summary + 列表 + Clear + 跳转 IDE)
- 跳转 IDE 协议: `androidide://open?file=&line=&column=` (与 P8 / v2.3 / v2.5 统一)

## New Files

### `runtime/ErrorAggregator.kt` (+250 行)
- `ErrorCategory` (enum): K2_COMPILE / D8_DEX / CLASSLOADER_SWAP / OTHER + `classifyByMessage()` 嗅探
- `ErrorSeverity` (enum): ERROR / WARNING
- `PreviewErrorInfo` (data class): 结构化错误 (category / severity / file / line / column / message / sourceHash)
- `AggregatedError` (data class): 折叠后错误 (count / firstTs / lastTs)
- `ErrorAggregator` (class): `ConcurrentHashMap<key, AggregatedError>` 原子折叠 + `add()` / `clear()` / `snapshot()` (按 category 升序, lastTs 降序) / `summaryByCategory()` / `totalAdds()` / `totalErrors()`
- `ErrorAggregatorRegistry` (object): atomic install + lazy snapshot (与 v2.2 P3 LiveEditStatsRegistry / v2.1 P3-P5 各 Registry 模式一致)

### `ui/JumpToIde.kt` (+70 行)
- `JumpToIde.jumpToFile(context, file, line, column)`: 构造 `Intent(ACTION_VIEW, "androidide://open?...")` 唤起 IDE 编辑器
- 失败 (ActivityNotFound / SecurityException) 静默返回 false, 不抛

### `test/ErrorAggregatorTest.kt` (+210 行, 15 case)
- add / fold / count
- 不同 file/line/category 不折叠
- null file 折叠
- clear 重置
- snapshot 排序 (category asc, lastTs desc)
- summaryByCategory 计数
- classifier 4 类映射 (dex/d8/swap/ClassNotFound/compile/K2/other/null)
- PreviewErrorInfo.fromMessage 工厂
- **并发 add** 10 thread × 100 add 验证 ConcurrentHashMap.compute 原子性

## Modified Files

### `runtime/LiveEditCoordinator.kt` (+37 行)
- `LiveEditResult.Error` 新增 `info: PreviewErrorInfo?` 字段 (默认 null, 向后兼容)
- `LiveEditCallback.classifyError(e, sourceHash)`: 默认返回 null,Repository 端可覆盖为把 `CompilationException.diagnostics` 转为 `PreviewErrorInfo`
- `reload()` catch Throwable: 先调 `cb.classifyError(e)`,fallback 到 `PreviewErrorInfo.fromMessage(e.message)`
- `reload()` 成功路径调 `ErrorAggregatorRegistry.clear()` 清旧错
- `reload()` 失败路径调 `ErrorAggregatorRegistry.add(result.info)`
- `getOrCreate()` 注册全局 `ErrorAggregator`

### `ui/DebugDrawer.kt` (+217 行)
- 加 import: `ErrorOutline` / `OpenInNew` icon + `LocalContext` + 5 个 runtime 类型
- `DebugTab` enum 加第 8 项 `Errors` (icon: `ErrorOutline`)
- 加 `DebugTab.Errors -> ErrorsPanel(...)` dispatch case
- `ErrorsPanel` composable: summary + category breakdown + Clear 按钮 + LazyColumn 错误列表
- `ErrorRow` composable: CategoryChip (4 色) + SeverityChip (ERROR 红 / WARN 黄) + file:line (含 OpenInNew 跳转) + message (max 3 行)
- `fileLabel()` helper: 文件名截断 (不显示完整路径)
- `CategoryChip()` composable: 4 category 不同背景色
- `SeverityChip()` composable: ERROR/WARN 标签

## Architecture

```
compile/swap 失败
  → Repository 抛 CompilationException(message, diagnostics)
  → LiveEditCoordinator 捕获
       ├→ LiveEditStats.recordError(message, sourceHash)  (已有)
       └→ ErrorAggregator.add(PreviewErrorInfo)  (P7 新)
            └→ ConcurrentHashMap.compute() 原子折叠 (cat, file, line) 合并, count++

compile 成功
  → LiveEditCoordinator
       └→ ErrorAggregator.clear()  (清旧错, 重新开始)

DebugDrawer ErrorsPanel 每 500ms 拉取 ErrorAggregator.snapshot()
用户点击 OpenInNew 图标
  → JumpToIde.jumpToFile(context, file, line, col)
  → startActivity(Intent "androidide://open?file=...&line=...&column=...")
```

## Test Coverage

15 个 unit test case, 0 改其他生产代码(除 P7 自己引入的)。

## Related

- Base: `feat/compose-preview-v2.2-p6-docs` (PR #345)
- v2.2 PR 链: #339 → ... → #345 → **#346 (本)**
- 后续: v2.2 P8 Resource 监听 / v2.3 P0 Multi-module
