### PR TITLE
feat(compose-preview): v2.3 P1 @PreviewParameter — registry + Gallery 切换箭头

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewParameterRegistry.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewParameterRegistry.kt
@@ -1,0 +1,176 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * v2.3 P1: 单个 provider 的预加载数据.
+ *
+ * - [providerInstance]: 通过反射 `providerClass.getDeclaredConstructor().newInstance()` 创建.
+ * - [values]: 调用 `providerInstance.getValues()` 一次, 缓存 `Sequence` 物化为 [List] 便于随机访问.
+ * - [currentIndex]: 当前选中的 index, 默认 0.
+ */
+data class PreviewParameterEntry(
+    val providerClass: Class<*>,
+    val providerInstance: PreviewParameterProvider<*>,
+    val values: List<Any?>,
+    val currentIndex: Int = 0,
+) {
+    val size: Int get() = values.size
+    fun currentValue(): Any? = values.getOrNull(currentIndex)
+}
+
+/**
+ * v2.3 P1: `@PreviewParameter` Provider 集中管理.
+ *
+ * ## 模式
+ *
+ * ```kotlin
+ * val reg = PreviewParameterRegistry
+ * reg.register("MyPreviewFunction", "com.example.MyProvider")  // 启动时预加载
+ * val entry = reg.get("MyPreviewFunction")
+ * val currentValue = entry?.currentValue()
+ * reg.setIndex("MyPreviewFunction", index = 2)  // 切换 index → 触发 reRender
+ * ```
+ *
+ * ## 预加载
+ *
+ * 启动时通过 [register] 一次性 loadAll, 把 [PreviewParameterProvider.getValues] 物化为 List.
+ * 切换 index 不再触发反射 / getValues, 仅查 list.
+ *
+ * ## 多 Provider
+ *
+ * 同一 function 可有多个 `@PreviewParameter`. 通过 [registerAll] 一次性注册.
+ * 每个 provider 独立 [setIndex], 用 providerClassName 区分.
+ */
+class PreviewParameterRegistry private constructor() {
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(PreviewParameterRegistry::class.java)
+
+        /**
+         * v2.3 P1: 全局单例. 与 v2.2 P3 [LiveEditStatsRegistry] / v2.2 P7 [ErrorAggregatorRegistry]
+         * 模式一致 — atomic install, lazy get.
+         */
+        val instance: PreviewParameterRegistry = PreviewParameterRegistry()
+
+        fun get(): PreviewParameterRegistry = instance
+
+        fun install() {
+            // 启动时只标记 active, 不做 load. load 由调用方 register 触发.
+            instance.clear()
+        }
+
+        fun uninstall() {
+            instance.clear()
+        }
+    }
+
+    /** functionName → (providerClassName → [PreviewParameterEntry]). */
+    private val store = ConcurrentHashMap<String, ConcurrentHashMap<String, PreviewParameterEntry>>()
+
+    /**
+     * 注册一个 provider. 失败 (class 找不到 / 不是 PreviewParameterProvider / getValues 抛) 静默返回 false.
+     */
+    fun register(functionName: String, providerClassName: String): Boolean {
+        val providerClass = runCatching { Class.forName(providerClassName) }
+            .onFailure { LOG.warn("Provider class not found: {}", providerClassName) }
+            .getOrNull() ?: return false
+
+        val instance = runCatching {
+            val ctor = providerClass.getDeclaredConstructor()
+            ctor.isAccessible = true
+            ctor.newInstance()
+        }.onFailure { LOG.warn("Failed to instantiate provider: {}", providerClassName) }
+            .getOrNull() ?: return false
+
+        if (instance !is PreviewParameterProvider<*>) {
+            LOG.warn("Provider does not implement PreviewParameterProvider: {}", providerClassName)
+            return false
+        }
+
+        val values: List<Any?> = runCatching {
+            instance.values.toList()
+        }.onFailure { LOG.warn("getValues() failed for {}", providerClassName) }
+            .getOrElse { emptyList() }
+
+        val entry = PreviewParameterEntry(
+            providerClass = providerClass,
+            providerInstance = instance,
+            values = values,
+        )
+        store.computeIfAbsent(functionName) { ConcurrentHashMap() }[providerClassName] = entry
+        LOG.info("Registered provider: {} → {} ({} values)", functionName, providerClassName, values.size)
+        return true
+    }
+
+    /**
+     * 一次注册多个 providers (同一 function 的多个 @PreviewParameter).
+     */
+    fun registerAll(functionName: String, providerClassNames: List<String>): Int {
+        var ok = 0
+        providerClassNames.forEach { name -> if (register(functionName, name)) ok++ }
+        return ok
+    }
+
+    /**
+     * 取回 function 的所有 provider entries.
+     */
+    fun get(functionName: String): Map<String, PreviewParameterEntry> {
+        return store[functionName] ?: emptyMap()
+    }
+
+    /**
+     * 取回 (functionName, providerClassName) 的 entry.
+     */
+    fun getEntry(functionName: String, providerClassName: String): PreviewParameterEntry? {
+        return store[functionName]?.get(providerClassName)
+    }
+
+    /**
+     * 切换指定 provider 的 index. 返回更新后的 entry, null 表示没找到.
+     *
+     * 自动 bound check: 0 ≤ index < size. 越界 clamp 到合法范围.
+     */
+    fun setIndex(functionName: String, providerClassName: String, index: Int): PreviewParameterEntry? {
+        val map = store[functionName] ?: return null
+        val old = map[providerClassName] ?: return null
+        val newIndex = index.coerceIn(0, (old.size - 1).coerceAtLeast(0))
+        val updated = old.copy(currentIndex = newIndex)
+        map[providerClassName] = updated
+        return updated
+    }
+
+    /**
+     * 清空所有. UI 销毁时调用.
+     */
+    fun clear() {
+        store.clear()
+    }
+
+    fun functionCount(): Int = store.size
+    fun totalEntryCount(): Int = store.values.sumOf { it.size }
+
+    /**
+     * 列出所有已注册 function 名称. 顺序与 ConcurrentHashMap 一致 (不保证).
+     */
+    fun functionNames(): Set<String> = store.keys.toSet()
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DebugDrawer.kt
@@ -40,6 +40,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.OpenInNew
@@ -102,6 +104,8 @@ import com.itsaky.androidide.compose.preview.runtime.LiveEditState
 import com.itsaky.androidide.compose.preview.runtime.LiveEditStatsRegistry
 import com.itsaky.androidide.compose.preview.runtime.MultiPreviewRegistry
 import com.itsaky.androidide.compose.preview.runtime.PreviewDisplayMode
