### PR TITLE
fix(compose-preview): 删除无效的 Dp.toPx import (PR #359/#360 合并后残留)

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.Dp.toPx
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme


### PR DESCRIPTION
## 背景

PR #359 和 #360 合并到 main 后,CI 仍报:
```
e: SystemBarsOverlay.kt:47 Unresolved reference 'toPx'
```

## 根因

两个 PR 都在 `SystemBarsOverlay.kt` 第 47 行加入了**无效的 import 语句**:
- PR #359 (593e2108): `import androidx.compose.ui.unit.Dp.Companion.toPx`
- PR #360 (634b376b): `import androidx.compose.ui.unit.Dp.toPx`

两者**都是错的**!`Dp.toPx()` 是 `androidx.compose.ui.unit.Density` 接口的 **member extension function**,它:
- 不是一个顶层函数
- 不是一个 Companion object 上的方法
- **不能 import** — 必须通过 `Density` 实例 receiver 访问

Kotlin 编译器对无效 import 路径报 "Unresolved reference 'toPx'",但这并不是说 `toPx` 函数不存在,而是说 import 路径找不到对应声明.

## 修复

```diff
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.Dp.toPx
 import androidx.compose.ui.unit.sp
```

`with(LocalDensity.current) { 108f.dp.toPx() }` 写法本身正确 — `with(density) { ... }` 提供 implicit `Density` receiver,编译器从 `Density` 接口解析 `Dp.toPx()` member extension,不需要任何 import.

## 变更统计

```
 modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt | 1 -
 1 file changed, 1 deletion(-)
```

## 与 #359/#360 的关系

- #359 修复了 v2.1 P0/P1 时期 25 条错误中的 24 条 (含错误的 toPx import)
- #360 是 toPx 修复的独立 PR (含错误的 toPx import)
- 本 PR #361 删除无效 import,使 main 上 SystemBarsOverlay.kt 真正可编译

## 验证

修复后,SystemBarsOverlay.kt 的 imports 区:
```kotlin
import androidx.compose.ui.platform.LocalDensity
import androidx.compose.ui.unit.Dp
import androidx.compose.ui.unit.dp
import androidx.compose.ui.unit.sp
```
无任何 toPx import,符合 `Dp.toPx()` 作为 `Density` member extension 的语义.

## 参考

- https://stackoverflow.com/questions/65921799/how-to-convert-dp-to-pixels-in-android-jetpack-compose
- https://composables.com/docs/androidx.compose.ui/ui-unit/interfaces/Density
- https://developer.android.com/jetpack/compose/resources/density