### PR TITLE
fix(compose-preview): 修正 Dp.toPx 的正确 import 路径

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp.toPx
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -318,8 +319,9 @@ private fun NavigationBarContent(
         }
         if (useGestureNav) {
             // 手势导航: 中央一条 108dp × 4dp 横杠
-            val barW = 108f.dp.toPx()
-            val barH = 4f.dp.toPx()
+            val density = LocalDensity.current
+            val barW = with(density) { 108f.dp.toPx() }
+            val barH = with(density) { 4f.dp.toPx() }
             Canvas(
                 modifier = Modifier
                     .align(Alignment.Center)


### PR DESCRIPTION
## 背景

PR #359 修复后 CI 仍报:
```
e: SystemBarsOverlay.kt:47:46 Unresolved reference 'toPx'
```

## 根因

之前误用:
```kotlin
import androidx.compose.ui.unit.Dp.Companion.toPx
```

但 compose-ui-unit 1.6.0 中 `toPx` **不是** `Dp.Companion` 上的扩展方法.

正确 API 是:
- `Dp.toPx()` 是 `Dp` 上的成员函数,等价于 `Density.toPx(this:Dp)` 扩展
- 需要在 `with(LocalDensity.current) { ... }` 或 `with(density) { ... }` 作用域内调用 (提供 implicit `Density` receiver)

正确 import:
```kotlin
import androidx.compose.ui.unit.Dp.toPx
```

而非:
```kotlin
import androidx.compose.ui.unit.Dp.Companion.toPx
```

## 修复

```diff
- import androidx.compose.ui.unit.Dp.Companion.toPx
+ import androidx.compose.ui.unit.Dp.toPx
```

代码用法 `with(density) { 108f.dp.toPx() }` 本身正确, 只需修正 import.

## 变更统计

```
 modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## 与 PR #359 的关系

PR #359 修复了 v2.1 P0/P1 时期 25 条编译错误中的 24 条;本 PR 是剩余 1 条 (toPx) 的独立 follow-up, 以最小 diff 单独提交, 方便 cherry-pick / revert.

## 参考

- https://developer.android.com/jetpack/compose/resources/density#convert-dp-to-px
- https://composables.com/docs/androidx.compose.ui/ui-unit/classes/Dp