### PR TITLE
feat(compose-preview): v2.5 P2 PerfPanel mmap 集成 + Registry + Evictor

### DIFF
--- a/modules/compose-preview/TODO.md
+++ b/modules/compose-preview/TODO.md
@@ -517,3 +517,24 @@ v2.5 P2 推进 3 个子项,共 5 文件 / +337/-1。
 | DexMmapPoolRegistry stats 拉取 | < 1µs | AtomicReference.get |
 | DexMmapPoolEvictor 启动开销 | < 5ms | SupervisorJob + Dispatchers.Default |
 | Evict 单次 (5 stale entry) | < 10ms | ConcurrentHashMap iter + Cleaner |
+
+---
+
+## v2.5 P3 完成总结 (PR #356)
+
+v2.5 P3 推进 Evictor 生命周期集成,共 3 文件 / +91/-2。
+
+### P3 Evictor 生命周期 (PR #356)
+
+- [x] `v25P3-RT-01` `ComposePreviewFragment.kt` — `mmapEvictor: DexMmapPoolEvictor?` 字段
+- [x] `v25P3-RT-02` `onViewCreated` 启动 evictor (idempotent 检查)
+- [x] `v25P3-RT-03` `onDestroyView` 停止 evictor (合并到既有清理逻辑)
+- [x] `v25P3-TS-01` `EvictorLifecycleTest.kt` — 4 case (lifecycle host / 幂等 / 顺序无关 / 实际 evict)
+
+### 生命周期 / 资源基线
+
+| 指标 | 目标 | 备注 |
+| --- | --- | --- |
+| Evictor start 延迟 | < 5ms | 仅启动后台 coroutine |
+| Evictor stop 延迟 | < 10ms | cancel + scope shutdown |
+| 视图销毁 → evict 停止 | 0 leak | onDestroyView 立即清引用 |

--- a/modules/compose-preview/TODO.md
+++ b/modules/compose-preview/TODO.md
@@ -478,3 +478,42 @@ v2.5 P0 推进 3 个 P3-FE 子项,共 7 文件 / +1085 / -13。
 | PreviewServer 端到端 (mock) | < 5ms | 127.0.0.1 loopback |
 | AdbForwardTunnel 命令超时 | 5s | 强制 destroyForcibly |
 | RemoteProfileRepository fetch | < 5s | 5s HttpURLConnection |
+
+---
+
+## v2.5 P1 完成总结 (PR #354)
+
+v2.5 P1 把 v2.5 P0 引入的 `DexMmapPool` 接入 `ComposeClassLoader`,共 1 文件 / +77/-2。
+
+### P1 DexMmapPool 集成 (PR #354)
+
+- [x] `v25P1-RT-01` `ComposeClassLoader.kt` — DexMmapPool 注入构造器
+- [x] `v25P1-RT-02` `getOrCreateLoader` 流程加 mmap acquire + dex magic 校验
+- [x] `v25P1-RT-03` `invalidateAll` 增强 — 归还所有 loader 关联的 mmap 引用
+- [x] `v25P1-RT-04` `mmapStats()` / `mmapBytes` 暴露 getter
+- [x] `v25P1-RT-05` `DEX_MAGIC` 常量 = `dex\n` 4 字节
+
+集成测试推迟 (依赖 Android Context, 沙箱无 Robolectric, CI 跑 instrumented test)。
+
+---
+
+## v2.5 P2 完成总结 (PR #355)
+
+v2.5 P2 推进 3 个子项,共 5 文件 / +337/-1。
+
+### P2 PerfPanel mmap 集成 (PR #355)
+
+- [x] `v25P2-RT-01` `DexMmapPoolRegistry.kt` — 全局单例, AtomicReference + getOrCreate + install + stats + evictStale + reset
+- [x] `v25P2-RT-02` `DexMmapPoolEvictor.kt` — 协程定时 evict (默认 10 分钟) + 累计计数
+- [x] `v25P2-RT-03` `ComposeClassLoader.kt` — 默认 mmapPool 改为 `DexMmapPoolRegistry.getOrCreate()` + init 注册
+- [x] `v25P2-UI-01` `PerfPanel.kt` 加 `MmapPoolSection` 卡片 — active / hit / acq / rel + Evict 按钮
+- [x] `v25P2-TS-01` `DexMmapPoolRegistryTest.kt` — 7 case (install / lazy / stats / evict / reset / 替换)
+- [x] `v25P2-TS-02` `DexMmapPoolEvictorTest.kt` — 5 case (start / 幂等 / stop / 定时触发 / 初始 0)
+
+### 性能 / evict 基线
+
+| 指标 | 目标 | 备注 |
+| --- | --- | --- |
+| DexMmapPoolRegistry stats 拉取 | < 1µs | AtomicReference.get |
+| DexMmapPoolEvictor 启动开销 | < 5ms | SupervisorJob + Dispatchers.Default |
+| Evict 单次 (5 stale entry) | < 10ms | ConcurrentHashMap iter + Cleaner |

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewFragment.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.itsaky.androidide.compose.preview.databinding.FragmentComposePreviewBinding
 import com.itsaky.androidide.compose.preview.runtime.ComposeClassLoader
 import com.itsaky.androidide.compose.preview.runtime.ComposableRenderer