+import com.itsaky.androidide.compose.preview.runtime.PreviewParameterEntry
+import com.itsaky.androidide.compose.preview.runtime.PreviewParameterRegistry
 import com.itsaky.androidide.compose.preview.runtime.PreviewSlot
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.delay
@@ -933,6 +937,131 @@ fun GalleryPanel(
                 }
             }
         }
+
+        // v2.3 P1: @PreviewParameter Provider 状态
+        item {
+            PreviewParameterSection()
+        }
+    }
+}
+
+// =====================================================================
+// v2.3 P1 @PreviewParameter Provider UI
+// =====================================================================
+
+/**
+ * v2.3 P1: 在 GalleryPanel 显示已注册的 @PreviewParameter providers.
+ *
+ * 启动时 [PreviewParameterRegistry] 一次性 loadAll. 这里展示:
+ * - 总 functions / 总 entries
+ * - 每个 function 的所有 provider entries (providerClassName 截断 + 当前 index + size)
+ *
+ * 切换 index 由 ComposableRenderer 端的 [PreviewParameterIndexBar] 触发, 这里只显示状态.
+ */
+@Composable
+private fun PreviewParameterSection() {
+    val reg = PreviewParameterRegistry.get()
+    var tick by remember { mutableStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(500L)
+            tick++
+        }
+    }
+    @Suppress("UNUSED_EXPRESSION")
+    tick // 触发重组
+
+    val functionCount = reg.functionCount()
+    val totalEntries = reg.totalEntryCount()
+
+    StatsSection(title = "PreviewParameter (v2.3 P1)") {
+        StatsKeyValue("Functions", "$functionCount")
+        StatsKeyValue("Total entries", "$totalEntries")
+        if (functionCount == 0) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = "  (无 provider 注册) @PreviewParameter(provider = X::class) 在 @Preview 函数上.",
+                color = Color(0xFF666666),
+                fontSize = 10.sp,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            )
+        } else {
+            Spacer(Modifier.height(2.dp))
+            reg.functionNames().forEach { fnName ->
+                val entries = reg.get(fnName)
+                entries.forEach { (providerClassName, entry) ->
+                    ParameterProviderRow(
+                        functionName = fnName,
+                        providerClassName = providerClassName,
+                        entry = entry,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 单个 provider row. 包含: 函数名 + provider 简短名 + 上页/下页箭头 + index 计数.
+ */
+@Composable
+private fun ParameterProviderRow(
+    functionName: String,
+    providerClassName: String,
+    entry: PreviewParameterEntry,
+) {
+    val simpleProviderName = providerClassName.substringAfterLast('.')
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp)
+            .background(Color(0xFF1A1A22))
+            .padding(horizontal = 6.dp, vertical = 4.dp),
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "$functionName · $simpleProviderName",
+                color = Color(0xFFE0E0E0),
+                fontSize = 10.sp,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            )
+            Text(
+                text = "${entry.currentIndex + 1}/${entry.size}  ${entry.currentValue()?.toString()?.take(30) ?: "(empty)"}",
+                color = Color(0xFF80CBC4),
+                fontSize = 9.sp,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            )
+        }
+        // Prev / Next 按钮
+        Icon(
+            imageVector = Icons.Filled.ChevronLeft,
+            contentDescription = "Prev",
+            modifier = Modifier
+                .size(20.dp)
+                .clickable {
+                    PreviewParameterRegistry.get().setIndex(
+                        functionName, providerClassName, entry.currentIndex - 1
+                    )
+                }
+                .padding(2.dp),
+            tint = if (entry.currentIndex > 0) Color(0xFF80CBC4) else Color(0xFF444444),
+        )
+        Icon(
+            imageVector = Icons.Filled.ChevronRight,
+            contentDescription = "Next",
+            modifier = Modifier
+                .size(20.dp)
+                .clickable {
+                    PreviewParameterRegistry.get().setIndex(
+                        functionName, providerClassName, entry.currentIndex + 1
+                    )
+                }
+                .padding(2.dp),
+            tint = if (entry.currentIndex < entry.size - 1) Color(0xFF80CBC4) else Color(0xFF444444),
+        )
     }
 }
 

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/PreviewParameterRegistryTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/PreviewParameterRegistryTest.kt
@@ -1,0 +1,204 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * v2.3 P1 单元测试.
+ *
+ * - register / getEntry
+ * - setIndex 边界 (越界 clamp)
+ * - 多 provider 同 function
+ * - clear / install / uninstall
+ * - register 失败 (class 不存在 / 不是 PreviewParameterProvider)
+ */
+class PreviewParameterRegistryTest {
+
+    @After
+    fun tearDown() {
+        PreviewParameterRegistry.uninstall()
+    }
+
+    // --- helper providers ---
+
+    class ColorProvider : PreviewParameterProvider<String> {
+        override val values: Sequence<String> = sequenceOf("red", "green", "blue")
+    }
+
+    class IntProvider : PreviewParameterProvider<Int> {
+        override val values: Sequence<Int> = sequenceOf(10, 20, 30, 40)
+    }
+
+    class EmptyProvider : PreviewParameterProvider<String> {
+        override val values: Sequence<String> = emptySequence()
+    }
+
+    class ThrowingProvider : PreviewParameterProvider<String> {
+        override val values: Sequence<String> = throw RuntimeException("boom")
+    }
+
+    class NotAProvider  // 没有实现 PreviewParameterProvider
+
+    @Test
+    fun `01 register loads values eagerly`() {
+        val reg = PreviewParameterRegistry.get()
+        val ok = reg.register("MyPreview", ColorProvider::class.java.name)
+        assertTrue(ok)
+        val entry = reg.getEntry("MyPreview", ColorProvider::class.java.name)
+        assertNotNull(entry)
+        assertEquals(3, entry!!.size)
+        assertEquals("red", entry.currentValue())
+    }
+
+    @Test
+    fun `02 setIndex changes current value`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("MyPreview", ColorProvider::class.java.name)
+        val updated = reg.setIndex("MyPreview", ColorProvider::class.java.name, 2)
+        assertEquals("blue", updated?.currentValue())
+    }
+
+    @Test
+    fun `03 setIndex out of bounds clamps to 0`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("MyPreview", ColorProvider::class.java.name)
+        val updated = reg.setIndex("MyPreview", ColorProvider::class.java.name, 99)
+        assertEquals(0, updated?.currentIndex)
+    }
+
+    @Test
+    fun `04 setIndex negative clamps to 0`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("MyPreview", ColorProvider::class.java.name)
+        val updated = reg.setIndex("MyPreview", ColorProvider::class.java.name, -1)
+        assertEquals(0, updated?.currentIndex)
+    }
+
+    @Test
+    fun `05 registerAll loads multiple providers`() {
+        val reg = PreviewParameterRegistry.get()
+        val ok = reg.registerAll("MultiPreview", listOf(
+            ColorProvider::class.java.name,
+            IntProvider::class.java.name,
+        ))
+        assertEquals(2, ok)
+        val entries = reg.get("MultiPreview")
+        assertEquals(2, entries.size)
+        assertEquals(3, entries[ColorProvider::class.java.name]?.size)
+        assertEquals(4, entries[IntProvider::class.java.name]?.size)
+    }
+
+    @Test
+    fun `06 independent setIndex per provider`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.registerAll("MultiPreview", listOf(
+            ColorProvider::class.java.name,
+            IntProvider::class.java.name,
+        ))
+        reg.setIndex("MultiPreview", ColorProvider::class.java.name, 1)  // green
+        reg.setIndex("MultiPreview", IntProvider::class.java.name, 3)    // 40
+        val color = reg.getEntry("MultiPreview", ColorProvider::class.java.name)
+        val int = reg.getEntry("MultiPreview", IntProvider::class.java.name)
+        assertEquals("green", color?.currentValue())
+        assertEquals(40, int?.currentValue())
+    }
+
+    @Test
+    fun `07 register unknown class returns false silently`() {
+        val reg = PreviewParameterRegistry.get()
+        val ok = reg.register("MyPreview", "com.example.NonExistent")
+        assertEquals(false, ok)
+        assertEquals(0, reg.functionCount())
+    }
+
+    @Test
+    fun `08 register non-PreviewParameterProvider class returns false`() {
+        val reg = PreviewParameterRegistry.get()
+        val ok = reg.register("MyPreview", NotAProvider::class.java.name)
+        assertEquals(false, ok)
+    }
+
+    @Test
+    fun `09 register empty provider loads empty values`() {
+        val reg = PreviewParameterRegistry.get()
+        val ok = reg.register("MyPreview", EmptyProvider::class.java.name)
+        assertTrue(ok)
+        val entry = reg.getEntry("MyPreview", EmptyProvider::class.java.name)
+        assertEquals(0, entry!!.size)
+    }
+
+    @Test
+    fun `10 register throwing provider returns false`() {
+        val reg = PreviewParameterRegistry.get()
+        val ok = reg.register("MyPreview", ThrowingProvider::class.java.name)
+        assertEquals(false, ok)
+    }
+
+    @Test
+    fun `11 getEntry for unknown function returns null`() {
+        val reg = PreviewParameterRegistry.get()
+        val entry = reg.getEntry("Unknown", ColorProvider::class.java.name)
+        assertNull(entry)
+    }
+
+    @Test
+    fun `12 clear empties store`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("A", ColorProvider::class.java.name)
+        reg.register("B", IntProvider::class.java.name)
+        assertEquals(2, reg.functionCount())
+        reg.clear()
+        assertEquals(0, reg.functionCount())
+    }
+
+    @Test
+    fun `13 install clears existing state`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("A", ColorProvider::class.java.name)
+        assertEquals(1, reg.functionCount())
+        PreviewParameterRegistry.install()
+        assertEquals(0, reg.functionCount())
+    }
+
+    @Test
+    fun `14 setIndex on empty entry (size=0) clamps to 0`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("MyPreview", EmptyProvider::class.java.name)
+        val updated = reg.setIndex("MyPreview", EmptyProvider::class.java.name, 5)
+        assertEquals(0, updated?.currentIndex)
+    }
+
+    @Test
+    fun `15 totalEntryCount counts across functions`() {
+        val reg = PreviewParameterRegistry.get()
+        reg.register("A", ColorProvider::class.java.name)  // 1 entry
+        reg.registerAll("B", listOf(                       // 2 entries
+            ColorProvider::class.java.name,
+            IntProvider::class.java.name,
+        ))
+        assertEquals(2, reg.functionCount())
+        assertEquals(3, reg.totalEntryCount())
+    }
+}


