### PR TITLE
feat(perf): PR #3/5 :perf 进程 server + 协议 + PhaseCollector

### DIFF
--- a/core/app/src/main/AndroidManifest.xml
+++ b/core/app/src/main/AndroidManifest.xml
@@ -47,6 +47,34 @@
                     <category android:name="android.intent.category.LAUNCHER" />
                </intent-filter>
           </activity>
+
+          <!--
+            Perf Console (性能监控调试控制台).
+            跑在独立进程 ":perf", 不受主 application 初始化阻塞.
+            桌面启动图标, 用户可从桌面独立启动, 即使主 application
+            启动崩溃, 此 Activity 仍能显示并继续记录.
+
+            - process=":perf"        : 独立进程, fork 时只跑 BaseApplication
+            - taskAffinity=""        : 不与主进程共享任务栈, 避免回主进程
+            - launchMode="singleInstance" : 多次从桌面点击只产生一个实例
+            - excludeFromRecents="true"   : 不出现在最近任务列表
+            - icon / label           : 桌面图标 / 标题
+          -->
+          <activity
+               android:name=".perf.PerfConsoleActivity"
+               android:exported="true"
+               android:process=":perf"
+               android:taskAffinity=""
+               android:launchMode="singleInstance"
+               android:excludeFromRecents="true"
+               android:theme="@style/Theme.AndroidIDE"
+               android:icon="@mipmap/ic_perf_console"
+               android:label="@string/perf_console_title">
+               <intent-filter>
+                    <action android:name="android.intent.action.MAIN" />
+                    <category android:name="android.intent.category.LAUNCHER" />
+               </intent-filter>
+          </activity>
           
           <activity
                android:exported="false"

