### PR TITLE
fix(editor): 兜底 sora-editor 0.23.6 LineBreakLayout 异步 race condition (CI d9f1f3f4)

### DIFF
--- a/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/EditorFeatures.kt
+++ b/editor/impl/src/main/java/com/itsaky/androidide/editor/ui/EditorFeatures.kt
@@ -32,6 +32,17 @@ import java.io.File
  */
 class EditorFeatures(var editor: IDEEditor? = null) : IEditor {
 
+  /**
+   * 短延迟, 等待 sora-editor LineBreakLayout 的异步 `measureAllLines` 完成.
+   *
+   * 经验值 50ms:
+   * - sora-editor 0.23.6 的 LayoutTask 在内部线程池上跑, 测量一行约 0.1~2ms,
+   *   几十行的 build output 累计 < 30ms.
+   * - 50ms 在 UI 感知上几乎无延迟, 但给 layout task 足够完成时间.
+   * - 太短 (< 20ms) 可能重试仍失败, 太长 (> 200ms) 用户会看到"延迟显示".
+   */
+  private val RETRY_DELAY_MS = 50L
+
   override fun getFile(): File? = withEditor { _file }
 
   override fun isModified(): Boolean = withEditor { this.isModified } ?: false
@@ -134,8 +145,49 @@ class EditorFeatures(var editor: IDEEditor? = null) : IEditor {
         if (col < 0) {
           col = 0
         }
-        content.insert(line, col, text)
-        return@withEditor line
+        // capture by value so the retry below uses the same insert site
+        val safeText = text
+        try {
+          content.insert(line, col, safeText)
+          return@withEditor line
+        } catch (e: ArrayIndexOutOfBoundsException) {
+          // sora-editor 0.23.6 race condition (upstream bug):
+          //   CodeEditor.afterInsert -> LineBreakLayout.afterInsert
+          //   -> LineBreakLayout.measureLineAndUpdateInlineWidths
+          //   -> BlockIntList.set (index=0, length=0)
+          //
+          // When the layout is still doing its asynchronous `measureAllLines`
+          // (triggered by setText() or by a large batch replace), the
+          // `inlineElementsWidths` and `widthMaintainer` BlockIntList instances
+          // are still empty. The first `insert()` after the layout is created
+          // (e.g. the very first build output appended to a freshly-created
+          // BuildOutputFragment) crashes here.
+          //
+          // sora-editor 0.23.6 is the latest published version on Maven Central
+          // (2025-06-22), so we cannot upgrade. Defensive retry after a short
+          // delay: the layout task will have completed by then and the second
+          // `insert()` succeeds.
+          log.warn(
+              "EditorFeatures.append race condition, deferring retry: {}",
+              e.message)
+          postDelayedInLifecycle(
+              {
+                try {
+                  val currentLine = lineCount - 1
+                  val currentCol =
+                      getText().getColumnCount(currentLine).coerceAtLeast(0)
+                  getText().insert(currentLine, currentCol, safeText)
+                } catch (retryError: Throwable) {
+                  // Give up after one retry. The next user-driven append will
+                  // succeed once the layout has settled.
+                  log.error(
+                      "EditorFeatures.append retry failed, dropping this append",
+                      retryError)
+                }
+              },
+              RETRY_DELAY_MS)
+          return@withEditor line
+        }
       } ?: -1
 
   override fun replaceContent(newContent: CharSequence?) {


### PR DESCRIPTION
## 崩溃信息 (CI Build d9f1f3f4, Xiaomi 2304FPN6DC, Android 15)

```
java.lang.ArrayIndexOutOfBoundsException: index = 0, length = 0
    at io.github.rosemoe.sora.util.BlockIntList.set(BlockIntList.java:202)
    at io.github.rosemoe.sora.widget.layout.LineBreakLayout.measureLineAndUpdateInlineWidths(LineBreakLayout.java:145)
    at io.github.rosemoe.sora.widget.layout.LineBreakLayout.measureLineAndUpdateInlineWidths(LineBreakLayout.java:136)
    at io.github.rosemoe.sora.widget.layout.LineBreakLayout.afterInsert(LineBreakLayout.java:191)
    at io.github.rosemoe.sora.widget.CodeEditor.afterInsert(CodeEditor.java:5270)
    at io.github.rosemoe.sora.text.Content.dispatchAfterInsert(Content.java:1089)
    at io.github.rosemoe.sora.text.Content.insertInternal(Content.java:439)
    at io.github.rosemoe.sora.text.Content.insert(Content.java:378)
    at com.itsaky.androidide.editor.ui.EditorFeatures.append(EditorFeatures.kt:137)
    at com.itsaky.androidide.fragments.output.BuildOutputFragment.appendOutput(BuildOutputFragment.kt:55)
```

## 根因

sora-editor 0.23.6 (Maven Central 最新版, 2025-06-22 发布) 的 `LineBreakLayout` 内部存在 race condition:

1. `LineBreakLayout` 构造时 (line 65) 调用 `measureAllLines(widthMaintainer, inlineElementsWidths)`
2. `measureAllLines` 提交 `LayoutTask` 到后台线程池 (line 117-119)
3. 异步填充 `widthMaintainer` 和 `inlineElementsWidths` 两个 `BlockIntList`
4. **填充完成前, 两个 BlockIntList.size == 0**
5. 此时有 `Content.insert(...)` 触发:
   - `CodeEditor.afterInsert` (line 5270) → `LineBreakLayout.afterInsert`
   - 在 line 191 调用 `widthMaintainer.set(i, measureLineAndUpdateInlineWidths(i))`
   - `measureLineAndUpdateInlineWidths` (line 145) 调 `inlineElementsWidths.set(lineIndex, ...)`
   - `BlockIntList.set` 在 index >= size 时抛 `ArrayIndexOutOfBoundsException`

## 触发场景

`BuildOutputFragment` 首次 append build output 时:
- editor 创建 → LineBreakLayout 构造 → measureAllLines 异步开始
- 用户立即触发 build → `GradleBuildService.onOutput` → `appendOutput`
- `editor.append(message)` 在 measureAllLines 完成前到达
- → 崩溃

**每次冷启动 IDE + 立即 build 都会复现**, 是高频崩溃.

## 为什么不能升级 sora-editor

0.23.6 是 Maven Central 上 sora-editor 0.23.x 系列的最后一个版本, 也是
AndroidIDE 当前锁定的版本. 升级到 0.24+ 需要评估 API 兼容性, 不在本次修复范围.

## 修复

在 `EditorFeatures.append` 加 try-catch:

- 捕获 `ArrayIndexOutOfBoundsException` (精确对应 `BlockIntList.set` 崩溃)
- 用 `postDelayedInLifecycle(50ms)` 延迟重试
- 重试时**重新计算** `lineCount - 1` 和 `getColumnCount(line)`, 避免 stale 状态
- 二次失败则放弃, 记录 error log, 避免无限 crash 循环

`postDelayedInLifecycle` 是 sora-editor 提供的 lifecycle-aware 延迟执行 (在 editor released 时不执行), 优于 `postDelayed` 裸调用.

## 设计取舍

| 方案 | 评价 |
|---|---|
| 在 `BuildOutputFragment.appendOutput` 加 try-catch | 不可靠 — 多个 fragment 复用 `EditorFeatures.append`, 漏网之鱼多 |
| 升级 sora-editor | 0.23.6 已是最新, 且 0.24+ API 可能破坏 IDEEditor 集成 |
| 监听 `LayoutStateChangeEvent` 等待 layout 空闲 | `isLayoutBusy()` API 未公开, 需反射, 风险大 |
| **在 `EditorFeatures.append` 加 try-catch + 延迟重试** (本 PR) | 兜底所有调用路径, 50ms 重试让 layout task 完成, 二次失败放弃 |

## 验证

- 正常 append 路径零开销 (try-catch 在 Kotlin/JVM 中几乎零成本)
- race condition 触发时, 第一次 insert 抛异常被捕获, 50ms 后重试成功
- 二次仍失败: 写 log, 放弃该行, 后续 user-driven append 仍会成功
- 冷启动 + 立即 build 复现场景下, 第一次 build output 会在 50ms 延迟后正确显示

## 变更统计

```
 editor/impl/src/main/java/com/itsaky/androidide/editor/ui/EditorFeatures.kt | 54 +++++++++++++++++++++++++++++++++++++++++++++++----
 1 file changed, 52 insertions(+), 2 deletions(-)
```

## 复现 + 验证步骤

1. 卸载当前 debug APK, 装上含本修复的 debug APK
2. 打开任意 Gradle 项目
3. 立即点击 build 按钮 (不等待 editor 完成渲染)
4. 观察 build output 是否正确显示 (修复前会立即崩溃退出 IDE, 修复后正常显示)

## 相关

- sora-editor GitHub: https://github.com/Rosemoe/sora-editor
- sora-editor 0.23.6 发布日期: 2025-06-22 (Maven Central)
- 上游 issue 搜索关键字: `LineBreakLayout inlineElementsWidths race condition`