### PR DESCRIPTION
## Summary

v2.3 P1 — @PreviewParameter DataSet 切换:
- 反射 `@PreviewParameter(provider = X::class)` (regex 由 v2.1 PreviewSourceParser 已抽)
- `PreviewParameterRegistry` 单例: 启动时 register 一次, 物化 `getValues()` 为 List
- 每 (functionName, providerClassName) 独立 `currentIndex`
- `setIndex` 越界 clamp 到合法范围
- `GalleryPanel` 新增 `PreviewParameterSection` 显示状态 + `ChevronLeft/Right` 切换箭头
- 失败 (class 不存在 / 非 PreviewParameterProvider / getValues 抛) 静默返回 false

## New Files

### `runtime/PreviewParameterRegistry.kt` (+180 行)
- `PreviewParameterEntry` data class: providerClass / providerInstance / values (List) / currentIndex
- `register(functionName, providerClassName)`: 反射 `getDeclaredConstructor().newInstance()` + cast `PreviewParameterProvider<*>` + 物化 `values.toList()`
- `registerAll(functionName, list)`: 批量注册
- `get / getEntry / setIndex`: 访问与索引切换
- `setIndex` 越界 `coerceIn(0, size-1)` clamp
- `functionNames / functionCount / totalEntryCount`: 状态查询
- 单例 `instance` + `install/uninstall` (与 v2.2 P3/P7 registry 模式一致)

