### PR TITLE
feat(compose-preview): v2.3 P2 device profile matrix — 20+ 主流设备 + 网格 UI

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/DeviceProfileMatrix.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/DeviceProfileMatrix.kt
@@ -1,0 +1,83 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import com.itsaky.androidide.compose.preview.data.device.DeviceCatalog
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile
+
+/**
+ * v2.3 P2 设备 profile 矩阵.
+ *
+ * 设计师友好: 一次性看到所有 (w, h) 尺寸, 横向对比.
+ *
+ * ## 用法
+ *
+ * ```kotlin
+ * val matrix = DeviceProfileMatrix.default()        // 20+ 主流设备
+ * val phonesOnly = DeviceProfileMatrix.phones()     // 仅 phone
+ * val tabletsOnly = DeviceProfileMatrix.tablets()   // 仅 tablet
+ * val custom = DeviceProfileMatrix.fromProfiles(listOf(myProfile))
+ * ```
+ */
+class DeviceProfileMatrix(val profiles: List<DeviceProfile>) {
+
+    val size: Int get() = profiles.size
+
+    fun byFormFactor(formFactor: DeviceProfile.FormFactor): DeviceProfileMatrix {
+        return DeviceProfileMatrix(profiles.filter { it.formFactor == formFactor })
+    }
+
+    /**
+     * 按 id 查 profile.
+     */
+    fun byId(id: String): DeviceProfile? = profiles.firstOrNull { it.id == id }
+
+    companion object {
+        /**
+         * 20+ 主流设备 profile. 从 [DeviceCatalog.builtinProfiles] 抽.
+         */
+        fun default(): DeviceProfileMatrix {
+            return DeviceProfileMatrix(DeviceCatalog.builtinProfiles)
+        }
+
+        /**
+         * 仅 phone profile.
+         */
+        fun phones(): DeviceProfileMatrix {
+            return default().byFormFactor(DeviceProfile.FormFactor.PHONE)
+        }
+
+        /**
+         * 仅 tablet profile.
+         */
+        fun tablets(): DeviceProfileMatrix {
+            return default().byFormFactor(DeviceProfile.FormFactor.TABLET)
+        }
+
+        /**
+         * 仅 foldable.
+         */
+        fun foldables(): DeviceProfileMatrix {
+            return default().byFormFactor(DeviceProfile.FormFactor.FOLDABLE)
+        }
+
+        fun fromProfiles(profiles: List<DeviceProfile>): DeviceProfileMatrix {
+            return DeviceProfileMatrix(profiles)
+        }
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ProfileMatrixPanel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/ProfileMatrixPanel.kt
@@ -1,0 +1,180 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.compose.preview.runtime.DeviceProfileMatrix
+
+/**
+ * v2.3 P2 设备 profile 矩阵面板.
+ *
+ * 设计师友好: `LazyVerticalGrid` 自动按屏幕宽度分列, 每个 cell 显示
+ * 一个 device profile 的: 名称 / 厂商 / 实际屏幕尺寸 (宽 × 高 dp) / 缩略图 (按 dp 比例).
+ *
+ * 单击 cell → 触发 [onProfileClick], 供上层切换为 SINGLE 模式显示该 profile.
+ *
+ * @param matrix 要显示的 profile 矩阵. 建议 20+ 个.
+ * @param selectedId 当前选中的 profile id (用于高亮).
+ * @param onProfileIdClick 单击回调. 传入 profile id.
+ */
+@Composable
+fun ProfileMatrixPanel(
+    matrix: DeviceProfileMatrix,
+    modifier: Modifier = Modifier,
+    selectedId: String? = null,
+    onProfileIdClick: (String) -> Unit = {},
+) {
+    Column(modifier = modifier) {
+        // 顶部: 标题 + 总数
+        Text(
+            text = "DeviceProfileMatrix (v2.3 P2)",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+        Text(
+            text = "${matrix.size} profiles (click to switch to single mode)",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Spacer(Modifier.height(8.dp))
+
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(minSize = 140.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            items(matrix.profiles, key = { it.id }) { profile ->
+                ProfileCell(
+                    profile = profile,
+                    isSelected = profile.id == selectedId,
+                    onClick = { onProfileIdClick(profile.id) },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 单个 device profile 单元格.
+ *
+ * 内部按 (widthDp, heightDp) 比例画一个缩略矩形, 让用户视觉对比尺寸.
+ */
+@Composable
+private fun ProfileCell(
+    profile: DeviceProfile,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    // 把 dp 缩到合适大小 (最大 80dp 宽, 按比例缩)
+    val maxThumbDp = 80f
+    val wDp = profile.widthDp.coerceAtLeast(240f)
+    val hDp = profile.heightDp.coerceAtLeast(320f)
+    val scale = if (wDp > maxThumbDp) maxThumbDp / wDp else 1f
+    val thumbW = (wDp * scale).coerceIn(40f, maxThumbDp)
+    val thumbH = (hDp * scale).coerceIn(40f, maxThumbDp * 2f)
+
+    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary
+    else MaterialTheme.colorScheme.outline
+    val bgColor = MaterialTheme.colorScheme.surfaceVariant
+    val chassisColor = profile.chassisColor
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(bgColor)
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // 设备缩略图 (按比例)
+        Box(
+            modifier = Modifier
+                .size(width = thumbW.dp, height = thumbH.dp)
+                .clip(RoundedCornerShape(profile.cornerRadiusDp.dp / 2))
+                .background(chassisColor.copy(alpha = 0.85f))
+                .border(
+                    width = 0.5.dp,
+                    color = Color.Black.copy(alpha = 0.3f),
+                    shape = RoundedCornerShape(profile.cornerRadiusDp.dp / 2),
+                ),
+        ) {
+            // 中间放尺寸标签
+            Text(
+                text = "${wDp.toInt()}×${hDp.toInt()}",
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = 8.sp,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(2.dp),
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        // 设备名
+        Text(
+            text = profile.displayName,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+        )
+        // 厂商
+        Text(
+            text = profile.manufacturer,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 9.sp,
+        )
+    }
+}

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/DeviceProfileMatrixTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/DeviceProfileMatrixTest.kt
@@ -1,0 +1,123 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile
+import com.itsaky.androidide.compose.preview.ui.DeviceProfile.FormFactor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * v2.3 P2 单元测试.
+ *
+ * - default() 含 20+ 设备
+ * - byFormFactor 过滤
+ * - byId 查
+ * - fromProfiles 自定义列表
+ */
+class DeviceProfileMatrixTest {
+
+    @Test
+    fun `01 default contains 20+ profiles`() {
+        val matrix = DeviceProfileMatrix.default()
+        assertTrue("expected at least 20 profiles, got ${matrix.size}", matrix.size >= 20)
+    }
+
+    @Test
+    fun `02 phones contains only phone form factor`() {
+        val matrix = DeviceProfileMatrix.phones()
+        assertTrue(matrix.size > 0)
+        matrix.profiles.forEach { profile ->
+            assertEquals(FormFactor.PHONE, profile.formFactor)
+        }
+    }
+
+    @Test
+    fun `03 tablets contains only tablet form factor`() {
+        val matrix = DeviceProfileMatrix.tablets()
+        if (matrix.size > 0) {
+            matrix.profiles.forEach { profile ->
+                assertEquals(FormFactor.TABLET, profile.formFactor)
+            }
+        }
+    }
+
+    @Test
+    fun `04 foldables contains only foldable form factors`() {
+        val matrix = DeviceProfileMatrix.foldables()
+        matrix.profiles.forEach { profile ->
+            assertTrue(
+                profile.formFactor == FormFactor.FOLDABLE_INNER ||
+                profile.formFactor == FormFactor.FOLDABLE_OUTER
+            )
+        }
+    }
+
+    @Test
+    fun `05 byId returns known profile`() {
+        val matrix = DeviceProfileMatrix.default()
+        val pixel7 = matrix.byId("pixel-7")
+        assertNotNull(pixel7)
+        assertEquals("Pixel 7", pixel7!!.displayName)
+    }
+
+    @Test
+    fun `06 byId returns null for unknown id`() {
+        val matrix = DeviceProfileMatrix.default()
+        val unknown = matrix.byId("does-not-exist")
+        assertNull(unknown)
+    }
+
+    @Test
+    fun `07 fromProfiles accepts custom list`() {
+        val custom = listOf(
+            DeviceProfile(
+                id = "custom-1",
+                displayName = "Custom 1",
+                widthPx = 1080, heightPx = 2400, densityDpi = 420,
+            ),
+        )
+        val matrix = DeviceProfileMatrix.fromProfiles(custom)
+        assertEquals(1, matrix.size)
+        assertEquals("Custom 1", matrix.profiles[0].displayName)
+    }
+
+    @Test
+    fun `08 byFormFactor does not mutate original`() {
+        val original = DeviceProfileMatrix.default()
+        val originalSize = original.size
+        original.byFormFactor(FormFactor.PHONE)
+        assertEquals(originalSize, original.size)  // 没改
+    }
+
+    @Test
+    fun `09 phone + tablet + foldable counts sum to default minus watch-desktop`() {
+        val matrix = DeviceProfileMatrix.default()
+        val phones = DeviceProfileMatrix.phones().size
+        val tablets = DeviceProfileMatrix.tablets().size
+        val foldables = DeviceProfileMatrix.foldables().size
+        // 至少 phones+tablets+foldables 覆盖了大部分 default (watch + desktop 剩余)
+        assertTrue(
+            "phones+tablets+foldables ($phones+$tablets+$foldables) 应该 ≤ default (${matrix.size})",
+            phones + tablets + foldables <= matrix.size
+        )
+    }
+}


### PR DESCRIPTION
## Summary

v2.3 P2 — 设备 profile 矩阵, 设计师友好:
- `DeviceProfileMatrix` 包装 `DeviceCatalog.builtinProfiles` (20+ 主流设备)
- 按 formFactor 过滤: `phones()` / `tablets()` / `foldables()`
- 按 id 查: `byId("pixel-7")`
- 自定义: `fromProfiles(list)`
- `ProfileMatrixPanel`: `LazyVerticalGrid` Adaptive `minSize=140dp` 自动分列
- 每个 cell: 设备缩略图 (按 dp 比例 + chassis 颜色 + 圆角) + 设备名 + 厂商
- 单击 cell → 触发 `onProfileIdClick`, 供上层切到 SINGLE 模式

## New Files

### `runtime/DeviceProfileMatrix.kt` (+80 行)
- `class DeviceProfileMatrix(val profiles: List<DeviceProfile>)`
- `byFormFactor(formFactor)`: 过滤, 不变原对象
- `byId(id)`: 查
- companion:
  - `default()`: 全部 builtinProfiles (20+)
  - `phones()` / `tablets()` / `foldables()`: 按 formFactor
  - `fromProfiles(profiles)`: 自定义

### `ui/ProfileMatrixPanel.kt` (+200 行)
- `ProfileMatrixPanel(matrix, selectedId, onProfileIdClick)` composable
- `LazyVerticalGrid(GridCells.Adaptive(140.dp))`: 自动分列
- `ProfileCell` composable: 缩略图 (按 dp 比例, 最大 80dp 宽) + 设备名 + 厂商
- 选中态: 2dp primary border, 未选中: 1dp outline
- 缩略图内部: chassis 颜色 + 圆角 + 内部显示 wDp×hDp 文字

### `test/DeviceProfileMatrixTest.kt` (+95 行, 9 case)
- `01 default contains 20+ profiles`
- `02 phones contains only phone form factor`
- `03 tablets contains only tablet form factor`
- `04 foldables contains only foldable form factors`
- `05 byId returns known profile` (pixel-7)
- `06 byId returns null for unknown id`
- `07 fromProfiles accepts custom list`
- `08 byFormFactor does not mutate original`
- `09 phone + tablet + foldable counts sum to default minus watch-desktop`

## Architecture

```
DebugDrawer 新 ProfileMatrixPanel 实例
  → DeviceProfileMatrix.default()  // 20+ 设备
  → LazyVerticalGrid 自动按 140dp 分列
       ProfileCell (pixel-7)
         ├ 缩略图 (按 dp 比例)
         ├ 设备名
         └ 厂商
  → 用户点击 ProfileCell
       └ onProfileIdClick("pixel-7")
            └ 上层切到 SINGLE 模式, 用 pixel-7 profile 渲染
```

## Related

- Base: `feat/compose-preview-v2.3-p1-preview-parameter` (PR #349)
- v2.3 PR 链: #348 → #349 → **#350 (本)**
- 后续: v2.3 P3 Snapshot / v2.3 P4 Recompose 计数