+import com.itsaky.androidide.compose.preview.runtime.DexMmapPoolEvictor
 import com.itsaky.androidide.resources.R as ResourcesR
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
@@ -27,6 +28,8 @@ class ComposePreviewFragment : Fragment() {
 
     private var classLoader: ComposeClassLoader? = null
     private var renderer: ComposableRenderer? = null
+    // v2.5 P3: 定时 evict 调度器, 随 fragment 视图生命周期启停
+    private var mmapEvictor: DexMmapPoolEvictor? = null
 
     private var sourceCode: String = DEFAULT_SOURCE
     private var onNavigateBack: (() -> Unit)? = null
@@ -47,12 +50,30 @@ class ComposePreviewFragment : Fragment() {
         setupPreview()
         observeState()
 
+        // v2.5 P3: 启动 mmap evict 调度器, 定时释放 refCount=0 的 stale entry
+        if (mmapEvictor == null) {
+            mmapEvictor = DexMmapPoolEvictor().apply { start() }
+            LOG.info("ComposePreviewFragment started mmap evictor")
+        }
+
         val filePath = arguments?.getString(ARG_FILE_PATH) ?: ""
         viewModel.initialize(requireContext(), filePath)
 
         arguments?.getString(ARG_SOURCE_CODE)?.let {
             sourceCode = it
         }
+    }
+
+    override fun onDestroyView() {
+        // v2.5 P3: 停止 mmap evict 调度器, 释放后台协程
+        mmapEvictor?.stop()
+        mmapEvictor = null
+        LOG.info("ComposePreviewFragment stopped mmap evictor")
+        super.onDestroyView()
+        classLoader?.release()
+        classLoader = null
+        renderer = null
+        _binding = null
     }
 
     private fun setupToolbar() {
@@ -149,14 +170,6 @@ class ComposePreviewFragment : Fragment() {
 
     fun setNavigateBackListener(listener: () -> Unit) {
         onNavigateBack = listener
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        classLoader?.release()
-        classLoader = null
-        renderer = null
-        _binding = null
     }
 
     override fun onLowMemory() {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ComposeClassLoader.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/ComposeClassLoader.kt
@@ -33,7 +33,16 @@ import java.util.concurrent.ConcurrentHashMap
  *   不会触发优化, 直接走 system classloader.
  * - **可监控**: 暴露 [loadedClassCount] / [activeLoaderCount] 给上层做监控.
  */
-class ComposeClassLoader(private val context: Context) {
+class ComposeClassLoader(
+    private val context: Context,
+    // v2.5 P1: DexMmapPool 集成, 零拷贝共享 dex 字节
+    private val mmapPool: DexMmapPool = DexMmapPoolRegistry.getOrCreate(),
+) {
+
+    init {
+        // v2.5 P2: 把构造时使用的 mmapPool 注册到全局 Registry (供 UI 端 PerfPanel 访问)
+        DexMmapPoolRegistry.install(mmapPool)
+    }
 
     private val LOG = LoggerFactory.getLogger(ComposeClassLoader::class.java)
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolEvictor.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolEvictor.kt
@@ -1,0 +1,113 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * v2.5 P2: DexMmapPool 定时 evict 调度器.
+ *
+ * ## 设计目标
+ *
+ * [DexMmapPool.evictStale] 释放 5 分钟以上无引用的 mmap entry. 但实际项目中需要
+ * 有人定时触发这个清理, 否则 mmap 永远占用物理页. 本类用协程定时 (默认 10 分钟) 跑一次.
+ *
+ * ## 用法
+ *
+ * ```
+ * // 在 DebugDrawer / Application onCreate
+ * val evictor = DexMmapPoolEvictor()
+ * evictor.start()
+ *
+ * // UI destroy / 进程退出
+ * evictor.stop()
+ * ```
+ *
+ * ## 线程模型
+ *
+ * - 后台 coroutine (Dispatchers.Default) 定时触发
+ * - [start] 幂等 (compareAndSet)
+ * - [stop] 取消 scope
+ * - [evictCount] 统计累计 evict 次数
+ */
+class DexMmapPoolEvictor(
+    private val pool: DexMmapPool = DexMmapPoolRegistry.getOrCreate(),
+    private val intervalMs: Long = DEFAULT_INTERVAL_MS,
+    private val maxAgeMs: Long = DEFAULT_MAX_AGE_MS,
+) {
+
+    private val running = java.util.concurrent.atomic.AtomicBoolean(false)
+    private var scope: CoroutineScope? = null
+    private var job: Job? = null
+
+    private val evictCount = AtomicLong(0L)
+    private val evictedEntries = AtomicLong(0L)
+
+    /** 启动定时 evict. 幂等. */
+    fun start() {
+        if (!running.compareAndSet(false, true)) return
+        val s = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope = s
+        job = s.launch {
+            while (isActive) {
+                delay(intervalMs)
+                try {
+                    val n = pool.evictStale(maxAgeMs)
+                    if (n > 0) {
+                        evictCount.incrementAndGet()
+                        evictedEntries.addAndGet(n.toLong())
+                    }
+                } catch (e: Throwable) {
+                    // 后台异常, 不抛
+                }
+            }
+        }
+    }
+
+    fun isRunning(): Boolean = running.get()
+
+    /** 累计触发次数. */
+    fun evictRunCount(): Long = evictCount.get()
+
+    /** 累计释放的 entry 数. */
+    fun evictedEntryCount(): Long = evictedEntries.get()
+
+    fun stop() {
+        if (!running.compareAndSet(true, false)) return
+        job?.cancel()
+        scope?.cancel()
+        job = null
+        scope = null
+    }
+
+    companion object {
+        /** 10 分钟 evict 一次. */
+        const val DEFAULT_INTERVAL_MS: Long = 10L * 60_000L
+
+        /** 5 分钟无引用的 entry 视为 stale. */
+        const val DEFAULT_MAX_AGE_MS: Long = 5L * 60_000L
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolRegistry.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolRegistry.kt
@@ -1,0 +1,78 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * v2.5 P2: 全局 [DexMmapPool] 注册中心.
+ *
+ * ## 用途
+ *
+ * UI 层 ([com.itsaky.androidide.compose.preview.ui.PerfPanel] / DebugDrawer) 需要
+ * 读取 mmap pool 统计, 但 [ComposeClassLoader] 持有的是 private 字段. 通过本 Registry
+ * 提供一个全局访问点, ComposeClassLoader 在构造时 install, UI 端通过 [getOrCreate]
+ * / [stats] / [pool] 拉取.
+ *
+ * ## 用法
+ *
+ * ```
+ * // 在 ComposeClassLoader 构造时
+ * DexMmapPoolRegistry.install(mmapPool)
+ *
+ * // UI 端
+ * val stats = DexMmapPoolRegistry.stats()
+ * println("active=${stats.activeEntries} hitRate=${stats.hitRate}")
+ * ```
+ *
+ * ## 线程模型
+ *
+ * - [install] / [getOrCreate] 原子 (AtomicReference + getAndSet / compareAndSet)
+ * - [stats] 无锁读
+ * - [reset] 测试用
+ */
+object DexMmapPoolRegistry {
+
+    private val ref = AtomicReference<DexMmapPool?>(null)
+
+    /** 安装 (或替换) 全局 pool. */
+    fun install(pool: DexMmapPool) {
+        ref.set(pool)
+    }
+
+    /** 获取已安装的 pool, 否则 lazy 创建. */
+    fun getOrCreate(): DexMmapPool = ref.get() ?: synchronized(this) {
+        ref.get() ?: DexMmapPool().also { ref.set(it) }
+    }
+
+    /** 当前 pool (可能 null). */
+    fun pool(): DexMmapPool? = ref.get()
+
+    /** 直接拉取 stats, 没安装时返回空. */
+    fun stats(): DexMmapPool.PoolStats =
+        ref.get()?.stats() ?: DexMmapPool.PoolStats(0, 0, 0, 0, 0)
+
+    /** 触发一次 evictStale, 返回释放的 entry 数. */
+    fun evictStale(maxAgeMs: Long): Int =
+        ref.get()?.evictStale(maxAgeMs) ?: 0
+
+    /** 测试 / 进程退出时清空. */
+    fun reset() {
+        ref.getAndSet(null)?.clear()
+    }
+}

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PerfPanel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PerfPanel.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.AssistChip
@@ -56,6 +57,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.compose.preview.runtime.DexMmapPool
+import com.itsaky.androidide.compose.preview.runtime.DexMmapPoolEvictor
+import com.itsaky.androidide.compose.preview.runtime.DexMmapPoolRegistry
 import com.itsaky.androidide.compose.preview.runtime.TimingRegistry
 import kotlinx.coroutines.delay
 
@@ -70,10 +74,13 @@ import kotlinx.coroutines.delay
 @Composable
 fun PerfPanel(modifier: Modifier = Modifier) {
     var snapshot by remember { mutableStateOf(TimingRegistry.snapshot()) }
+    var mmapStats by remember { mutableStateOf(DexMmapPoolRegistry.stats()) }
+    var evictTrigger by remember { mutableStateOf(0) }
 
     LaunchedEffect(Unit) {
         while (true) {
             snapshot = TimingRegistry.snapshot()
+            mmapStats = DexMmapPoolRegistry.stats()
             delay(REFRESH_INTERVAL_MS)
         }
     }
@@ -103,7 +110,10 @@ fun PerfPanel(modifier: Modifier = Modifier) {
             )
             Spacer(Modifier.width(8.dp))
             AssistChip(
-                onClick = { TimingRegistry.reset(); snapshot = TimingRegistry.snapshot() },
+                onClick = {
+                    TimingRegistry.reset()
+                    snapshot = TimingRegistry.snapshot()
+                },
                 label = { Text("Reset", fontSize = 11.sp) },
                 leadingIcon = {
                     Icon(Icons.Filled.Refresh, null, modifier = Modifier.size(14.dp))
@@ -112,6 +122,16 @@ fun PerfPanel(modifier: Modifier = Modifier) {
             )
         }
         Spacer(Modifier.height(12.dp))
+
+        // v2.5 P2: mmap 池子状态卡片
+        MmapPoolSection(
+            stats = mmapStats,
+            onEvict = {
+                val n = DexMmapPoolRegistry.evictStale(maxAgeMs = 0L)  // 立即 evict 所有 refCount=0
+                evictTrigger += n
+            },
+        )
+        Spacer(Modifier.height(8.dp))
 
         if (snapshot.phases.values.all { it.count == 0L }) {
             EmptyState()
@@ -125,6 +145,62 @@ fun PerfPanel(modifier: Modifier = Modifier) {
             items(TimingRegistry.Phase.values().toList(), key = { it.name }) { phase ->
                 val stats = snapshot.phases[phase] ?: TimingRegistry.PhaseStats.EMPTY
                 PhaseCard(phase = phase, stats = stats)
+            }
+        }
+    }
+}
+
+/**
+ * v2.5 P2: mmap pool 状态卡片.
+ *
+ * 显示: activeEntries / hitRate / totalAcquires-Releases / 立即 evict 按钮.
+ */
+@Composable
+private fun MmapPoolSection(
+    stats: DexMmapPool.PoolStats,
+    onEvict: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f))
+            .padding(12.dp),
+    ) {
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.Memory,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "Dex MMap Pool",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(Modifier.weight(1f))
+                AssistChip(
+                    onClick = onEvict,
+                    label = { Text("Evict", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Filled.Refresh, null, modifier = Modifier.size(12.dp))
+                    },
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+
+            // 4 个指标
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                MetricCell("active", stats.activeEntries.toString())
+                MetricCell("hit", "${(stats.hitRate * 100).toInt()}%")
+                MetricCell("acq", stats.totalAcquires.toString())
+                MetricCell("rel", stats.totalReleases.toString())
             }
         }
     }

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolEvictorTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolEvictorTest.kt
@@ -1,0 +1,113 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * v2.5 P2: DexMmapPoolEvictor 单元测试.
+ */
+class DexMmapPoolEvictorTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var pool: DexMmapPool
+
+    @After
+    fun tearDown() {
+        DexMmapPoolRegistry.reset()
+    }
+
+    @Test
+    fun `start launches background coroutine and isRunning becomes true`() = runTest {
+        pool = DexMmapPool()
+        val evictor = DexMmapPoolEvictor(
+            pool = pool,
+            intervalMs = 50L,
+            maxAgeMs = 0L,
+        )
+        assertFalse(evictor.isRunning())
+        evictor.start()
+        assertTrue(evictor.isRunning())
+        evictor.stop()
+        assertFalse(evictor.isRunning())
+    }
+
+    @Test
+    fun `start is idempotent`() {
+        pool = DexMmapPool()
+        val evictor = DexMmapPoolEvictor(pool, intervalMs = 100_000L, maxAgeMs = 100_000L)
+        evictor.start()
+        evictor.start()  // 二次启动应该 noop
+        evictor.stop()
+    }
+
+    @Test
+    fun `stop without start is noop`() {
+        pool = DexMmapPool()
+        val evictor = DexMmapPoolEvictor(pool)
+        evictor.stop()  // 不抛
+    }
+
+    @Test
+    fun `evictor runs evictStale at interval`() = runTest {
+        pool = DexMmapPool()
+        // 准备一个 stale dex
+        val dex = tmp.newFile("stale.dex")
+        dex.writeBytes(ByteArray(64) { 0x00 })
+        val entry = pool.acquire(dex)
+        assertNotNull(entry)
+        pool.release(entry!!)
+        // refCount=0, 5 分钟前
+        val evictor = DexMmapPoolEvictor(
+            pool = pool,
+            intervalMs = 50L,
+            maxAgeMs = 0L,  // 任何 refCount=0 立即 evict
+        )
+        evictor.start()
+        // 等几次 interval
+        delay(200L)
+        evictor.stop()
+        // 至少跑过 1 次 evict (可能多次)
+        assertTrue("evictor should run at least once, got ${evictor.evictRunCount()}", evictor.evictRunCount() >= 1L)
+        // 至少释放 1 个 entry
+        assertTrue("should evict at least 1 entry, got ${evictor.evictedEntryCount()}", evictor.evictedEntryCount() >= 1L)
+    }
+
+    @Test
+    fun `evictor stats start at 0`() {
+        pool = DexMmapPool()
+        val evictor = DexMmapPoolEvictor(pool, intervalMs = 100_000L, maxAgeMs = 100_000L)
+        assertEquals(0L, evictor.evictRunCount())
+        assertEquals(0L, evictor.evictedEntryCount())
+    }
+
+    private fun assertNotNull(o: Any?) {
+        org.junit.Assert.assertNotNull(o)
+    }
+}

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolRegistryTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/DexMmapPoolRegistryTest.kt
@@ -1,0 +1,98 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * v2.5 P2: DexMmapPoolRegistry 单元测试.
+ */
+class DexMmapPoolRegistryTest {
+
+    @After
+    fun tearDown() {
+        DexMmapPoolRegistry.reset()
+    }
+
+    @Test
+    fun `install and pool returns same instance`() {
+        val pool = DexMmapPool()
+        DexMmapPoolRegistry.install(pool)
+        assertSame(pool, DexMmapPoolRegistry.pool())
+    }
+
+    @Test
+    fun `getOrCreate lazy creates when empty`() {
+        assertNull(DexMmapPoolRegistry.pool())
+        val pool = DexMmapPoolRegistry.getOrCreate()
+        assertNotNull(pool)
+        assertSame(pool, DexMmapPoolRegistry.pool())
+    }
+
+    @Test
+    fun `getOrCreate returns installed when present`() {
+        val installed = DexMmapPool()
+        DexMmapPoolRegistry.install(installed)
+        assertSame(installed, DexMmapPoolRegistry.getOrCreate())
+    }
+
+    @Test
+    fun `stats returns empty when nothing installed`() {
+        val stats = DexMmapPoolRegistry.stats()
+        assertEquals(0, stats.activeEntries)
+        assertEquals(0, stats.totalAcquires)
+    }
+
+    @Test
+    fun `stats delegates to installed pool`() {
+        val pool = DexMmapPool()
+        pool.acquire(java.io.File("/tmp/nonexistent.dex"))  // returns null, 但 totalAcquire++? 不, missing 返回 null 不增
+        // 直接拿个空 stats 测一下
+        DexMmapPoolRegistry.install(pool)
+        val stats = DexMmapPoolRegistry.stats()
+        assertEquals(0, stats.activeEntries)
+    }
+
+    @Test
+    fun `evictStale returns 0 when nothing installed`() {
+        assertEquals(0, DexMmapPoolRegistry.evictStale(maxAgeMs = 0L))
+    }
+
+    @Test
+    fun `reset clears and releases pool`() {
+        val pool = DexMmapPool()
+        DexMmapPoolRegistry.install(pool)
+        assertNotNull(DexMmapPoolRegistry.pool())
+        DexMmapPoolRegistry.reset()
+        assertNull(DexMmapPoolRegistry.pool())
+    }
+
+    @Test
+    fun `install replaces previous pool`() {
+        val a = DexMmapPool()
+        val b = DexMmapPool()
+        DexMmapPoolRegistry.install(a)
+        DexMmapPoolRegistry.install(b)
+        assertSame(b, DexMmapPoolRegistry.pool())
+    }
+}

--- a/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/EvictorLifecycleTest.kt
+++ b/modules/compose-preview/src/test/java/com/itsaky/androidide/compose/preview/runtime/EvictorLifecycleTest.kt
@@ -1,0 +1,126 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.runtime
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * v2.5 P3: 模拟 Fragment 视图生命周期的 Evictor 测试.
+ *
+ * ComposePreviewFragment.onViewCreated → evictor.start()
+ * ComposePreviewFragment.onDestroyView → evictor.stop()
+ *
+ * 这里用 [LifecycleHost] 模拟, 验证生命周期集成行为.
+ */
+class EvictorLifecycleTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @After
+    fun tearDown() {
+        DexMmapPoolRegistry.reset()
+    }
+
+    @Test
+    fun `lifecycle host start then stop mirrors fragment onViewCreated to onDestroyView`() = runTest {
+        val pool = DexMmapPool()
+        val host = LifecycleHost(pool)
+        // 模拟 onViewCreated
+        host.onViewCreated()
+        assertTrue("evictor should be running after onViewCreated", host.evictor?.isRunning() == true)
+        // 模拟 onDestroyView
+        host.onDestroyView()
+        assertNull("evictor ref should be null after onDestroyView", host.evictor)
+    }
+
+    @Test
+    fun `lifecycle host onViewCreated twice is idempotent`() {
+        val pool = DexMmapPool()
+        val host = LifecycleHost(pool)
+        host.onViewCreated()
+        val first = host.evictor
+        host.onViewCreated()  // 第二次应该不覆盖
+        assertTrue("second onViewCreated should not replace existing evictor", host.evictor === first)
+        host.onDestroyView()
+    }
+
+    @Test
+    fun `lifecycle host onDestroyView before onViewCreated is noop`() {
+        val pool = DexMmapPool()
+        val host = LifecycleHost(pool)
+        // 没 start 就 stop, 不抛
+        host.onDestroyView()
+        assertNull(host.evictor)
+    }
+
+    @Test
+    fun `lifecycle host evictor actually evicts while running`() = runTest {
+        val pool = DexMmapPool()
+        val host = LifecycleHost(pool)
+        // 准备 stale entry
+        val dex = tmp.newFile("stale.dex")
+        dex.writeBytes(ByteArray(64) { 0x00 })
+        val entry = pool.acquire(dex)!!
+        pool.release(entry)
+        // 启动 (短 interval + 0 ms 阈值, 立刻 evict)
+        host.onViewCreated()
+        delay(150L)
+        host.onDestroyView()
+        // 至少跑过 1 次 evict
+        assertTrue(
+            "evictor should run at least once, got ${host.evictor?.evictRunCount()}",
+            (host.totalEvictedEntries()) >= 1L,
+        )
+    }
+
+    /**
+     * 模拟 ComposePreviewFragment 持有 Evictor 的方式.
+     */
+    private class LifecycleHost(private val pool: DexMmapPool) {
+        var evictor: DexMmapPoolEvictor? = null
+            private set
+
+        fun onViewCreated() {
+            if (evictor == null) {
+                evictor = DexMmapPoolEvictor(
+                    pool = pool,
+                    intervalMs = 50L,
+                    maxAgeMs = 0L,
+                ).apply { start() }
+            }
+        }
+
+        fun onDestroyView() {
+            evictor?.stop()
+            evictor = null
+        }
+
+        fun totalEvictedEntries(): Long = evictor?.evictedEntryCount() ?: 0L
+    }
+}


### PR DESCRIPTION
## Overview

`modules/compose-preview/` 把 `DexMmapPool` 真正"可见化": 通过 `DexMmapPoolRegistry` 全局单例让 UI 层访问, 通过 `DexMmapPoolEvictor` 协程定时清理 stale entry, PerfPanel 增加 mmap 状态卡片。

**范围**: v2.5 P2
**前置 PR**: #353 (v2.5 P0) / #354 (v2.5 P1)

## 改动

### 新增 (4 文件)

- **`DexMmapPoolRegistry.kt`** (~80 行): 全局单例
  - `install(pool)` / `getOrCreate()` / `pool()` / `stats()` / `evictStale(maxAgeMs)` / `reset()`
  - AtomicReference + lazy init

- **`DexMmapPoolEvictor.kt`** (~95 行): 协程定时 evict
  - `start()` / `stop()` / `isRunning()` / `evictRunCount()` / `evictedEntryCount()`
  - 默认 10 分钟一次, 5 分钟无引用视为 stale
  - SupervisorJob + Dispatchers.Default
  - 累计统计 (跑了几次 / 释放了几个 entry)

- **`DexMmapPoolRegistryTest.kt`** (~120 行, 7 case):
  - install / getOrCreate lazy / 重复 install 替换 / stats / evictStale / reset / 替换

- **`DexMmapPoolEvictorTest.kt`** (~100 行, 5 case):
  - start 启动 / 幂等 / stop 无副作用 / 定时触发 evict / 初始 0

### 修改 (3 文件)

- **`ComposeClassLoader.kt`** (+5/-2):
  - 默认 `mmapPool: DexMmapPool = DexMmapPoolRegistry.getOrCreate()` (从 P1 的 `DexMmapPool()` 升级为全局)
  - `init` 块: `DexMmapPoolRegistry.install(mmapPool)` (UI 端可读到)

- **`PerfPanel.kt`** (+57/-1):
  - 500ms 刷新循环加 `mmapStats = DexMmapPoolRegistry.stats()`
  - 新增 `MmapPoolSection` 卡片:
    - 标题: `Memory` icon + "Dex MMap Pool"
    - 4 个指标: active / hit% / acquires / releases
    - `Evict` 按钮: 立即 evict refCount=0 (maxAgeMs=0)
  - 卡片使用 `primaryContainer` 颜色与下方 phase 卡片区分

- **`TODO.md`** (+30/-0):
  - 追加 v2.5 P1 / P2 完成总结
  - 性能 / evict 基线表

## 设计选择

1. **Registry 用 AtomicReference + lazy getOrCreate** — 简单, 无锁
2. **Evictor 默认 10 分钟** — 与 mmap 池的 5 分钟 stale 阈值配合, 留余量
3. **Evictor 后台 supervisor** — 异常不会 crash, 自动重试下一轮
4. **ComposeClassLoader 默认池子 = Registry.getOrCreate()** — 与 P1 单例池一致
5. **init 注册** — 构造时一次性 install, UI 端随时 stats 拉取
6. **PerfPanel Evict 按钮 maxAgeMs=0** — 立即释放所有 refCount=0, 调试友好
7. **Registry + Evictor 测试隔离** — Registry 直接 new pool 注入, Evictor 短 interval (50ms) 验证

## 后续

- v2.5 P3: ComposePreviewFragment.start() 中 install Evictor, onDestroyView 停止
- v2.5 P4: PerfPanel 集成 evict 触发的 toast 提示
- v2.5 P5: instrumented test 覆盖 mmap 集成全链路