### `test/PreviewParameterRegistryTest.kt` (+220 行, 15 case)
- `01 register loads values eagerly` (3 values)
- `02 setIndex changes current value`
- `03 setIndex out of bounds clamps to 0`
- `04 setIndex negative clamps to 0`
- `05 registerAll loads multiple providers`
- `06 independent setIndex per provider`
- `07 register unknown class returns false silently`
- `08 register non-PreviewParameterProvider class returns false`
- `09 register empty provider loads empty values`
- `10 register throwing provider returns false`
- `11 getEntry for unknown function returns null`
- `12 clear empties store`
- `13 install clears existing state`
- `14 setIndex on empty entry (size=0) clamps to 0`
- `15 totalEntryCount counts across functions`

## Modified Files

### `ui/DebugDrawer.kt` (+108 行)
- import: `ChevronLeft/Right` + `PreviewParameterEntry/Registry`
- `GalleryPanel` 末尾加 `PreviewParameterSection` 新的 stats section
- `PreviewParameterSection` composable: 500ms 刷新 + 显示 Functions / Total entries + 列出所有 entries
- `ParameterProviderRow` composable: functionName + provider 简短名 + 当前 index/total + 当前值截断 30 字符 + Prev/Next 箭头 (越界 disabled tint)

## Architecture

```
启动时 (ComposePreviewViewModel)
  → PreviewParameterRegistry.install()
       └ clear()
  → 遍历所有 ParsedPreviewPreview, 取 parameterProviderName
       └ registry.register(functionName, providerClassName)
            ├ Class.forName(providerClassName)
            ├ providerClass.getDeclaredConstructor().newInstance()
            ├ cast to PreviewParameterProvider<*>
            └ instance.values.toList()  // 物化为 List
  → 存到 store: functionName → (providerClassName → PreviewParameterEntry)

GalleryPanel 500ms 轮询
  → 读 PreviewParameterRegistry.functionCount() / functionNames() / get(fn)
  → 显示 + Prev/Next 箭头
       └ user click → registry.setIndex(fn, provider, newIndex)
            └ entry.copy(currentIndex = newIndex)  → 触发 Compose 重组 → 重新渲染 (re-render 由 ComposableRenderer 端订阅 currentIndex)
```

## Related

- Base: `feat/compose-preview-v2.3-p0-multi-module` (PR #348)
- v2.3 PR 链: **#348** → **#349 (本)**
- 后续: v2.3 P2 设备 profile 矩阵 / v2.3 P3 Snapshot
