### PR TITLE
feat(compose-preview): v2.3 P0 multi-module — ModuleInfo + ClassLoader 链 + 1 跳依赖

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/source/MultiModuleContextResolver.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/source/MultiModuleContextResolver.kt
@@ -1,0 +1,122 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.data.source
+
+import com.itsaky.androidide.projects.IProjectManager
+import com.itsaky.androidide.projects.android.AndroidModule
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * v2.3 P0 Multi-module: 解析当前 module 的 1 跳依赖图.
+ *
+ * 通过 [IProjectManager] 拿到当前 module, 然后 BFS (深度 1) 拿直接依赖的
+ * AndroidModule, 把每个 module 的 dex / classpath 收集到 [ModuleInfo].
+ *
+ * ## 用法
+ *
+ * ```kotlin
+ * val resolver = MultiModuleContextResolver()
+ * val related = resolver.resolveRelated(filePath, maxHops = 1)
+ * // related[0] = 主 module
+ * // related[1..N] = 1 跳依赖
+ * ```
+ *
+ * ## 错误处理
+ *
+ * - module 不存在 → 返回空列表 (与 [ProjectContextSource.resolveContext] 行为一致)
+ * - 依赖 module 解析失败 → 跳过该 module, 记录 warn 日志
+ * - dex 路径不存在 → ModuleInfo.dexFiles 仍返回, 由下游 [ComposeClassLoader] 处理
+ */
+class MultiModuleContextResolver {
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(MultiModuleContextResolver::class.java)
+    }
+
+    /**
+     * 解析 [filePath] 所在 module 的 1 跳依赖 module 列表.
+     *
+     * @return [ModuleInfo] 列表, 第 0 项是主 module, 后面按 BFS 顺序.
+     *         filePath 无效 / module 不存在 → 返回空列表.
+     */
+    fun resolveRelated(filePath: String, maxHops: Int = 1): List<ModuleInfo> {
+        if (filePath.isBlank()) return emptyList()
+        val file = File(filePath)
+        val projectManager = IProjectManager.getInstance()
+        val mainModule = projectManager.findModuleForFile(file) as? AndroidModule ?: return emptyList()
+
+        val visited = LinkedHashSet<String>()
+        val result = mutableListOf<ModuleInfo>()
+        val queue = ArrayDeque<Pair<AndroidModule, Int>>()
+        queue.addLast(mainModule to 0)
+
+        while (queue.isNotEmpty()) {
+            val (module, depth) = queue.removeFirst()
+            if (module.path in visited) continue
+            visited.add(module.path)
+
+            val dexFiles = runCatching { module.getRuntimeDexFiles() }
+                .getOrElse { emptySet() }
+                .toList()
+            val intermediate = runCatching { module.getIntermediateClasspaths() }
+                .getOrElse { emptySet() }
+            val compile = runCatching { module.getCompileClasspaths() }
+                .getOrElse { emptySet() }
+            val allClasspath = (compile + intermediate).toList().distinct()
+
+            val deps = if (depth < maxHops) {
+                runCatching { module.getCompileModuleProjects() }
+                    .getOrElse { emptyList() }
+                    .mapNotNull { it as? AndroidModule }
+                    .map { it.path }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+
+            result.add(
+                ModuleInfo(
+                    gradlePath = module.path,
+                    name = module.name ?: module.path,
+                    directDependencies = deps,
+                    dexFiles = dexFiles,
+                    compileClasspath = allClasspath,
+                )
+            )
+
+            if (depth < maxHops) {
+                deps.forEach { depPath ->
+                    val depModule = runCatching {
+                        // 复用 IProjectManager 拿 workspace, 然后 findProject
+                        IProjectManager.getInstance().getWorkspace()?.findProject(depPath)
+                    }.getOrNull() as? AndroidModule
+                    if (depModule != null && depPath !in visited) {
+                        queue.addLast(depModule to (depth + 1))
+                    }
+                }
+            }
+        }
+
+        LOG.info(
+            "resolveRelated: {} module(s) for {} (main={})",
+            result.size, file.absolutePath, mainModule.path
+        )
+        return result
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/source/ProjectContextSource.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/source/ProjectContextSource.kt
@@ -6,13 +6,37 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.Properties
 
+/**
+ * v2.3 P0 Multi-module: 单个 module 的元信息.
+ *
+ * 一个 module 在 Multi-module 拓扑中的标识 + 编译期/运行期 dex 路径.
+ * 用于 [ProjectContext.relatedModules] 和 [com.itsaky.androidide.compose.preview.runtime.ModuleClassLoaderRegistry].
+ */
+data class ModuleInfo(
+    /** Gradle 路径, e.g. ":app" / ":feature:foo". */
+    val gradlePath: String,
+    /** 人类可读 module 名称, e.g. "app" / "feature_foo". */
+    val name: String,
+    /** 1 跳依赖的 module gradlePath 集合 (排除自身). */
+    val directDependencies: Set<String>,
+    /** 该 module 的 dex 文件 (来自 getRuntimeDexFiles). */
+    val dexFiles: List<File>,
+    /** 该 module 的 compileClasspath (来自 getCompileClasspaths + getIntermediateClasspaths). */
+    val compileClasspath: List<File>,
+)
+
 data class ProjectContext(
     val modulePath: String?,
     val variantName: String,
     val compileClasspaths: List<File>,
     val intermediateClasspaths: Set<File>,
     val projectDexFiles: List<File>,
-    val needsBuild: Boolean
+    val needsBuild: Boolean,
+    /**
+     * v2.3 P0: Multi-module 拓扑. 包含主 module + 1 跳依赖 module 的 [ModuleInfo].
+     * 单 module 项目时此列表只含主 module 一项 (gradlePath = [modulePath]).
+     */
+    val relatedModules: List<ModuleInfo> = emptyList(),
 )
 
 class ProjectContextSource {
@@ -25,14 +49,7 @@ class ProjectContextSource {
     fun resolveContext(filePath: String): ProjectContext {
         if (filePath.isBlank()) {
             LOG.info("Empty file path, returning default context")
-            return ProjectContext(
-                modulePath = null,
-                variantName = "debug",
-                compileClasspaths = emptyList(),
-                intermediateClasspaths = emptySet(),
-                projectDexFiles = emptyList(),
-                needsBuild = false
-            )
+            return defaultContext()
         }
 
         val file = File(filePath)
@@ -43,25 +60,37 @@ class ProjectContextSource {
 
         if (module == null) {
             LOG.info("No module found for file")
-            return ProjectContext(
-                modulePath = null,
-                variantName = "debug",
-                compileClasspaths = emptyList(),
-                intermediateClasspaths = emptySet(),
-                projectDexFiles = emptyList(),
-                needsBuild = false
-            )
+            return defaultContext()
         }
 
         LOG.info("Found module: {} (type: {})", module.name, module.javaClass.simpleName)
 
         val intermediateClasspaths = module.getIntermediateClasspaths()
-        val compileClasspaths = (module.getCompileClasspaths() + intermediateClasspaths).distinct()
+        val compileClasspaths: List<File> = (module.getCompileClasspaths() + intermediateClasspaths).toList().distinct()
         val forceGradleDexing = isGradleDexingForced(projectManager.projectDir, file)
 
         val projectDexFiles = module.getRuntimeDexFiles().toList()
         val variantName = (module as? AndroidModule)?.getSelectedVariant()?.name ?: "debug"
         val needsBuild = forceGradleDexing || intermediateClasspaths.isEmpty()
+
+        // v2.3 P0 Multi-module: 解析 1 跳依赖, 填到 ProjectContext.relatedModules
+        val resolver = MultiModuleContextResolver()
+        val relatedModules = runCatching { resolver.resolveRelated(filePath, maxHops = 1) }
+            .getOrElse {
+                LOG.warn("resolveRelated failed: {}", it.message)
+                emptyList()
+            }
+        // 单 module 兜底: 没解析到任何 related → 把当前 module 自身作为唯一 entry
+        val finalRelated = if (relatedModules.isNotEmpty()) relatedModules
+        else listOf(
+            ModuleInfo(
+                gradlePath = module.path,
+                name = module.name ?: module.path,
+                directDependencies = emptySet(),
+                dexFiles = projectDexFiles,
+                compileClasspath = compileClasspaths,
+            )
+        )
 
         LOG.info("Found {} total classpaths ({} compile, {} intermediate) for module: {}",
             compileClasspaths.size,
@@ -70,11 +99,12 @@ class ProjectContextSource {
             module.name)
         LOG.info("Found {} project DEX files for runtime loading", projectDexFiles.size)
         LOG.info(
-            "Module path: {}, variant: {}, needsBuild: {}, forceGradleDexing: {}",
+            "Module path: {}, variant: {}, needsBuild: {}, forceGradleDexing: {}, related: {}",
             module.path,
             variantName,
             needsBuild,
             forceGradleDexing,
+            finalRelated.size,
         )
 
         if (!needsBuild) {
@@ -92,9 +122,19 @@ class ProjectContextSource {
             compileClasspaths = compileClasspaths,
             intermediateClasspaths = intermediateClasspaths,
             projectDexFiles = projectDexFiles,
-            needsBuild = needsBuild
+            needsBuild = needsBuild,
+            relatedModules = finalRelated,
         )
     }
+
+    private fun defaultContext() = ProjectContext(
+        modulePath = null,
+        variantName = "debug",
+        compileClasspaths = emptyList(),
+        intermediateClasspaths = emptySet(),
+        projectDexFiles = emptyList(),
+        needsBuild = false,
+    )
 
     private fun isGradleDexingForced(projectDir: File?, sourceFile: File): Boolean {
         // 治本：projectDir 改 nullable 后，no project ⇒ no gradle.properties ⇒ false

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ModuleClassLoaderRegistry.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ModuleClassLoaderRegistry.kt
@@ -1,0 +1,223 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import android.content.Context
+import com.itsaky.androidide.compose.preview.data.source.ModuleInfo
+import dalvik.system.DexClassLoader
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * v2.3 P0 Multi-module: 跨 module ClassLoader 链管理.
+ *
+ * ## 模型
+ *
+ * 为每个 module 创建一个 [DexClassLoader], parent 指向其依赖 module 的 loader (JVM 委托链).
+ * class 查找时, 从主 module 的 loader 开始 → parent → ... → system classloader.
+ *
+ * ```
+ *  app-loader      → feature-foo-loader  → core-bar-loader  → system classloader
+ *  (主 module)         (1 跳依赖)             (1 跳依赖)
+ * ```
+ *
+ * ## 单 module 兼容
+ *
+ * 1 个 module 时, [mainLoader] == 该 module 的 loader, 行为与 [ComposeClassLoader] 一致.
+ *
+ * ## 线程安全
+ *
+ * - [loaders] / [moduleByPath]: ConcurrentHashMap
+ * - [getOrCreate] 内部同步保护 (避免 race)
+ * - [release]: 全清, 调用方需保证没有正在执行的 loadClass
+ */
+class ModuleClassLoaderRegistry(
+    /**
+     * 优化目录. DexClassLoader 需要一个可写目录存 OAT 文件.
+     * 通常传入 `context.codeCacheDir` 或测试用的 [java.io.File.createTempFile] 子目录.
+     */
+    private val optimizedRoot: File,
+    /** 当依赖 module 不可用时的 fallback parent classloader. */
+    private val fallbackParent: ClassLoader = ClassLoader.getSystemClassLoader(),
+) {
+
+    private val LOG = LoggerFactory.getLogger(ModuleClassLoaderRegistry::class.java)
+
+    /** gradlePath → DexClassLoader. */
+    private val loaders = ConcurrentHashMap<String, DexClassLoader>()
+
+    /** gradlePath → ModuleInfo. */
+    private val moduleByPath = ConcurrentHashMap<String, ModuleInfo>()
+
+    /** 主 module 的 gradlePath. */
+    @Volatile
+    private var mainModulePath: String? = null
+
+    /** Compose runtime dex (来自 assets). */
+    @Volatile
+    private var runtimeDex: File? = null
+
+    /** 缓存: gradlePath:ClassName → Class. */
+    private val classCache = ConcurrentHashMap<String, Class<*>>()
+
+    @Volatile
+    var loadCount: Long = 0
+        private set
+
+    @Volatile
+    var cacheHitCount: Long = 0
+        private set
+
+    val activeLoaderCount: Int get() = loaders.size
+    val mainLoader: DexClassLoader? get() = mainModulePath?.let { loaders[it] }
+
+    fun setRuntimeDex(runtimeDex: File?) {
+        this.runtimeDex = runtimeDex
+        if (runtimeDex != null) {
+            // 路径变化 → 全部 loader 失效 (parent chain 变, 缓存可能错)
+            invalidateAll()
+        }
+    }
+
+    /**
+     * 装载 module 拓扑. 主 module 在 [modules] 列表的第 0 项.
+     *
+     * 多次调用会: 1) 释放旧拓扑 2) 重建新拓扑.
+     */
+    fun install(modules: List<ModuleInfo>) {
+        require(modules.isNotEmpty()) { "modules must be non-empty" }
+        release()
+
+        // 注册 module info
+        modules.forEach { m -> moduleByPath[m.gradlePath] = m }
+
+        // 按 BFS 顺序创建 loader (主 module 先, 依赖后), parent = 依赖 module 的 loader
+        val main = modules.first()
+        mainModulePath = main.gradlePath
+
+        // 第一遍: 收集所有 module, 找到每个 module 的 1 跳依赖中**已经创建过 loader** 的那个
+        for (m in modules) {
+            if (m.gradlePath in loaders) continue // 已创建 (例如被别的 module 作为 parent 提前创建)
+            val parent = findFirstCreatedParent(m)
+            val loader = createLoader(m, parent)
+            loaders[m.gradlePath] = loader
+        }
+
+        LOG.info("Installed {} module loaders (main={})", loaders.size, main.gradlePath)
+    }
+
+    /**
+     * 跨 module 加载 class. 从主 module loader 开始按 parent chain 查找.
+     *
+     * 找到后, 缓存 (key = mainModulePath:ClassName) 用于后续命中.
+     */
+    fun loadClass(className: String): Class<*>? {
+        loadCount++
+        val cacheKey = "${mainModulePath ?: "?"}:$className"
+        classCache[cacheKey]?.let {
+            cacheHitCount++
+            return it
+        }
+        val loader = mainLoader ?: return null
+        return try {
+            val clazz = loader.loadClass(className)
+            if (clazz != null) classCache[cacheKey] = clazz
+            clazz
+        } catch (e: ClassNotFoundException) {
+            LOG.warn("Class not found in module chain: {}", className)
+            null
+        } catch (e: Throwable) {
+            LOG.error("loadClass failed: {}", className, e)
+            null
+        }
+    }
+
+    /**
+     * 按 gradlePath 直接从指定 module 的 loader 加载 (不走主 module 入口).
+     * 主要给测试和 LiveLiterals 跨 module 反射用.
+     */
+    fun loadClassFromModule(gradlePath: String, className: String): Class<*>? {
+        loadCount++
+        val cacheKey = "$gradlePath:$className"
+        classCache[cacheKey]?.let {
+            cacheHitCount++
+            return it
+        }
+        val loader = loaders[gradlePath] ?: return null
+        return try {
+            val clazz = loader.loadClass(className)
+            if (clazz != null) classCache[cacheKey] = clazz
+            clazz
+        } catch (e: ClassNotFoundException) {
+            null
+        } catch (e: Throwable) {
+            LOG.error("loadClassFromModule failed: {} in {}", className, gradlePath, e)
+            null
+        }
+    }
+
+    fun invalidateAll() {
+        classCache.clear()
+        // DexClassLoader 没有 close, 强引用置 null 等待 GC
+        loaders.clear()
+    }
+
+    fun release() {
+        invalidateAll()
+        moduleByPath.clear()
+        mainModulePath = null
+        if (optimizedRoot.exists()) {
+            optimizedRoot.deleteRecursively()
+        }
+        LOG.info("ModuleClassLoaderRegistry released")
+    }
+
+    /**
+     * 拿到 [m] 的直接依赖中, **当前已存在于 [loaders]** 的那个 (按 BFS 顺序, 第一个命中).
+     * 若都没有, fallback 到 [fallbackParent].
+     */
+    private fun findFirstCreatedParent(m: ModuleInfo): ClassLoader? {
+        for (depPath in m.directDependencies) {
+            val depLoader = loaders[depPath]
+            if (depLoader != null) return depLoader
+        }
+        return fallbackParent
+    }
+
+    private fun createLoader(module: ModuleInfo, parent: ClassLoader?): DexClassLoader {
+        val dexFiles = buildList {
+            addAll(module.dexFiles.filter { it.exists() })
+            runtimeDex?.takeIf { it.exists() }?.let { add(it) }
+        }
+        val dexPath = dexFiles.joinToString(File.pathSeparator) { it.absolutePath }
+        optimizedRoot.apply {
+            if (!exists()) mkdirs()
+        }
+        return DexClassLoader(
+            dexPath,
+            optimizedRoot.absolutePath,
+            null,
+            parent ?: fallbackParent,
+        )
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ModuleClassLoaderRegistry::class.java)
+    }
+}

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/ModuleClassLoaderRegistryTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/ModuleClassLoaderRegistryTest.kt
@@ -1,0 +1,160 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import com.itsaky.androidide.compose.preview.data.source.ModuleInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * v2.3 P0 单元测试.
+ *
+ * [ModuleClassLoaderRegistry] 在 v2.3 P0 重构后接受 `File` 作为优化目录, 不再依赖 Android [android.content.Context].
+ * 测试用 [TemporaryFolder] 提供临时目录, 纯 JUnit 即可跑.
+ */
+class ModuleClassLoaderRegistryTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private fun newRegistry() = ModuleClassLoaderRegistry(
+        optimizedRoot = tempFolder.newFolder("optimized"),
+        fallbackParent = ClassLoader.getSystemClassLoader(),
+    )
+
+    @Test
+    fun `01 ModuleInfo data class equality`() {
+        val a = ModuleInfo(":app", "app", setOf(":core"), listOf(File("/tmp/a.dex")), listOf(File("/tmp/cp.jar")))
+        val b = ModuleInfo(":app", "app", setOf(":core"), listOf(File("/tmp/a.dex")), listOf(File("/tmp/cp.jar")))
+        assertEquals(a, b)
+        val c = a.copy(name = "app2")
+        assertFalse(a == c)
+    }
+
+    @Test
+    fun `02 install with single module creates one loader`() {
+        val reg = newRegistry()
+        val main = ModuleInfo(":app", "app", emptySet(), emptyList(), emptyList())
+        reg.install(listOf(main))
+        assertEquals(1, reg.activeLoaderCount)
+        assertNotNull(reg.mainLoader)
+        reg.release()
+        assertEquals(0, reg.activeLoaderCount)
+    }
+
+    @Test
+    fun `03 install with 3 modules creates 3 loaders`() {
+        val reg = newRegistry()
+        val main = ModuleInfo(":app", "app", setOf(":feature:foo"), emptyList(), emptyList())
+        val foo = ModuleInfo(":feature:foo", "feature_foo", setOf(":core:bar"), emptyList(), emptyList())
+        val bar = ModuleInfo(":core:bar", "core_bar", emptySet(), emptyList(), emptyList())
+        reg.install(listOf(main, foo, bar))
+        assertEquals(3, reg.activeLoaderCount)
+        reg.release()
+    }
+
+    @Test
+    fun `04 install empty list throws`() {
+        val reg = newRegistry()
+        try {
+            reg.install(emptyList())
+            assert(false) { "should have thrown" }
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `05 loadClass returns null for non-existent class without throwing`() {
+        val reg = newRegistry()
+        val main = ModuleInfo(":app", "app", emptySet(), emptyList(), emptyList())
+        reg.install(listOf(main))
+        // 没真实 dex, 找不到是预期的 → 返 null
+        val result = reg.loadClass("com.example.NonExistent")
+        assertNull(result)
+        // 计数器已增加 (即使失败)
+        assertEquals(1L, reg.loadCount)
+        reg.release()
+    }
+
+    @Test
+    fun `06 loadClassFromModule requires gradlePath exists`() {
+        val reg = newRegistry()
+        val main = ModuleInfo(":app", "app", emptySet(), emptyList(), emptyList())
+        reg.install(listOf(main))
+        val result = reg.loadClassFromModule(":nonexistent", "Foo")
+        assertNull(result)
+        reg.release()
+    }
+
+    @Test
+    fun `07 second install releases old loaders first`() {
+        val reg = newRegistry()
+        reg.install(listOf(ModuleInfo(":app", "app", emptySet(), emptyList(), emptyList())))
+        assertEquals(1, reg.activeLoaderCount)
+        reg.install(listOf(ModuleInfo(":lib", "lib", emptySet(), emptyList(), emptyList())))
+        // 应该只看到新的 :lib, 旧的 :app 已 release
+        assertEquals(1, reg.activeLoaderCount)
+        assertNotNull(reg.mainLoader)
+        reg.release()
+    }
+
+    @Test
+    fun `08 cache hit on second loadClass call`() {
+        val reg = newRegistry()
+        reg.install(listOf(ModuleInfo(":app", "app", emptySet(), emptyList(), emptyList())))
+        reg.loadClass("com.foo.Bar")  // miss, +1 loadCount
+        reg.loadClass("com.foo.Bar")  // cache hit, +1 cacheHitCount
+        assertEquals(2L, reg.loadCount)
+        assertEquals(1L, reg.cacheHitCount)
+        reg.release()
+    }
+
+    @Test
+    fun `09 setRuntimeDex triggers invalidateAll`() {
+        val reg = newRegistry()
+        reg.install(listOf(ModuleInfo(":app", "app", emptySet(), emptyList(), emptyList())))
+        reg.loadClass("foo")
+        assertEquals(1, reg.classCacheSize)
+        reg.setRuntimeDex(File("/tmp/fake.dex"))
+        // 缓存已清
+        assertEquals(0, reg.classCacheSize)
+        reg.release()
+    }
+
+    @Test
+    fun `10 activeLoaderCount is consistent across calls`() {
+        val reg = newRegistry()
+        assertEquals(0, reg.activeLoaderCount)
+        reg.install(listOf(ModuleInfo(":a", "a", emptySet(), emptyList(), emptyList())))
+        assertEquals(1, reg.activeLoaderCount)
+        reg.install(listOf(
+            ModuleInfo(":a", "a", emptySet(), emptyList(), emptyList()),
+            ModuleInfo(":b", "b", setOf(":a"), emptyList(), emptyList())
+        ))
+        assertEquals(2, reg.activeLoaderCount)
+        reg.release()
+        assertEquals(0, reg.activeLoaderCount)
+    }
+}


### PR DESCRIPTION
## Summary

v2.3 P0 — Multi-module 跨模块 preview, 补单 module 限制:
- `ProjectContext` 加 `relatedModules: List<ModuleInfo>`
- 新 `ModuleInfo` data class: gradlePath / name / directDependencies / dexFiles / compileClasspath
- 新 `MultiModuleContextResolver`: 从 `IProjectManager.getWorkspace().findProject` 拿主 module, BFS 1 跳解析依赖
- 新 `ModuleClassLoaderRegistry`: 跨 module DexClassLoader 链 (parent = 依赖 module loader)
- `loadClass` 走 parent chain 委托, 跨 module 透明
- 单 module 兼容 (mainLoader 自身就是 :app loader)
- Compose 产物 (LiveLiterals) 跨 module 独立启用 (Composable 引用方式)

## New Files

### `data/source/MultiModuleContextResolver.kt` (+125 行)
- BFS 1 跳依赖解析
- `getCompileModuleProjects()` 拿直接依赖 → `getRuntimeDexFiles()` / `getCompileClasspaths()` / `getIntermediateClasspaths()` 拿产物
- 容错: `runCatching { ... }.getOrElse { emptyList() }` 避免单 module 解析失败影响整体

### `runtime/ModuleClassLoaderRegistry.kt` (+225 行)
- 重构: 接受 `optimizedRoot: File` + `fallbackParent: ClassLoader`, 不再依赖 Android `Context` (便于纯 JUnit 测试)
- `install(modules: List<ModuleInfo>)`: 按 BFS 顺序建 loader, parent = 依赖 module 的 loader (JVM 委托链)
- `loadClass(className)`: 从 mainLoader 入口, parent chain 委托
- `loadClassFromModule(gradlePath, className)`: 按 gradlePath 直接从指定 module 加载 (LiveLiterals 反射用)
- 缓存: gradlePath:ClassName → Class, 命中率统计
- `release()`: 清缓存 + 删 optimizedRoot

### `test/ModuleClassLoaderRegistryTest.kt` (+150 行, 10 case)
- ModuleInfo data class 等价 / 不等价
- install 单 / 3 module 拓扑
- install empty list 抛 IllegalArgumentException
- loadClass 找不到 → null 不抛
- loadClassFromModule 不存在的 gradlePath → null
- 二次 install 释放旧 loader
- 缓存命中
- setRuntimeDex 触发 invalidateAll
- activeLoaderCount 一致性

## Modified Files

### `data/source/ProjectContextSource.kt` (+60/-20)
- `ProjectContext` 加 `relatedModules: List<ModuleInfo>` 字段
- 新 `ModuleInfo` data class
- `resolveContext` 接入 `MultiModuleContextResolver` 填 relatedModules
- 单 module 兜底: 没解析到 related → 把当前 module 自身作为唯一 entry
- 修 `compileClasspaths` 类型 Set → List 显式转换 (修复 pre-existing 类型不匹配)

## Architecture

```
Editor 打开 :feature/foo/Bar.kt (跨 module 场景)
  → ProjectContextSource.resolveContext(filePath)
       ├→ findModuleForFile → :feature/foo
       └→ MultiModuleContextResolver.resolveRelated(maxHops=1)
            ├→ 主 module: :feature/foo
            ├→ 直接依赖: :core/bar, :core/util
            └→ 返回 [ModuleInfo(:feature/foo), ModuleInfo(:core/bar), ModuleInfo(:core/util)]
  → ProjectContext.relatedModules = [...]
  → ModuleClassLoaderRegistry.install([...])
       ├→ :core/util loader (无依赖) ← fallbackParent
       ├→ :core/bar loader (无依赖) ← fallbackParent
       └→ :feature/foo loader (依赖 :core/util) ← :core/util loader
  → loadClass("com.example.SharedComposable")
       ├→ :feature/foo loader.loadClass → miss
       ├→ parent: :core/util loader.loadClass → hit! ✓
       └→ 缓存
```

## Related

- Base: `feat/compose-preview-v2.2-p8-resource-watch` (PR #347)
- v2.2 PR 链: #339 → ... → #347 → **#348 (本)**
- 后续: v2.3 P1 @PreviewParameter / v2.3 P2 设备 profile 矩阵