--- a/core/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
@@ -162,6 +162,7 @@ class MainActivity : EdgeToEdgeIDEActivity() {
     }
 
     onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
   }
 
   private fun askProjectOpenPermission(root: File) {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -61,10 +61,11 @@ class OnboardingActivity : AppIntro2() {
 
   @SuppressLint("SourceLockedOrientationActivity")
   override fun onCreate(savedInstanceState: Bundle?) {
-    IThemeManager.getInstance().applyTheme(this)
-    try {
-      requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    } catch (e: Exception) {}
+    PerfTracer.trace("onboarding_activity_oncreate") {
+      IThemeManager.getInstance().applyTheme(this)
+      try {
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+      } catch (e: Exception) {}
 
     super.onCreate(savedInstanceState)
 
@@ -142,6 +143,7 @@ class OnboardingActivity : AppIntro2() {
 
     if (!SdkChecker.isEnvironmentReadySync()) {
       addSlide(OdSdkToolInstallFragment.newInstance(this))
+    }
     }
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/activities/SplashActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/SplashActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.itsaky.androidide.perf.tracer.PerfTracer
 
 /**
  * Startup launcher activity.
@@ -18,8 +19,10 @@ class SplashActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     // Keep launcher activity ultra-lightweight: no Compose / no heavy rendering work.
-    startActivity(Intent(this, OnboardingActivity::class.java))
-    finish()
-    overridePendingTransition(0, 0)
+    PerfTracer.trace("splash_activity_oncreate") {
+      startActivity(Intent(this, OnboardingActivity::class.java))
+      finish()
+      overridePendingTransition(0, 0)
+    }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -78,11 +78,13 @@ class IDEApplication : TermuxApplication() {
     val bootStart = System.currentTimeMillis()
 
     // :perf 进程: 只跑 super.onCreate (BaseApplication + TermuxApplication 必要初始化),
+    // 然后调 PerfApplication.init 启动 server / PhaseCollector, 再 return.
     // 完全跳过 IDE 特有的初始化 (Koin/EventBus/StrictMode/ColorScheme 等).
     // 让 Perf Console 在 :perf 进程极轻量, 不被主 application 的任何阻塞影响.
     if (isPerfProcess()) {
       super.onCreate()
       log.info("IDEApplication onCreate skipped (running in :perf process)")
+      PerfApplication.init(this)
       return
     }
 

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -36,6 +36,7 @@ import com.itsaky.androidide.events.EditorEventsIndex
 import com.itsaky.androidide.events.LspApiEventsIndex
 import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
+import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.resources.localization.LocaleProvider
@@ -75,44 +76,73 @@ class IDEApplication : TermuxApplication() {
   @OptIn(DelicateCoroutinesApi::class)
   override fun onCreate() {
     val bootStart = System.currentTimeMillis()
+
+    // :perf 进程: 只跑 super.onCreate (BaseApplication + TermuxApplication 必要初始化),
+    // 完全跳过 IDE 特有的初始化 (Koin/EventBus/StrictMode/ColorScheme 等).
+    // 让 Perf Console 在 :perf 进程极轻量, 不被主 application 的任何阻塞影响.
+    if (isPerfProcess()) {
+      super.onCreate()
+      log.info("IDEApplication onCreate skipped (running in :perf process)")
+      return
+    }
+
     instance = this
-    super.onCreate()
-    RikkaHubRuntime.ensureKoinStarted(this)
+    PerfTracer.reportInstant("ide_on_create_begin")
+    PerfTracer.tryAttach(this)
+    PerfTracer.trace("super_on_create") { super.onCreate() }
+    PerfTracer.trace("init_koin") { RikkaHubRuntime.ensureKoinStarted(this) }
 
-    applyPersistedLocale()
+    PerfTracer.trace("apply_persisted_locale") { applyPersistedLocale() }
 
-    uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
-    Thread.setDefaultUncaughtExceptionHandler { thread, th -> handleCrash(thread, th) }
+    PerfTracer.trace("set_uncaught_handler") {
+      uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+      Thread.setDefaultUncaughtExceptionHandler { thread, th -> handleCrash(thread, th) }
+    }
 
     if (BuildConfig.DEBUG) {
-      StrictMode.setVmPolicy(
-          StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy()).penaltyLog().detectAll().build()
-      )
+      PerfTracer.trace("strict_mode_setup") {
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy()).penaltyLog().detectAll().build()
+        )
+      }
       if (DevOpsPreferences.dumpLogs) {
-        startLogcatReader()
+        PerfTracer.trace("start_logcat_reader") { startLogcatReader() }
       }
     }
 
-    EventBus.builder()
-        .addIndex(AppEventsIndex())
-        .addIndex(EditorEventsIndex())
-        .addIndex(LspApiEventsIndex())
-        .addIndex(LspJavaEventsIndex())
-        .addIndex(LspKotlinEventsIndex())
-        .installDefaultEventBus(true)
-
-    EventBus.getDefault().register(this)
-
-    AppCompatDelegate.setDefaultNightMode(GeneralPreferences.uiMode)
-
-    if (IThemeManager.getInstance().getCurrentTheme() == IDETheme.MATERIAL_YOU) {
-      DynamicColors.applyToActivitiesIfAvailable(this)
+    PerfTracer.trace("eventbus_add_indexes") {
+      EventBus.builder()
+          .addIndex(AppEventsIndex())
+          .addIndex(EditorEventsIndex())
+          .addIndex(LspApiEventsIndex())
+          .addIndex(LspJavaEventsIndex())
+          .addIndex(LspKotlinEventsIndex())
+          .installDefaultEventBus(true)
     }
 
-    EditorColorScheme.setDefault(SchemeAndroidIDE.newInstance(null))
+    PerfTracer.trace("eventbus_register") { EventBus.getDefault().register(this) }
 
-    GlobalScope.launch(Dispatchers.IO) { IDEColorSchemeProvider.init() }
+    PerfTracer.trace("set_default_night_mode") {
+      AppCompatDelegate.setDefaultNightMode(GeneralPreferences.uiMode)
+    }
 
+    if (IThemeManager.getInstance().getCurrentTheme() == IDETheme.MATERIAL_YOU) {
+      PerfTracer.trace("dynamic_colors_apply") {
+        DynamicColors.applyToActivitiesIfAvailable(this)
+      }
+    }
+
+    PerfTracer.trace("editor_color_scheme_default") {
+      EditorColorScheme.setDefault(SchemeAndroidIDE.newInstance(null))
+    }
+
+    PerfTracer.reportInstant("ide_color_scheme_provider_init_start")
+    GlobalScope.launch(Dispatchers.IO) {
+      PerfTracer.trace("ide_color_scheme_provider_init") { IDEColorSchemeProvider.init() }
+    }
+
+    PerfTracer.reportInstant("ide_on_create_end")
+    PerfTracer.endBoot()
   }
 
   /**
@@ -207,6 +237,7 @@ class IDEApplication : TermuxApplication() {
 
   override fun attachBaseContext(base: android.content.Context?) {
     if (base != null) {
+      PerfTracer.reportInstant("ide_attach_base_context")
       val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(base)
       val selectedLocaleKey = prefs.getString(GeneralPreferences.SELECTED_LOCALE, null)
       val localeListCompat =
@@ -220,6 +251,24 @@ class IDEApplication : TermuxApplication() {
 
   companion object {
     private val log = LoggerFactory.getLogger(IDEApplication::class.java)
+
+    /**
+     * 当前进程是否在 `:perf` 进程 (Perf Console 独立进程).
+     *
+     * 用 `endsWith(":perf")` 而不是 equals 是因为: `Process.myProcessName()` 在某些
+     * OEM (e.g. 小米) 上可能返回 `com.itsaky.androidide:perf` 或 `xxx:perf`,
+     * 末尾 `:perf` 是稳定后缀.
+     */
+    @JvmStatic
+    private fun isPerfProcess(): Boolean {
+      val processName =
+          runCatching {
+            // android.os.Process.myProcessName() requires API 28
+            @Suppress("DEPRECATION")
+            android.os.Process.myProcessName()
+          }.getOrDefault("")
+      return processName.endsWith(":perf")
+    }
 
     @JvmStatic
     lateinit var instance: IDEApplication

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
@@ -16,56 +16,107 @@
  */
 package com.itsaky.androidide.perf
 
-import android.app.Application
+import android.content.Context
+import com.itsaky.androidide.perf.server.PerfServerSocket
+import com.itsaky.androidide.perf.server.PhaseCollector
+import java.io.File
+import java.util.concurrent.Executors
 import org.slf4j.LoggerFactory
 
 /**
- * :perf 进程的 [Application].
+ * :perf 进程的"逻辑 Application" (PR #3/5).
  *
- * 跑在独立进程 `android:process=":perf"`, 不会被主 application
- * (`com.itsaky.androidide`) 任何初始化阻塞. 主 application 启动
- * 崩溃时, 此 Application 仍可用, 性能监控 UI 仍能显示.
+ * ## 重要: 本类 **不是** 系统加载的 Application 类
+ *
+ * Android 一个 APK 只能有一个 Application 类, 当前 manifest 用的是
+ * `com.itsaky.androidide.app.IDEApplication`. 系统在 fork `:perf` 进程时
+ * 会加载 IDEApplication, [IDEApplication.onCreate] 通过 [isPerfProcess] 判断
+ * 提前 return 后, **显式调 [init]** 把本类的逻辑跑起来.
+ *
+ * 这种设计的好处:
+ * 1. 保持 :perf 进程所有初始化代码集中在一个文件 ([init]), 易维护
+ * 2. 主进程 manifest 改动最小 (不需要 `tools:replace` 之类的 manifest merger 黑魔法)
+ * 3. IDEApplication 主进程代码完全不变, 只是在 :perf 进程多了一个 init 入口
  *
  * ## 启动后做的事 (按 PR 顺序)
  *
- * - PR #1 (本 PR): 仅 log, 不启动任何后台任务
- * - PR #3: 创建 `LocalServerSocket` ([PERF_SOCKET_PATH]) 等主进程 connect
- * - PR #4: 启动 4 个 Monitor (FrameRate / Memory / Gc / Anr)
+ * - **PR #1**: 骨架 — 仅 log 占位
+ * - **PR #3 (本 PR)**: 启动 [PerfServerSocket] + [PhaseCollector],
+ *   把 socket 路径写到 [PERF_SOCKET_PATH_FILE] 供主进程连接
+ * - **PR #4**: 启动 4 个 Monitor (FrameRate / Memory / Gc / Anr)
  *
- * 主进程的 `PerfTracer.tryAttach(...)` 通过读 [PERF_SOCKET_PATH_FILE] 文件
- * 获得 socket 完整路径, 实现两进程解耦.
+ * ## 进程模型
+ *
+ * ```
+ *  ┌──────────────────┐  LocalSocket (filesystem)  ┌──────────────────┐
+ *  │  Main process    │ ────────────────────────▶ │  :perf process   │
+ *  │  (IDEApplication)│   {"type":"phase",...}    │  PerfServerSocket│
+ *  │  PerfTracer      │                           │  → PhaseCollector│
+ *  │  PerfClientSocket│ ◀─────── (无返回) ──────── │  → UI (PR #5)    │
+ *  └──────────────────┘                            └──────────────────┘
+ * ```
  *
  * @author android_zero
  */
-class PerfApplication : Application() {
+object PerfApplication {
 
-  override fun onCreate() {
-    super.onCreate()
-    log.info("PerfApplication onCreate (PR #1 骨架, 无 socket server / monitor)")
+  private val log = LoggerFactory.getLogger(PerfApplication::class.java)
+
+  /**
+   * 后台 executor, 用于跑 server accept loop.
+   *
+   * 单线程足够 (server.start 内部用 cached pool 处理多 client).
+   * daemon = true 保证不阻止 JVM 退出.
+   */
+  private val serverExecutor = Executors.newSingleThreadExecutor { r ->
+    Thread(r, "perf-app-server").apply { isDaemon = true }
   }
 
-  companion object {
-    private val log = LoggerFactory.getLogger(PerfApplication::class.java)
+  /**
+   * 初始化 :perf 进程.
+   *
+   * 由 [com.itsaky.androidide.app.IDEApplication.onCreate] 在 `isPerfProcess()` 分支调.
+   * 幂等: 二次调用 no-op.
+   */
+  @JvmStatic
+  fun init(context: Context) {
+    if (PhaseStore.isReady()) {
+      log.info("PerfApplication.init already done, skip")
+      return
+    }
+    log.info("PerfApplication.init (PR #3 启动 server + PhaseCollector)")
 
-    /**
-     * LocalServerSocket 路径 (相对 app cacheDir).
-     *
-     * 放在 app cacheDir 而不是 filesDir, 因为:
-     * - cacheDir 在低存储时可被系统清理, 但 perf.sock 是运行时 socket,
-     *   app 退出后不需要保留, 清理无害
-     * - cacheDir 路径短, 减少 socket path 长度 (Linux AF_UNIX path ≤ 108 chars)
-     * - 与 TermuxAmSocketServer 路径隔离, 避免冲突
-     */
-    const val PERF_SOCKET_PATH = "perf/perf.sock"
+    val cacheDir = context.cacheDir
+    val socketPath = File(cacheDir, PERF_SOCKET_PATH).absolutePath
+    val pathFile = File(cacheDir, PERF_SOCKET_PATH_FILE)
 
-    /**
-     * Socket 路径信息文件.
-     *
-     * 主进程的 [com.itsaky.androidide.perf.tracer.PerfTracer] 通过
-     * ContentProvider / 直读此文件得到 socket 完整路径. 替代硬编码路径,
-     * 让 :perf 与主进程解耦.
-     */
-    const val PERF_SOCKET_PATH_FILE = "perf/socket-path.txt"
+    val collector = PhaseCollector()
+    val server = PerfServerSocket(socketPath, pathFile, collector)
+
+    // 标记 server 状态供 UI (PR #5) 读
+    PhaseStore.bind(collector, server)
+
+    // server 启动放后台线程, 不阻塞 IDEApplication.onCreate
+    serverExecutor.submit { server.start() }
   }
+
+  /**
+   * LocalServerSocket 路径 (相对 app cacheDir).
+   *
+   * 放在 app cacheDir 而不是 filesDir, 因为:
+   * - cacheDir 在低存储时可被系统清理, 但 perf.sock 是运行时 socket,
+   *   app 退出后不需要保留, 清理无害
+   * - cacheDir 路径短, 减少 socket path 长度 (Linux AF_UNIX path ≤ 108 chars)
+   * - 与 TermuxAmSocketServer 路径隔离, 避免冲突
+   */
+  const val PERF_SOCKET_PATH = "perf/perf.sock"
+
+  /**
+   * Socket 路径信息文件.
+   *
+   * 主进程的 [com.itsaky.androidide.perf.tracer.PerfTracer] 通过
+   * ContentProvider / 直读此文件得到 socket 完整路径. 替代硬编码路径,
+   * 让 :perf 与主进程解耦.
+   */
+  const val PERF_SOCKET_PATH_FILE = "perf/socket-path.txt"
 }
-

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
@@ -1,0 +1,71 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf
+
+import android.app.Application
+import org.slf4j.LoggerFactory
+
+/**
+ * :perf 进程的 [Application].
+ *
+ * 跑在独立进程 `android:process=":perf"`, 不会被主 application
+ * (`com.itsaky.androidide`) 任何初始化阻塞. 主 application 启动
+ * 崩溃时, 此 Application 仍可用, 性能监控 UI 仍能显示.
+ *
+ * ## 启动后做的事 (按 PR 顺序)
+ *
+ * - PR #1 (本 PR): 仅 log, 不启动任何后台任务
+ * - PR #3: 创建 `LocalServerSocket` ([PERF_SOCKET_PATH]) 等主进程 connect
+ * - PR #4: 启动 4 个 Monitor (FrameRate / Memory / Gc / Anr)
+ *
+ * 主进程的 `PerfTracer.tryAttach(...)` 通过读 [PERF_SOCKET_PATH_FILE] 文件
+ * 获得 socket 完整路径, 实现两进程解耦.
+ *
+ * @author android_zero
+ */
+class PerfApplication : Application() {
+
+  override fun onCreate() {
+    super.onCreate()
+    log.info("PerfApplication onCreate (PR #1 骨架, 无 socket server / monitor)")
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(PerfApplication::class.java)
+
+    /**
+     * LocalServerSocket 路径 (相对 app cacheDir).
+     *
+     * 放在 app cacheDir 而不是 filesDir, 因为:
+     * - cacheDir 在低存储时可被系统清理, 但 perf.sock 是运行时 socket,
+     *   app 退出后不需要保留, 清理无害
+     * - cacheDir 路径短, 减少 socket path 长度 (Linux AF_UNIX path ≤ 108 chars)
+     * - 与 TermuxAmSocketServer 路径隔离, 避免冲突
+     */
+    const val PERF_SOCKET_PATH = "perf/perf.sock"
+
+    /**
+     * Socket 路径信息文件.
+     *
+     * 主进程的 [com.itsaky.androidide.perf.tracer.PerfTracer] 通过
+     * ContentProvider / 直读此文件得到 socket 完整路径. 替代硬编码路径,
+     * 让 :perf 与主进程解耦.
+     */
+    const val PERF_SOCKET_PATH_FILE = "perf/socket-path.txt"
+  }
+}
+

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfConsoleActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfConsoleActivity.kt
@@ -1,0 +1,142 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 性能监控调试控制台 (PR #1 骨架).
+ *
+ * 跑在独立进程 `android:process=":perf"`, 不会被主 application
+ * (`com.itsaky.androidide`) 的初始化阻塞. 主 application 启动崩溃时,
+ * 此 Activity 仍能启动, 监控 UI 仍能显示.
+ *
+ * ## PR 路线图
+ *
+ * - **PR #1 (本 PR)**: 骨架 — 独立 :perf 进程 + 桌面图标 + 占位 UI
+ * - **PR #2**: 主进程 [com.itsaky.androidide.perf.tracer.PerfTracer] +
+ *   IDEApplication.onCreate 18 段埋点
+ * - **PR #3**: [com.itsaky.androidide.perf.server.PerfServerSocket] +
+ *   跨进程协议 + PhaseCollector
+ * - **PR #4**: 4 个 Monitor (FrameRate / Memory / Gc / Anr) + BootHistoryStore
+ * - **PR #5**: 完整 Compose UI (Dashboard + 4 tab + 6 card)
+ *
+ * 当前 Activity 仅显示静态占位文字, 让用户能验证 :perf 进程独立启动.
+ *
+ * @author android_zero
+ */
+class PerfConsoleActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { MaterialTheme { PerfConsoleSkeletonScreen() } }
+  }
+}
+
+/**
+ * PR #1 骨架占位屏.
+ *
+ * 后续 PR 会替换为:
+ * - 顶部 toolbar: 进程名 / PID / 启动耗时
+ * - 4 tab: Boot / Frame / Memory / Threads
+ * - Dashboard: 6 card 显示当前监控数据
+ */
+@Composable
+private fun PerfConsoleSkeletonScreen() {
+  Surface(
+      modifier = Modifier.fillMaxSize(),
+      color = MaterialTheme.colorScheme.background,
+  ) {
+    Box(modifier = Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+      Column(
+          verticalArrangement = Arrangement.spacedBy(16.dp),
+          horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(
+            text = "Perf Console",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "独立 :perf 进程 · 桌面快捷入口",
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                ),
+        ) {
+          Column(
+              modifier = Modifier.padding(20.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            Text(
+                text = "PR #1 骨架完成 ✅",
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text =
+                    """
+                    • 独立进程 android:process=":perf" 已生效
+                    • 桌面启动图标已注册
+                    • 等待 PR #2 接入主进程埋点
+                    • 等待 PR #3 启动 LocalServerSocket
+                    • 等待 PR #4 启动 4 个 Monitor
+                    • 等待 PR #5 接入完整 UI
+                    """.trimIndent(),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+
+        Text(
+            text = "详细 spec: docs/superpowers/specs/2026-06-14-perf-console-design.md",
+            fontSize = 10.sp,
+            color = MaterialTheme.colorScheme.outline,
+        )
+      }
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PhaseStore.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PhaseStore.kt
@@ -1,0 +1,62 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf
+
+import com.itsaky.androidide.perf.server.PerfServerSocket
+import com.itsaky.androidide.perf.server.PhaseCollector
+
+/**
+ * :perf 进程内的全局 holder (PR #3/5).
+ *
+ * [com.itsaky.androidide.perf.PerfApplication.onCreate] 启动 [PerfServerSocket]
+ * 时, 把 [PhaseCollector] 和 server 实例 bind 到本单例.
+ * UI (PR #5) 通过 [collector] 读当前累积数据, 通过 [server] 在 onDestroy
+ * 时关闭.
+ *
+ * ## 设计
+ *
+ * - 单例 (object) 因为 :perf 进程内只有一个 Application + 一个 server
+ * - 不在主进程使用 ([com.itsaky.androidide.perf.tracer.PerfTracer] 是主进程
+ *   自己的 socket client, 不通过本 holder 通信)
+ * - 没有锁: bind() 只在 onCreate 后台线程调一次, 读在 UI 线程, 内存模型上
+ *   safe (init 顺序保证 happens-before 关系)
+ *
+ * @author android_zero
+ */
+object PhaseStore {
+
+  @Volatile private var _collector: PhaseCollector? = null
+
+  @Volatile private var _server: PerfServerSocket? = null
+
+  /**
+   * 在 [com.itsaky.androidide.perf.PerfApplication.onCreate] 调一次.
+   */
+  fun bind(collector: PhaseCollector, server: PerfServerSocket) {
+    _collector = collector
+    _server = server
+  }
+
+  /** 当前 [PhaseCollector], 启动前返回 null. */
+  fun collector(): PhaseCollector? = _collector
+
+  /** 当前 [PerfServerSocket], 启动前返回 null. */
+  fun server(): PerfServerSocket? = _server
+
+  /** 是否已 bind (UI 用此判断"等待 server 启动" vs "已连接"). */
+  fun isReady(): Boolean = _collector != null && _server != null
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfEvent.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfEvent.kt
@@ -1,0 +1,47 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.proto
+
+/**
+ * 主进程 → :perf 进程的跨进程事件.
+ *
+ * 三种类型:
+ *
+ * - [Phase]: 一段代码块的耗时 (用 [com.itsaky.androidide.perf.tracer.PerfTracer.trace])
+ * - [Instant]: 无耗时的瞬时事件 (e.g. `ide_on_create_begin` / `end_boot` 之前的 marker)
+ * - [EndBoot]: 启动阶段结束标记. server 收到后切换为"启动后采样"模式 (PR #4)
+ *
+ * 序列化: line-delimited JSON, 由 [PerfSocketProtocol] 编解码.
+ *
+ * @author android_zero
+ */
+sealed class PerfEvent {
+
+  /** 一段代码块的耗时测量. */
+  data class Phase(
+      val name: String,
+      val elapsedMs: Long,
+  ) : PerfEvent()
+
+  /** 瞬时事件 (无耗时, 仅记录时间点). */
+  data class Instant(
+      val name: String,
+  ) : PerfEvent()
+
+  /** 启动阶段结束. */
+  data object EndBoot : PerfEvent()
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfSocketProtocol.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfSocketProtocol.kt
@@ -1,0 +1,99 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.proto
+
+/**
+ * 跨进程事件的 JSON 编解码 (PR #3/5).
+ *
+ * 协议格式: line-delimited JSON, UTF-8, `\n` 分隔.
+ *
+ * ```
+ * {"type":"phase","name":"koin_start","elapsed":45}
+ * {"type":"instant","name":"ide_on_create_begin"}
+ * {"type":"end_boot"}
+ * ```
+ *
+ * ## 设计取舍
+ *
+ * - **JSON vs 二进制**: JSON 调试友好 (logcat 可读, 简单 `cat` 即可复盘),
+ *   体积略大但 18 段 phase + 后续 1Hz 采样也才几 KB/分钟, 完全够用.
+ * - **无 schema 校验**: 服务端容错 (解析失败返回 null 并 log warn), 允许
+ *   主进程新版本加新字段而不破坏旧 server.
+ * - **手工 parser**: 18 段 phase 字段固定 (type/name/elapsed), 用 regex
+ *   比引入 org.json 或 kotlinx.serialization 更轻 (避免给 :perf 进程增加
+ *   依赖体积).
+ *
+ * @author android_zero
+ */
+internal object PerfSocketProtocol {
+
+  private val PHASE_REGEX =
+      Regex(""""type"\s*:\s*"phase".*?"name"\s*:\s*"([^"]+)".*?"elapsed"\s*:\s*(\d+)""")
+
+  private val INSTANT_REGEX =
+      Regex(""""type"\s*:\s*"instant".*?"name"\s*:\s*"([^"]+)"""")
+
+  private val END_BOOT_REGEX = Regex(""""type"\s*:\s*"end_boot"""")
+
+  /**
+   * 解析一行 JSON 为 [PerfEvent].
+   *
+   * @return 成功 → 事件; 失败 / 类型未知 → null
+   */
+  fun parse(line: String): PerfEvent? {
+    val trimmed = line.trim()
+    if (trimmed.isEmpty()) return null
+
+    return when {
+      END_BOOT_REGEX.containsMatchIn(trimmed) -> PerfEvent.EndBoot
+      else -> {
+        val phaseMatch = PHASE_REGEX.find(trimmed)
+        if (phaseMatch != null) {
+          val name = phaseMatch.groupValues[1].unescape()
+          val elapsed = phaseMatch.groupValues[2].toLongOrNull() ?: 0L
+          return PerfEvent.Phase(name, elapsed)
+        }
+        val instantMatch = INSTANT_REGEX.find(trimmed)
+        if (instantMatch != null) {
+          return PerfEvent.Instant(instantMatch.groupValues[1].unescape())
+        }
+        null
+      }
+    }
+  }
+
+  /**
+   * 序列化 [event] 为单行 JSON (不含换行).
+   *
+   * 主要给 server 端回放 / 测试用, 正常路径是 server 收 client 发的事件.
+   */
+  fun format(event: PerfEvent): String =
+      when (event) {
+        is PerfEvent.Phase ->
+            """{"type":"phase","name":"${event.name.escape()}","elapsed":${event.elapsedMs}}"""
+        is PerfEvent.Instant -> """{"type":"instant","name":"${event.name.escape()}"}"""
+        is PerfEvent.EndBoot -> """{"type":"end_boot"}"""
+      }
+
+  // -- 字符串转义 --
+
+  private fun String.escape(): String =
+      replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+  private fun String.unescape(): String =
+      replace("\\n", "\n").replace("\\\"", "\"").replace("\\\\", "\\")
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/server/PerfServerSocket.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/server/PerfServerSocket.kt
@@ -1,0 +1,173 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.server
+
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import com.itsaky.androidide.perf.proto.PerfEvent
+import com.itsaky.androidide.perf.proto.PerfSocketProtocol
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+
+/**
+ * :perf 进程 LocalServerSocket (PR #3/5).
+ *
+ * 与 [com.itsaky.androidide.perf.tracer.PerfClientSocket] (PR #2 实施)
+ * 通过 Unix domain socket 通信. 本类是 server, 跑在 :perf 进程.
+ *
+ * ## 启动流程
+ *
+ * 1. [com.itsaky.androidide.perf.PerfApplication.onCreate] (PR #1) 在
+ *    启动时创建本类实例, 调 [start].
+ * 2. [start] 在 [executor] 后台线程:
+ *    - 创建 [LocalServerSocket] 绑到 [socketPath]
+ *    - 把 [socketPath] 写到 [pathFile] (供主进程
+ *      [com.itsaky.androidide.perf.tracer.PerfTracer.tryAttach] 读)
+ *    - 进入 [acceptLoop] 死循环
+ * 3. 收到 client 连接 → 提交到 [executor] 的 [handleClient]:
+ *    - 按行读, 每行调 [PerfSocketProtocol.parse]
+ *    - 解析成功 → [collector.collect]
+ *    - 解析失败 → log warn, 继续读下一行 (不中断)
+ *    - 读到 EOF / IOException → 关闭 client socket
+ *
+ * ## 关闭流程
+ *
+ * - [stop] 关闭 server socket (让 accept() 抛异常退出循环)
+ * - [executor] shutdown, 已连接的 client handler 自然结束
+ * - [pathFile] 保留 (下次启动会被覆盖)
+ *
+ * @author android_zero
+ */
+internal class PerfServerSocket(
+    private val socketPath: String,
+    private val pathFile: java.io.File,
+    private val collector: PhaseCollector,
+) {
+
+  private val log = LoggerFactory.getLogger(PerfServerSocket::class.java)
+
+  private val executor = Executors.newCachedThreadPool { r ->
+    Thread(r, "perf-server").apply { isDaemon = true }
+  }
+
+  @Volatile private var server: LocalServerSocket? = null
+
+  @Volatile private var stopped: Boolean = false
+
+  /**
+   * 启动 server, 阻塞当前线程直到 [stop] 被调用.
+   *
+   * 设计: 业务线程 (PerfApplication.onCreate) 在后台线程调本方法, 不阻塞
+   * main thread.
+   */
+  fun start() {
+    if (stopped) {
+      log.warn("PerfServerSocket already stopped, skip start")
+      return
+    }
+    try {
+      // 先清理上次残留的 socket 文件 (system 异常退出可能留下)
+      java.io.File(socketPath).delete()
+
+      val srv = LocalServerSocket(socketPath)
+      server = srv
+
+      // 把 socket 完整路径写到 pathFile, 主进程 PerfTracer.tryAttach 读这个
+      pathFile.parentFile?.mkdirs()
+      pathFile.writeText(socketPath)
+
+      log.info("PerfServerSocket listening on {}", socketPath)
+      acceptLoop(srv)
+    } catch (e: IOException) {
+      log.error("PerfServerSocket start failed", e)
+      cleanup()
+    }
+  }
+
+  /** 停止 server. */
+  fun stop() {
+    stopped = true
+    cleanup()
+    executor.shutdown()
+    try {
+      executor.awaitTermination(2, TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
+  // -- private --
+
+  private fun acceptLoop(srv: LocalServerSocket) {
+    while (!stopped) {
+      val client =
+          try {
+            srv.accept()
+          } catch (e: IOException) {
+            if (stopped) {
+              log.info("PerfServerSocket accept loop exiting (server closed)")
+            } else {
+              log.warn("PerfServerSocket accept failed", e)
+            }
+            return
+          }
+      executor.submit { handleClient(client) }
+    }
+  }
+
+  private fun handleClient(client: LocalSocket) {
+    val remote = client.remoteSocketAddress?.toString() ?: "unknown"
+    try {
+      BufferedReader(InputStreamReader(client.inputStream, StandardCharsets.UTF_8)).use { reader ->
+        while (!stopped) {
+          val line =
+              try {
+                reader.readLine()
+              } catch (e: IOException) {
+                log.debug("PerfServerSocket client {} disconnected: {}", remote, e.message)
+                return@use
+              }
+          if (line == null) {
+            // EOF
+            return@use
+          }
+          val event = PerfSocketProtocol.parse(line)
+          if (event != null) {
+            collector.collect(event)
+          } else {
+            log.warn("PerfServerSocket received unparseable line from {}: {}", remote, line)
+          }
+        }
+      }
+    } catch (e: Throwable) {
+      log.warn("PerfServerSocket handleClient error for {}", remote, e)
+    } finally {
+      runCatching { client.close() }
+    }
+  }
+
+  private fun cleanup() {
+    runCatching { server?.close() }
+    server = null
+    // socket 路径文件保留 (PerfApplication onCreate 会重新写), 不删
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/server/PhaseCollector.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/server/PhaseCollector.kt
@@ -1,0 +1,101 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.server
+
+import com.itsaky.androidide.perf.proto.PerfEvent
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * 内存累积 phase 数据 (PR #3/5).
+ *
+ * 跑在 :perf 进程, 接收主进程通过 socket 发来的 [PerfEvent], 按收到顺序
+ * 累积到 [events] 列表. UI (PR #5) 通过 [snapshot] 周期性拉取 (1Hz).
+ *
+ * ## 线程安全
+ *
+ * - 写: accept loop 线程 ([com.itsaky.androidide.perf.server.PerfServerSocket] 的
+ *   每个 client handler) 并发调用 [collect]. 用 [CopyOnWriteArrayList] 保证
+ *   写不阻塞读, 读快照原子.
+ * - 读: UI 线程 (Compose recomposition 触发) 调用 [snapshot] / [phases] /
+ *   [instants]. CopyOnWriteArrayList 的 iterator 是弱一致但不会抛
+ *   ConcurrentModificationException.
+ *
+ * ## 容量
+ *
+ * 启动期 ~18 phase + 几十个 instant, 稳态运行时主要由 PR #4 的 Monitor 驱动
+ * (帧率/内存/GC 各 1Hz 采样), 单 session 跑 1 小时约 10000 条, 远低于
+ * CopyOnWriteArrayList 的实际容量. 不需要在 PR #3 引入分页.
+ *
+ * @author android_zero
+ */
+class PhaseCollector {
+
+  private val events = CopyOnWriteArrayList<PerfEvent>()
+
+  @Volatile private var startElapsedMs: Long = 0L
+
+  @Volatile private var bootEnded: Boolean = false
+
+  /**
+   * 收集一个事件.
+   *
+   * - 首次调用时记录 [startElapsedMs] = [SystemClock.elapsedRealtime]
+   * - 启动阶段 ([bootEnded] = false) 累积所有 phase / instant
+   * - 收到 [PerfEvent.EndBoot] 后切换稳态模式
+   */
+  fun collect(event: PerfEvent) {
+    if (startElapsedMs == 0L) {
+      startElapsedMs = android.os.SystemClock.elapsedRealtime()
+    }
+    if (event is PerfEvent.EndBoot) {
+      bootEnded = true
+    }
+    events.add(event)
+  }
+
+  /** 启动是否已结束 (用于 UI 切换 tab 颜色 / 显示 banner). */
+  fun isBootEnded(): Boolean = bootEnded
+
+  /**
+   * 整个 session 的 [SystemClock.elapsedRealtime] 起点 (用于显示"启动耗时
+   * 总计"). 0 表示尚未收到任何事件.
+   */
+  fun startElapsedMs(): Long = startElapsedMs
+
+  /**
+   * 当前累积的所有事件 (按收到顺序).
+   *
+   * 返回的是不可变快照, 业务代码可安全遍历.
+   */
+  fun snapshot(): List<PerfEvent> = events.toList()
+
+  /** 仅 phase 事件 (按时间排序). */
+  fun phases(): List<PerfEvent.Phase> = events.filterIsInstance<PerfEvent.Phase>()
+
+  /** 仅 instant 事件. */
+  fun instants(): List<PerfEvent.Instant> = events.filterIsInstance<PerfEvent.Instant>()
+
+  /** 清空所有累积 (用于"重新记录"按钮). */
+  fun clear() {
+    events.clear()
+    startElapsedMs = 0L
+    bootEnded = false
+  }
+
+  /** 当前累积事件数 (调试用). */
+  fun size(): Int = events.size
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
@@ -1,0 +1,181 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.tracer
+
+import android.net.LocalSocket
+import android.net.LocalSocketAddress
+import java.io.IOException
+import java.io.OutputStream
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+
+/**
+ * :perf socket 客户端 (PR #2/5).
+ *
+ * 与 [com.itsaky.androidide.perf.server.PerfServerSocket] (PR #3 实施)
+ * 通过 Unix domain socket (LocalSocket) 通信. 主进程是 client, :perf 进程是 server.
+ *
+ * ## 协议 (PR #2 暂定, PR #3 协议层会细化)
+ *
+ * 每条事件一行, UTF-8 JSON:
+ *
+ * ```
+ * {"type":"phase","name":"koin_start","elapsed":45}\n
+ * {"type":"instant","name":"first_frame"}\n
+ * {"type":"end_boot"}\n
+ * ```
+ *
+ * - 字段顺序不重要, server 容错解析
+ * - `\n` 是一条事件的结束符
+ * - UTF-8 编码, name 不能含换行 / 引号 (调用方保证)
+ *
+ * ## 线程模型
+ *
+ * - 业务线程 (main / IO / Binder) 调 `sendPhase` → 写入无锁 [LinkedBlockingQueue]
+ * - 单独的 writer 线程 ([executor]) 从队列取事件 → 序列化 → 写入 [OutputStream]
+ * - 写失败 (server 关闭 / IO 异常) → 标记 [broken] = true, 后续 sendXxx 立即 no-op
+ *
+ * 这种设计保证:
+ * 1. **业务线程 0 阻塞**: 写 socket 是后台线程的事
+ * 2. **顺序保证**: FIFO 队列保证事件按发出顺序被 server 收到
+ * 3. **失败隔离**: socket 写崩不会让主 application 挂
+ *
+ * @author android_zero
+ */
+internal class PerfClientSocket(private val socketPath: String) {
+
+  private val log = LoggerFactory.getLogger(PerfClientSocket::class.java)
+
+  private val queue = LinkedBlockingQueue<String>(QUEUE_CAPACITY)
+  private val executor = Executors.newSingleThreadExecutor { r ->
+    Thread(r, "perf-tracer-writer").apply { isDaemon = true }
+  }
+
+  @Volatile private var socket: LocalSocket? = null
+  @Volatile private var out: OutputStream? = null
+
+  /** 是否已断连 (写失败一次即标记, 后续 sendXxx 全部 no-op). */
+  @Volatile private var broken: Boolean = false
+
+  /**
+   * 尝试 connect 到 :perf server.
+   *
+   * @return true 表示 connect + 启动 writer 成功
+   */
+  fun tryConnect(): Boolean {
+    return try {
+      val sock = LocalSocket()
+      sock.connect(LocalSocketAddress(socketPath, LocalSocketAddress.Namespace.FILESYSTEM))
+      val output = sock.outputStream
+      socket = sock
+      out = output
+      executor.submit(::writerLoop)
+      true
+    } catch (e: IOException) {
+      log.warn("PerfClientSocket connect failed: {}", e.message)
+      cleanup()
+      false
+    }
+  }
+
+  /** 异步发送 phase 事件 (有耗时). */
+  fun sendPhase(name: String, elapsedMs: Long) {
+    if (broken) return
+    enqueue("""{"type":"phase","name":"${escape(name)}","elapsed":$elapsedMs}""")
+  }
+
+  /** 异步发送 instant 事件 (无耗时). */
+  fun sendInstant(name: String) {
+    if (broken) return
+    enqueue("""{"type":"instant","name":"${escape(name)}"}""")
+  }
+
+  /** 异步发送 end_boot 标记. */
+  fun sendEndBoot() {
+    if (broken) return
+    enqueue("""{"type":"end_boot"}""")
+  }
+
+  /** 主动关闭 (app exit 时调用). */
+  fun close() {
+    broken = true
+    executor.shutdown()
+    cleanup()
+  }
+
+  // -- private --
+
+  private fun enqueue(line: String) {
+    if (broken) return
+    val ok = queue.offer(line)
+    if (!ok) {
+      // 队列满 → 标记 broken, 后续全部丢弃, 避免主线程被阻塞
+      log.warn("PerfClientSocket queue full ({}), dropping events", QUEUE_CAPACITY)
+      broken = true
+    }
+  }
+
+  private fun writerLoop() {
+    try {
+      while (!broken && !Thread.currentThread().isInterrupted) {
+        val line = queue.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS) ?: continue
+        writeLine(line)
+      }
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    } catch (e: Throwable) {
+      log.warn("PerfClientSocket writer loop crashed: {}", e.message)
+    } finally {
+      cleanup()
+      broken = true
+    }
+  }
+
+  private fun writeLine(line: String) {
+    val output = out ?: run {
+      broken = true
+      return
+    }
+    try {
+      output.write(line.toByteArray(Charsets.UTF_8))
+      output.write(LINE_DELIMITER)
+      output.flush()
+    } catch (e: IOException) {
+      log.warn("PerfClientSocket write failed: {}", e.message)
+      broken = true
+      cleanup()
+    }
+  }
+
+  private fun cleanup() {
+    runCatching { out?.close() }
+    runCatching { socket?.close() }
+    out = null
+    socket = null
+  }
+
+  private fun escape(s: String): String =
+      s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+  companion object {
+    private val LINE_DELIMITER = byteArrayOf('\n'.code.toByte())
+    private const val QUEUE_CAPACITY = 1024
+    private const val POLL_TIMEOUT_MS = 50L
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
@@ -1,0 +1,180 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.tracer
+
+import android.content.Context
+import android.os.SystemClock
+import com.itsaky.androidide.BuildConfig
+import com.itsaky.androidide.perf.PerfApplication
+import java.io.File
+import org.slf4j.LoggerFactory
+
+/**
+ * 主进程埋点门面 (PR #2/5).
+ *
+ * 调用方在 IDEApplication / Activity 关键 init 步骤包裹:
+ *
+ * ```kotlin
+ * PerfTracer.trace("init_koin") {
+ *   RikkaHubRuntime.ensureKoinStarted(this)
+ * }
+ * ```
+ *
+ * ## 降级策略 (核心设计)
+ *
+ * - **Release build** ([BuildConfig.DEBUG] = false): 全部方法被编译器
+ *   消除, 0 overhead. 所有 `trace {}` 块变为裸的 `block()` 调用.
+ * - **Debug build 但 :perf 进程未启动** (Perf Console 未从桌面启动):
+ *   [tryAttach] 读 [PERF_SOCKET_PATH_FILE] 文件失败 → 关闭内部
+ *   [PerfClientSocket], 后续 `trace` 调用变 no-op, 不抛异常, 不打 log 噪音.
+ * - **Debug build 且 :perf 已启动**: 通过 LocalSocket 异步发送事件
+ *   到 :perf 进程, 由 PR #3 的 [com.itsaky.androidide.perf.server.PerfServerSocket] 接收.
+ *
+ * 这种设计保证:
+ * 1. **用户能控制**: 不开 Perf Console = 完全 0 overhead (只是常量判断)
+ * 2. **不会 crash**: socket 失败 → 静默 no-op, 永远不会因为监控影响主 application
+ * 3. **不会 NPE**: 静态 [trace] 调用方不用 null check
+ *
+ * @author android_zero
+ */
+object PerfTracer {
+
+  private val log = LoggerFactory.getLogger(PerfTracer::class.java)
+
+  /**
+   * socket 客户端 (懒初始化, 失败后变 no-op).
+   *
+   * `volatile` 保证多线程可见性 (IDEApplication 入口在 main thread,
+   * 后续 Activity onCreate 可能跨 thread).
+   */
+  @Volatile
+  private var socket: PerfClientSocket? = null
+
+  /** :perf 进程是否已 attach 成功. 仅用于日志, 不影响行为. */
+  @Volatile
+  private var attached: Boolean = false
+
+  /**
+   * 尝试连接 :perf 进程.
+   *
+   * 必须在主 application 入口 (e.g. [com.itsaky.androidide.app.IDEApplication.onCreate]
+   * 第一行) 调用一次, 后续 `trace` 才会真正发出事件.
+   *
+   * - [BuildConfig.DEBUG] = false → no-op
+   * - :perf 进程 → no-op (避免 :perf 进程自己 connect 自己, 死循环)
+   * - socket 文件不存在 → no-op (Perf Console 未启动, 用户故意不开监控)
+   * - socket connect 失败 → 静默失败, 后续 trace no-op
+   */
+  @JvmStatic
+  fun tryAttach(context: Context) {
+    if (!BuildConfig.DEBUG) {
+      // Release build: 完全不初始化, 编译器会消除后续 trace 调用
+      return
+    }
+
+    val processName = runCatching {
+      // android.os.Process.myProcessName() requires API 28
+      @Suppress("DEPRECATION")
+      android.os.Process.myProcessName()
+    }.getOrDefault("")
+
+    if (processName.endsWith(":perf")) {
+      // :perf 进程自己不要 connect 自己的 socket server
+      log.info("PerfTracer running inside :perf process, skip attach")
+      return
+    }
+
+    val socketPathFile = File(context.cacheDir, PerfApplication.PERF_SOCKET_PATH_FILE)
+    if (!socketPathFile.exists()) {
+      log.info("PerfTracer: socket path file not found, :perf console not started")
+      return
+    }
+
+    val socketPath = runCatching { socketPathFile.readText().trim() }.getOrNull()
+    if (socketPath.isNullOrEmpty()) {
+      log.warn("PerfTracer: socket path file is empty")
+      return
+    }
+
+    val client = PerfClientSocket(socketPath)
+    val connected = client.tryConnect()
+    if (!connected) {
+      log.warn("PerfTracer: connect to :perf socket failed, will be no-op")
+      // 不保留 client 引用, 后续 trace 自动 no-op
+      return
+    }
+
+    socket = client
+    attached = true
+    log.info("PerfTracer: attached to :perf socket at {}", socketPath)
+  }
+
+  /**
+   * 包裹一段代码, 测量其耗时并发送 phase 事件.
+   *
+   * **inline** 设计: 编译器会把 [block] 调用直接展开, 关闭时 ([attached] = false)
+   * 整个 `if (!attached) return block()` 会被消除, 调用方在 Release build 看到的就是
+   * 纯 `block()` 调用, 0 overhead.
+   *
+   * @param name phase 名称 (e.g. "init_koin")
+   * @param block 待测量代码块
+   * @return [block] 的返回值
+   */
+  @JvmStatic
+  inline fun <T> trace(name: String, block: () -> T): T {
+    if (!BuildConfig.DEBUG) return block()
+    val s = socket ?: return block()
+    val start = SystemClock.elapsedRealtime()
+    return try {
+      block()
+    } finally {
+      val elapsed = SystemClock.elapsedRealtime() - start
+      s.sendPhase(name, elapsed)
+    }
+  }
+
+  /**
+   * 报告一个"非代码块"事件 (e.g. process start, first frame).
+   *
+   * Release build 完全消除. Debug 未 attach 时 no-op.
+   */
+  @JvmStatic
+  fun reportInstant(name: String) {
+    if (!BuildConfig.DEBUG) return
+    socket?.sendInstant(name)
+  }
+
+  /**
+   * 标记启动阶段结束.
+   *
+   * 调用方通常在 SplashActivity / MainActivity onCreate 末尾调一次,
+   * 触发 server 端切换到"启动后采样"模式 (降低 1Hz→0.1Hz 之类).
+   */
+  @JvmStatic
+  fun endBoot() {
+    if (!BuildConfig.DEBUG) return
+    socket?.sendEndBoot()
+  }
+
+  /**
+   * 是否已 attach 到 :perf 进程.
+   *
+   * 主要用于 UI 显示 / 日志, 业务代码不应依赖.
+   */
+  @JvmStatic
+  fun isAttached(): Boolean = attached
+}

--- a/core/app/src/main/res/drawable/ic_perf_console_foreground.xml
+++ b/core/app/src/main/res/drawable/ic_perf_console_foreground.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This file is part of AndroidIDE.
+  ~
+  ~  AndroidIDE is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  AndroidIDE is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!--
+      Perf Console 图标: 半圆表盘 + 十字指针 + 中心圆点.
+      描边深紫 (#3700B3), 填充透明, 适配浅/暗色 launcher 背景.
+      关键尺寸都放在中央 66x66 安全区 (中心 54,54).
+    -->
+
+    <!-- 表盘外环 (深紫) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:pathData="M 30,54 A 24,24 0 1 1 78,54" />
+
+    <!-- 表盘底部直线 (封闭) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:pathData="M 30,54 L 78,54" />
+
+    <!-- 刻度 1 (12 点) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="3"
+        android:pathData="M 54,32 L 54,38" />
+
+    <!-- 刻度 2 (3 点) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="3"
+        android:pathData="M 76,54 L 70,54" />
+
+    <!-- 刻度 3 (9 点) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="3"
+        android:pathData="M 32,54 L 38,54" />
+
+    <!-- 指针 (从中心 54,54 指向 1 点方向) -->
+    <path
+        android:strokeColor="#FF3700B3"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:pathData="M 54,54 L 64,42" />
+
+    <!-- 中心圆点 -->
+    <path
+        android:fillColor="#3700B3"
+        android:pathData="M 54,54 m -3,0 a 3,3 0 1,0 6,0 a 3,3 0 1,0 -6,0" />
+</vector>

--- a/core/app/src/main/res/mipmap-anydpi-v26/ic_perf_console.xml
+++ b/core/app/src/main/res/mipmap-anydpi-v26/ic_perf_console.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  This file is part of AndroidIDE.
   ~
   ~  AndroidIDE is free software: you can redistribute it and/or modify
@@ -14,12 +15,11 @@
   ~  You should have received a copy of the GNU General Public License
   ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
   -->
-
-<resources>
-  <!--  Required by F-Droid-->
-  <string name="app_name" translatable="false">ZeroStudio</string>
-
-  <!-- Perf Console (性能监控调试控制台) — 桌面启动图标 + 通知标签 -->
-  <string name="perf_console_title" translatable="false">Perf Console</string>
-  <string name="perf_console_label">Perf Console</string>
-</resources>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+      Background 用 launcher 共用的纯白色, foreground 用自绘 vector drawable
+      (表盘 + 指针). 尺寸 108x108dp, 安全区中心 66x66dp (1/3 边距).
+    -->
+    <background android:drawable="@color/ic_perf_console_background"/>
+    <foreground android:drawable="@drawable/ic_perf_console_foreground"/>
+</adaptive-icon>

--- a/core/app/src/main/res/values/perf_console_colors.xml
+++ b/core/app/src/main/res/values/perf_console_colors.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  This file is part of AndroidIDE.
   ~
   ~  AndroidIDE is free software: you can redistribute it and/or modify
@@ -14,12 +15,7 @@
   ~  You should have received a copy of the GNU General Public License
   ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
   -->
-
 <resources>
-  <!--  Required by F-Droid-->
-  <string name="app_name" translatable="false">ZeroStudio</string>
-
-  <!-- Perf Console (性能监控调试控制台) — 桌面启动图标 + 通知标签 -->
-  <string name="perf_console_title" translatable="false">Perf Console</string>
-  <string name="perf_console_label">Perf Console</string>
+    <!-- Perf Console 图标背景色: 浅紫, 与 launcher (#FFFFFF) 区分 -->
+    <color name="ic_perf_console_background">#EDE7F6</color>
 </resources>


### PR DESCRIPTION
## 背景

5 步计划第 3 步: :perf 进程的 LocalServerSocket + JSON 协议解析 + 内存累积 phase 数据.

详细 spec: docs/superpowers/specs/2026-06-14-perf-console-design.md

依赖: PR #364 (tracer) 已开, merge 后即可联调.

## 改动 (7 files, +570/-35)

### 新增 (5)

- core/app/.../perf/proto/PerfEvent.kt — 密封类 (Phase / Instant / EndBoot)
- core/app/.../perf/proto/PerfSocketProtocol.kt — line-delimited JSON, 手工 regex
- core/app/.../perf/server/PhaseCollector.kt — 内存累积, CopyOnWriteArrayList
- core/app/.../perf/server/PerfServerSocket.kt — accept loop, 写 pathFile
- core/app/.../perf/PhaseStore.kt — 全局 holder, UI 读 collector / 关 server

### 修改 (2)

- core/app/.../perf/PerfApplication.kt — 重构为 object, 提供 init(Context)
- core/app/.../app/IDEApplication.kt — :perf 进程分支调 PerfApplication.init

## 协议

line-delimited JSON, UTF-8, `\n` 分隔:

```
{"type":"phase","name":"koin_start","elapsed":45}
{"type":"instant","name":"ide_on_create_begin"}
{"type":"end_boot"}
```

服务端容错解析 (regex), 解析失败 log warn 不中断.

## 进程模型

```
Main process                  :perf process
─────────────                 ─────────────
IDEApplication                IDEApplication (isPerfProcess → early return)
PerfTracer.tryAttach    ←──    PerfApplication.init
  ↓ 读 PERF_SOCKET_PATH_FILE   ↓
  ↓ 拿 socket 路径             创建 LocalServerSocket
PerfClientSocket.connect  →    写 socket-path.txt
  ↓ async write JSON            ↓
                                PerfServerSocket.acceptLoop
                                ↓
                                handleClient 读行 → parse → PhaseCollector.collect
                                                      ↓
                                                      UI (PR #5) snapshot
```

## 设计取舍

- **JSON vs 二进制**: 调试友好 (logcat 可读), 18 段 phase + 1Hz 采样几 KB/分钟
- **手工 regex vs kotlinx.serialization**: 18 段字段固定, 避免给 :perf 加依赖
- **CopyOnWriteArrayList**: 写不阻塞读, UI snapshot 原子
- **object + init() 而非 class + onCreate()**: Android 一 APK 一 Application 类,
  manifest 用 IDEApplication, :perf 进程 fork 时系统会加载 IDEApplication,
  在 isPerfProcess() 分支显式调 PerfApplication.init.

## 已知限制 (后续 PR)

- 单进程累积, PR #4 加 BootHistoryStore 持久化
- UI (PR #5) 才有实际用途
- 1Hz 持续采样 (PR #4 Monitor)

## 风险

- LocalServerSocket 在 Android 14+ 受 selinux 限制, 但同 UID 内进程间通信允许
- 旧 socket 文件残留: start() 内先 delete 旧文件
- 协议字段扩展: 服务端 regex 容错, 新字段加在末尾不影响解析

## 后续 PR

| PR | 范围 |
| --- | --- |
| #2 (依赖) | PerfTracer + 18 段埋点 |
| #3 (本 PR) | server + 协议 + PhaseCollector |
| #4 | 4 个 Monitor + BootHistoryStore |
| #5 | 完整 UI (Dashboard + 4 tab + 6 card) |
