### PR TITLE
feat(perf): PR #5/5 完整 Compose UI (Dashboard + 4 tab + 6 card)

### DIFF
--- a/core/app/src/main/AndroidManifest.xml
+++ b/core/app/src/main/AndroidManifest.xml
@@ -47,6 +47,34 @@
                     <category android:name="android.intent.category.LAUNCHER" />
                </intent-filter>
           </activity>
+
+          <!--
+            Perf Console (性能监控调试控制台).
+            跑在独立进程 ":perf", 不受主 application 初始化阻塞.
+            桌面启动图标, 用户可从桌面独立启动, 即使主 application
+            启动崩溃, 此 Activity 仍能显示并继续记录.
+
+            - process=":perf"        : 独立进程, fork 时只跑 BaseApplication
+            - taskAffinity=""        : 不与主进程共享任务栈, 避免回主进程
+            - launchMode="singleInstance" : 多次从桌面点击只产生一个实例
+            - excludeFromRecents="true"   : 不出现在最近任务列表
+            - icon / label           : 桌面图标 / 标题
+          -->
+          <activity
+               android:name=".perf.PerfConsoleActivity"
+               android:exported="true"
+               android:process=":perf"
+               android:taskAffinity=""
+               android:launchMode="singleInstance"
+               android:excludeFromRecents="true"
+               android:theme="@style/Theme.AndroidIDE"
+               android:icon="@mipmap/ic_perf_console"
+               android:label="@string/perf_console_title">
+               <intent-filter>
+                    <action android:name="android.intent.action.MAIN" />
+                    <category android:name="android.intent.category.LAUNCHER" />
+               </intent-filter>
+          </activity>
           
           <activity
                android:exported="false"

--- a/core/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
@@ -162,6 +162,7 @@ class MainActivity : EdgeToEdgeIDEActivity() {
     }
 
     onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
   }
 
   private fun askProjectOpenPermission(root: File) {

--- a/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -61,10 +61,11 @@ class OnboardingActivity : AppIntro2() {
 
   @SuppressLint("SourceLockedOrientationActivity")
   override fun onCreate(savedInstanceState: Bundle?) {
-    IThemeManager.getInstance().applyTheme(this)
-    try {
-      requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    } catch (e: Exception) {}
+    PerfTracer.trace("onboarding_activity_oncreate") {
+      IThemeManager.getInstance().applyTheme(this)
+      try {
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+      } catch (e: Exception) {}
 
     super.onCreate(savedInstanceState)
 
@@ -142,6 +143,7 @@ class OnboardingActivity : AppIntro2() {
 
     if (!SdkChecker.isEnvironmentReadySync()) {
       addSlide(OdSdkToolInstallFragment.newInstance(this))
+    }
     }
   }
 

--- a/core/app/src/main/java/com/itsaky/androidide/activities/SplashActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/SplashActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.itsaky.androidide.perf.tracer.PerfTracer
 
 /**
  * Startup launcher activity.
@@ -18,8 +19,10 @@ class SplashActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     // Keep launcher activity ultra-lightweight: no Compose / no heavy rendering work.
-    startActivity(Intent(this, OnboardingActivity::class.java))
-    finish()
-    overridePendingTransition(0, 0)
+    PerfTracer.trace("splash_activity_oncreate") {
+      startActivity(Intent(this, OnboardingActivity::class.java))
+      finish()
+      overridePendingTransition(0, 0)
+    }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -36,6 +36,8 @@ import com.itsaky.androidide.events.EditorEventsIndex
 import com.itsaky.androidide.events.LspApiEventsIndex
 import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
+import com.itsaky.androidide.perf.PerfApplication
+import com.itsaky.androidide.perf.monitor.MonitorCoordinator
 import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.preferences.internal.GeneralPreferences
@@ -145,6 +147,7 @@ class IDEApplication : TermuxApplication() {
 
     PerfTracer.reportInstant("ide_on_create_end")
     PerfTracer.endBoot()
+    MonitorCoordinator.start(this)
   }
 
   /**

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -78,11 +78,13 @@ class IDEApplication : TermuxApplication() {
     val bootStart = System.currentTimeMillis()
 
     // :perf 进程: 只跑 super.onCreate (BaseApplication + TermuxApplication 必要初始化),
+    // 然后调 PerfApplication.init 启动 server / PhaseCollector, 再 return.
     // 完全跳过 IDE 特有的初始化 (Koin/EventBus/StrictMode/ColorScheme 等).
     // 让 Perf Console 在 :perf 进程极轻量, 不被主 application 的任何阻塞影响.
     if (isPerfProcess()) {
       super.onCreate()
       log.info("IDEApplication onCreate skipped (running in :perf process)")
+      PerfApplication.init(this)
       return
     }
 

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -36,6 +36,7 @@ import com.itsaky.androidide.events.EditorEventsIndex
 import com.itsaky.androidide.events.LspApiEventsIndex
 import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
+import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.resources.localization.LocaleProvider
@@ -75,44 +76,73 @@ class IDEApplication : TermuxApplication() {
   @OptIn(DelicateCoroutinesApi::class)
   override fun onCreate() {
     val bootStart = System.currentTimeMillis()
+
+    // :perf 进程: 只跑 super.onCreate (BaseApplication + TermuxApplication 必要初始化),
+    // 完全跳过 IDE 特有的初始化 (Koin/EventBus/StrictMode/ColorScheme 等).
+    // 让 Perf Console 在 :perf 进程极轻量, 不被主 application 的任何阻塞影响.
+    if (isPerfProcess()) {
+      super.onCreate()
+      log.info("IDEApplication onCreate skipped (running in :perf process)")
+      return
+    }
+
     instance = this
-    super.onCreate()
-    RikkaHubRuntime.ensureKoinStarted(this)
+    PerfTracer.reportInstant("ide_on_create_begin")
+    PerfTracer.tryAttach(this)
+    PerfTracer.trace("super_on_create") { super.onCreate() }
+    PerfTracer.trace("init_koin") { RikkaHubRuntime.ensureKoinStarted(this) }
 
-    applyPersistedLocale()
+    PerfTracer.trace("apply_persisted_locale") { applyPersistedLocale() }
 
-    uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
-    Thread.setDefaultUncaughtExceptionHandler { thread, th -> handleCrash(thread, th) }
+    PerfTracer.trace("set_uncaught_handler") {
+      uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+      Thread.setDefaultUncaughtExceptionHandler { thread, th -> handleCrash(thread, th) }
+    }
 
     if (BuildConfig.DEBUG) {
-      StrictMode.setVmPolicy(
-          StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy()).penaltyLog().detectAll().build()
-      )
+      PerfTracer.trace("strict_mode_setup") {
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy()).penaltyLog().detectAll().build()
+        )
+      }
       if (DevOpsPreferences.dumpLogs) {
-        startLogcatReader()
+        PerfTracer.trace("start_logcat_reader") { startLogcatReader() }
       }
     }
 
-    EventBus.builder()
-        .addIndex(AppEventsIndex())
-        .addIndex(EditorEventsIndex())
-        .addIndex(LspApiEventsIndex())
-        .addIndex(LspJavaEventsIndex())
-        .addIndex(LspKotlinEventsIndex())
-        .installDefaultEventBus(true)
-
-    EventBus.getDefault().register(this)
-
-    AppCompatDelegate.setDefaultNightMode(GeneralPreferences.uiMode)
-
-    if (IThemeManager.getInstance().getCurrentTheme() == IDETheme.MATERIAL_YOU) {
-      DynamicColors.applyToActivitiesIfAvailable(this)
+    PerfTracer.trace("eventbus_add_indexes") {
+      EventBus.builder()
+          .addIndex(AppEventsIndex())
+          .addIndex(EditorEventsIndex())
+          .addIndex(LspApiEventsIndex())
+          .addIndex(LspJavaEventsIndex())
+          .addIndex(LspKotlinEventsIndex())
+          .installDefaultEventBus(true)
     }
 
-    EditorColorScheme.setDefault(SchemeAndroidIDE.newInstance(null))
+    PerfTracer.trace("eventbus_register") { EventBus.getDefault().register(this) }
 
-    GlobalScope.launch(Dispatchers.IO) { IDEColorSchemeProvider.init() }
+    PerfTracer.trace("set_default_night_mode") {
+      AppCompatDelegate.setDefaultNightMode(GeneralPreferences.uiMode)
+    }
 
+    if (IThemeManager.getInstance().getCurrentTheme() == IDETheme.MATERIAL_YOU) {
+      PerfTracer.trace("dynamic_colors_apply") {
+        DynamicColors.applyToActivitiesIfAvailable(this)
+      }
+    }
+
+    PerfTracer.trace("editor_color_scheme_default") {
+      EditorColorScheme.setDefault(SchemeAndroidIDE.newInstance(null))
+    }
+
+    PerfTracer.reportInstant("ide_color_scheme_provider_init_start")
+    GlobalScope.launch(Dispatchers.IO) {
+      PerfTracer.trace("ide_color_scheme_provider_init") { IDEColorSchemeProvider.init() }
+    }
+
+    PerfTracer.reportInstant("ide_on_create_end")
+    PerfTracer.endBoot()
   }
 
   /**
@@ -207,6 +237,7 @@ class IDEApplication : TermuxApplication() {
 
   override fun attachBaseContext(base: android.content.Context?) {
     if (base != null) {
+      PerfTracer.reportInstant("ide_attach_base_context")
       val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(base)
       val selectedLocaleKey = prefs.getString(GeneralPreferences.SELECTED_LOCALE, null)
       val localeListCompat =
@@ -220,6 +251,24 @@ class IDEApplication : TermuxApplication() {
 
   companion object {
     private val log = LoggerFactory.getLogger(IDEApplication::class.java)
+
+    /**
+     * 当前进程是否在 `:perf` 进程 (Perf Console 独立进程).
+     *
+     * 用 `endsWith(":perf")` 而不是 equals 是因为: `Process.myProcessName()` 在某些
+     * OEM (e.g. 小米) 上可能返回 `com.itsaky.androidide:perf` 或 `xxx:perf`,
+     * 末尾 `:perf` 是稳定后缀.
+     */
+    @JvmStatic
+    private fun isPerfProcess(): Boolean {
+      val processName =
+          runCatching {
+            // android.os.Process.myProcessName() requires API 28
+            @Suppress("DEPRECATION")
+            android.os.Process.myProcessName()
+          }.getOrDefault("")
+      return processName.endsWith(":perf")
+    }
 
     @JvmStatic
     lateinit var instance: IDEApplication

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
@@ -19,6 +19,7 @@ package com.itsaky.androidide.perf
 import android.content.Context
 import com.itsaky.androidide.perf.server.PerfServerSocket
 import com.itsaky.androidide.perf.server.PhaseCollector
+import com.itsaky.androidide.perf.store.BootHistoryStore
 import java.io.File
 import java.util.concurrent.Executors
 import org.slf4j.LoggerFactory
@@ -92,6 +93,12 @@ object PerfApplication {
 
     val collector = PhaseCollector()
     val server = PerfServerSocket(socketPath, pathFile, collector)
+
+    // 启动期结束 (PerfTracer.endBoot) 时持久化 phase 列表到历史
+    val historyStore = BootHistoryStore(context)
+    collector.addEndBootListener { events, startElapsedMs ->
+      historyStore.append(events, startElapsedMs)
+    }
 
     // 标记 server 状态供 UI (PR #5) 读
     PhaseStore.bind(collector, server)

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
@@ -16,56 +16,107 @@
  */
 package com.itsaky.androidide.perf
 
-import android.app.Application
+import android.content.Context
+import com.itsaky.androidide.perf.server.PerfServerSocket
+import com.itsaky.androidide.perf.server.PhaseCollector
+import java.io.File
+import java.util.concurrent.Executors
 import org.slf4j.LoggerFactory
 
 /**
- * :perf 进程的 [Application].
+ * :perf 进程的"逻辑 Application" (PR #3/5).
  *
- * 跑在独立进程 `android:process=":perf"`, 不会被主 application
- * (`com.itsaky.androidide`) 任何初始化阻塞. 主 application 启动
- * 崩溃时, 此 Application 仍可用, 性能监控 UI 仍能显示.
+ * ## 重要: 本类 **不是** 系统加载的 Application 类
+ *
+ * Android 一个 APK 只能有一个 Application 类, 当前 manifest 用的是
+ * `com.itsaky.androidide.app.IDEApplication`. 系统在 fork `:perf` 进程时
+ * 会加载 IDEApplication, [IDEApplication.onCreate] 通过 [isPerfProcess] 判断
+ * 提前 return 后, **显式调 [init]** 把本类的逻辑跑起来.
+ *
+ * 这种设计的好处:
+ * 1. 保持 :perf 进程所有初始化代码集中在一个文件 ([init]), 易维护
+ * 2. 主进程 manifest 改动最小 (不需要 `tools:replace` 之类的 manifest merger 黑魔法)
+ * 3. IDEApplication 主进程代码完全不变, 只是在 :perf 进程多了一个 init 入口
  *
  * ## 启动后做的事 (按 PR 顺序)
  *
- * - PR #1 (本 PR): 仅 log, 不启动任何后台任务
- * - PR #3: 创建 `LocalServerSocket` ([PERF_SOCKET_PATH]) 等主进程 connect
- * - PR #4: 启动 4 个 Monitor (FrameRate / Memory / Gc / Anr)
+ * - **PR #1**: 骨架 — 仅 log 占位
+ * - **PR #3 (本 PR)**: 启动 [PerfServerSocket] + [PhaseCollector],
+ *   把 socket 路径写到 [PERF_SOCKET_PATH_FILE] 供主进程连接
+ * - **PR #4**: 启动 4 个 Monitor (FrameRate / Memory / Gc / Anr)
  *
- * 主进程的 `PerfTracer.tryAttach(...)` 通过读 [PERF_SOCKET_PATH_FILE] 文件
- * 获得 socket 完整路径, 实现两进程解耦.
+ * ## 进程模型
+ *
+ * ```
+ *  ┌──────────────────┐  LocalSocket (filesystem)  ┌──────────────────┐
+ *  │  Main process    │ ────────────────────────▶ │  :perf process   │
+ *  │  (IDEApplication)│   {"type":"phase",...}    │  PerfServerSocket│
+ *  │  PerfTracer      │                           │  → PhaseCollector│
+ *  │  PerfClientSocket│ ◀─────── (无返回) ──────── │  → UI (PR #5)    │
+ *  └──────────────────┘                            └──────────────────┘
+ * ```
  *
  * @author android_zero
  */
-class PerfApplication : Application() {
+object PerfApplication {
 
-  override fun onCreate() {
-    super.onCreate()
-    log.info("PerfApplication onCreate (PR #1 骨架, 无 socket server / monitor)")
+  private val log = LoggerFactory.getLogger(PerfApplication::class.java)
+
+  /**
+   * 后台 executor, 用于跑 server accept loop.
+   *
+   * 单线程足够 (server.start 内部用 cached pool 处理多 client).
+   * daemon = true 保证不阻止 JVM 退出.
+   */
+  private val serverExecutor = Executors.newSingleThreadExecutor { r ->
+    Thread(r, "perf-app-server").apply { isDaemon = true }
   }
 
-  companion object {
-    private val log = LoggerFactory.getLogger(PerfApplication::class.java)
+  /**
+   * 初始化 :perf 进程.
+   *
+   * 由 [com.itsaky.androidide.app.IDEApplication.onCreate] 在 `isPerfProcess()` 分支调.
+   * 幂等: 二次调用 no-op.
+   */
+  @JvmStatic
+  fun init(context: Context) {
+    if (PhaseStore.isReady()) {
+      log.info("PerfApplication.init already done, skip")
+      return
+    }
+    log.info("PerfApplication.init (PR #3 启动 server + PhaseCollector)")
 
-    /**
-     * LocalServerSocket 路径 (相对 app cacheDir).
-     *
-     * 放在 app cacheDir 而不是 filesDir, 因为:
-     * - cacheDir 在低存储时可被系统清理, 但 perf.sock 是运行时 socket,
-     *   app 退出后不需要保留, 清理无害
-     * - cacheDir 路径短, 减少 socket path 长度 (Linux AF_UNIX path ≤ 108 chars)
-     * - 与 TermuxAmSocketServer 路径隔离, 避免冲突
-     */
-    const val PERF_SOCKET_PATH = "perf/perf.sock"
+    val cacheDir = context.cacheDir
+    val socketPath = File(cacheDir, PERF_SOCKET_PATH).absolutePath
+    val pathFile = File(cacheDir, PERF_SOCKET_PATH_FILE)
 
-    /**
-     * Socket 路径信息文件.
-     *
-     * 主进程的 [com.itsaky.androidide.perf.tracer.PerfTracer] 通过
-     * ContentProvider / 直读此文件得到 socket 完整路径. 替代硬编码路径,
-     * 让 :perf 与主进程解耦.
-     */
-    const val PERF_SOCKET_PATH_FILE = "perf/socket-path.txt"
+    val collector = PhaseCollector()
+    val server = PerfServerSocket(socketPath, pathFile, collector)
+
+    // 标记 server 状态供 UI (PR #5) 读
+    PhaseStore.bind(collector, server)
+
+    // server 启动放后台线程, 不阻塞 IDEApplication.onCreate
+    serverExecutor.submit { server.start() }
   }
+
+  /**
+   * LocalServerSocket 路径 (相对 app cacheDir).
+   *
+   * 放在 app cacheDir 而不是 filesDir, 因为:
+   * - cacheDir 在低存储时可被系统清理, 但 perf.sock 是运行时 socket,
+   *   app 退出后不需要保留, 清理无害
+   * - cacheDir 路径短, 减少 socket path 长度 (Linux AF_UNIX path ≤ 108 chars)
+   * - 与 TermuxAmSocketServer 路径隔离, 避免冲突
+   */
+  const val PERF_SOCKET_PATH = "perf/perf.sock"
+
+  /**
+   * Socket 路径信息文件.
+   *
+   * 主进程的 [com.itsaky.androidide.perf.tracer.PerfTracer] 通过
+   * ContentProvider / 直读此文件得到 socket 完整路径. 替代硬编码路径,
+   * 让 :perf 与主进程解耦.
+   */
+  const val PERF_SOCKET_PATH_FILE = "perf/socket-path.txt"
 }
-

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfApplication.kt
@@ -1,0 +1,71 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf
+
+import android.app.Application
+import org.slf4j.LoggerFactory
+
+/**
+ * :perf 进程的 [Application].
+ *
+ * 跑在独立进程 `android:process=":perf"`, 不会被主 application
+ * (`com.itsaky.androidide`) 任何初始化阻塞. 主 application 启动
+ * 崩溃时, 此 Application 仍可用, 性能监控 UI 仍能显示.
+ *
+ * ## 启动后做的事 (按 PR 顺序)
+ *
+ * - PR #1 (本 PR): 仅 log, 不启动任何后台任务
+ * - PR #3: 创建 `LocalServerSocket` ([PERF_SOCKET_PATH]) 等主进程 connect
+ * - PR #4: 启动 4 个 Monitor (FrameRate / Memory / Gc / Anr)
+ *
+ * 主进程的 `PerfTracer.tryAttach(...)` 通过读 [PERF_SOCKET_PATH_FILE] 文件
+ * 获得 socket 完整路径, 实现两进程解耦.
+ *
+ * @author android_zero
+ */
+class PerfApplication : Application() {
+
+  override fun onCreate() {
+    super.onCreate()
+    log.info("PerfApplication onCreate (PR #1 骨架, 无 socket server / monitor)")
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(PerfApplication::class.java)
+
+    /**
+     * LocalServerSocket 路径 (相对 app cacheDir).
+     *
+     * 放在 app cacheDir 而不是 filesDir, 因为:
+     * - cacheDir 在低存储时可被系统清理, 但 perf.sock 是运行时 socket,
+     *   app 退出后不需要保留, 清理无害
+     * - cacheDir 路径短, 减少 socket path 长度 (Linux AF_UNIX path ≤ 108 chars)
+     * - 与 TermuxAmSocketServer 路径隔离, 避免冲突
+     */
+    const val PERF_SOCKET_PATH = "perf/perf.sock"
+
+    /**
+     * Socket 路径信息文件.
+     *
+     * 主进程的 [com.itsaky.androidide.perf.tracer.PerfTracer] 通过
+     * ContentProvider / 直读此文件得到 socket 完整路径. 替代硬编码路径,
+     * 让 :perf 与主进程解耦.
+     */
+    const val PERF_SOCKET_PATH_FILE = "perf/socket-path.txt"
+  }
+}
+

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfConsoleActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfConsoleActivity.kt
@@ -19,124 +19,42 @@ package com.itsaky.androidide.perf
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.perf.ui.PerfConsoleScreen
+import com.itsaky.androidide.perf.ui.PerfConsoleViewModel
 
 /**
- * 性能监控调试控制台 (PR #1 骨架).
+ * 性能监控调试控制台 (PR #5 完成).
  *
  * 跑在独立进程 `android:process=":perf"`, 不会被主 application
  * (`com.itsaky.androidide`) 的初始化阻塞. 主 application 启动崩溃时,
  * 此 Activity 仍能启动, 监控 UI 仍能显示.
  *
- * ## PR 路线图
+ * ## 5 步路线图完成
  *
- * - **PR #1 (本 PR)**: 骨架 — 独立 :perf 进程 + 桌面图标 + 占位 UI
- * - **PR #2**: 主进程 [com.itsaky.androidide.perf.tracer.PerfTracer] +
- *   IDEApplication.onCreate 18 段埋点
- * - **PR #3**: [com.itsaky.androidide.perf.server.PerfServerSocket] +
- *   跨进程协议 + PhaseCollector
- * - **PR #4**: 4 个 Monitor (FrameRate / Memory / Gc / Anr) + BootHistoryStore
- * - **PR #5**: 完整 Compose UI (Dashboard + 4 tab + 6 card)
- *
- * 当前 Activity 仅显示静态占位文字, 让用户能验证 :perf 进程独立启动.
+ * - **PR #1**: 骨架 — 独立 :perf 进程 + 桌面图标 ✅
+ * - **PR #2**: 主进程 PerfTracer + IDEApplication.onCreate 18 段埋点 ✅
+ * - **PR #3**: PerfServerSocket + 跨进程协议 + PhaseCollector ✅
+ * - **PR #4**: 4 个 Monitor (FrameRate / Memory / Gc / Anr) + BootHistoryStore ✅
+ * - **PR #5 (本 PR)**: 完整 Compose UI ✅
  *
  * @author android_zero
  */
 class PerfConsoleActivity : ComponentActivity() {
 
+  // 手动创建 ViewModel 避免 viewModels delegate 依赖 androidx-lifecycle-viewmodel-savedstate
+  // (PR #5 走轻依赖路径). Activity onDestroy 时调 onCleared 释放 tickExecutor.
+  private val viewModel: PerfConsoleViewModel by lazy { PerfConsoleViewModel(application) }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContent { MaterialTheme { PerfConsoleSkeletonScreen() } }
+    setContent { MaterialTheme { PerfConsoleScreen(viewModel) } }
   }
-}
 
-/**
- * PR #1 骨架占位屏.
- *
- * 后续 PR 会替换为:
- * - 顶部 toolbar: 进程名 / PID / 启动耗时
- * - 4 tab: Boot / Frame / Memory / Threads
- * - Dashboard: 6 card 显示当前监控数据
- */
-@Composable
-private fun PerfConsoleSkeletonScreen() {
-  Surface(
-      modifier = Modifier.fillMaxSize(),
-      color = MaterialTheme.colorScheme.background,
-  ) {
-    Box(modifier = Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
-      Column(
-          verticalArrangement = Arrangement.spacedBy(16.dp),
-          horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        Text(
-            text = "Perf Console",
-            fontSize = 28.sp,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.primary,
-        )
-        Text(
-            text = "独立 :perf 进程 · 桌面快捷入口",
-            fontSize = 14.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Card(
-            shape = RoundedCornerShape(12.dp),
-            colors =
-                CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                ),
-        ) {
-          Column(
-              modifier = Modifier.padding(20.dp),
-              verticalArrangement = Arrangement.spacedBy(8.dp),
-          ) {
-            Text(
-                text = "PR #1 骨架完成 ✅",
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text =
-                    """
-                    • 独立进程 android:process=":perf" 已生效
-                    • 桌面启动图标已注册
-                    • 等待 PR #2 接入主进程埋点
-                    • 等待 PR #3 启动 LocalServerSocket
-                    • 等待 PR #4 启动 4 个 Monitor
-                    • 等待 PR #5 接入完整 UI
-                    """.trimIndent(),
-                fontFamily = FontFamily.Monospace,
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-          }
-        }
-
-        Text(
-            text = "详细 spec: docs/superpowers/specs/2026-06-14-perf-console-design.md",
-            fontSize = 10.sp,
-            color = MaterialTheme.colorScheme.outline,
-        )
-      }
+  override fun onDestroy() {
+    super.onDestroy()
+    if (isFinishing) {
+      viewModel.onCleared()
     }
   }
 }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PerfConsoleActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PerfConsoleActivity.kt
@@ -1,0 +1,142 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 性能监控调试控制台 (PR #1 骨架).
+ *
+ * 跑在独立进程 `android:process=":perf"`, 不会被主 application
+ * (`com.itsaky.androidide`) 的初始化阻塞. 主 application 启动崩溃时,
+ * 此 Activity 仍能启动, 监控 UI 仍能显示.
+ *
+ * ## PR 路线图
+ *
+ * - **PR #1 (本 PR)**: 骨架 — 独立 :perf 进程 + 桌面图标 + 占位 UI
+ * - **PR #2**: 主进程 [com.itsaky.androidide.perf.tracer.PerfTracer] +
+ *   IDEApplication.onCreate 18 段埋点
+ * - **PR #3**: [com.itsaky.androidide.perf.server.PerfServerSocket] +
+ *   跨进程协议 + PhaseCollector
+ * - **PR #4**: 4 个 Monitor (FrameRate / Memory / Gc / Anr) + BootHistoryStore
+ * - **PR #5**: 完整 Compose UI (Dashboard + 4 tab + 6 card)
+ *
+ * 当前 Activity 仅显示静态占位文字, 让用户能验证 :perf 进程独立启动.
+ *
+ * @author android_zero
+ */
+class PerfConsoleActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { MaterialTheme { PerfConsoleSkeletonScreen() } }
+  }
+}
+
+/**
+ * PR #1 骨架占位屏.
+ *
+ * 后续 PR 会替换为:
+ * - 顶部 toolbar: 进程名 / PID / 启动耗时
+ * - 4 tab: Boot / Frame / Memory / Threads
+ * - Dashboard: 6 card 显示当前监控数据
+ */
+@Composable
+private fun PerfConsoleSkeletonScreen() {
+  Surface(
+      modifier = Modifier.fillMaxSize(),
+      color = MaterialTheme.colorScheme.background,
+  ) {
+    Box(modifier = Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+      Column(
+          verticalArrangement = Arrangement.spacedBy(16.dp),
+          horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(
+            text = "Perf Console",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "独立 :perf 进程 · 桌面快捷入口",
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                ),
+        ) {
+          Column(
+              modifier = Modifier.padding(20.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            Text(
+                text = "PR #1 骨架完成 ✅",
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text =
+                    """
+                    • 独立进程 android:process=":perf" 已生效
+                    • 桌面启动图标已注册
+                    • 等待 PR #2 接入主进程埋点
+                    • 等待 PR #3 启动 LocalServerSocket
+                    • 等待 PR #4 启动 4 个 Monitor
+                    • 等待 PR #5 接入完整 UI
+                    """.trimIndent(),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+
+        Text(
+            text = "详细 spec: docs/superpowers/specs/2026-06-14-perf-console-design.md",
+            fontSize = 10.sp,
+            color = MaterialTheme.colorScheme.outline,
+        )
+      }
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/PhaseStore.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/PhaseStore.kt
@@ -1,0 +1,62 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf
+
+import com.itsaky.androidide.perf.server.PerfServerSocket
+import com.itsaky.androidide.perf.server.PhaseCollector
+
+/**
+ * :perf 进程内的全局 holder (PR #3/5).
+ *
+ * [com.itsaky.androidide.perf.PerfApplication.onCreate] 启动 [PerfServerSocket]
+ * 时, 把 [PhaseCollector] 和 server 实例 bind 到本单例.
+ * UI (PR #5) 通过 [collector] 读当前累积数据, 通过 [server] 在 onDestroy
+ * 时关闭.
+ *
+ * ## 设计
+ *
+ * - 单例 (object) 因为 :perf 进程内只有一个 Application + 一个 server
+ * - 不在主进程使用 ([com.itsaky.androidide.perf.tracer.PerfTracer] 是主进程
+ *   自己的 socket client, 不通过本 holder 通信)
+ * - 没有锁: bind() 只在 onCreate 后台线程调一次, 读在 UI 线程, 内存模型上
+ *   safe (init 顺序保证 happens-before 关系)
+ *
+ * @author android_zero
+ */
+object PhaseStore {
+
+  @Volatile private var _collector: PhaseCollector? = null
+
+  @Volatile private var _server: PerfServerSocket? = null
+
+  /**
+   * 在 [com.itsaky.androidide.perf.PerfApplication.onCreate] 调一次.
+   */
+  fun bind(collector: PhaseCollector, server: PerfServerSocket) {
+    _collector = collector
+    _server = server
+  }
+
+  /** 当前 [PhaseCollector], 启动前返回 null. */
+  fun collector(): PhaseCollector? = _collector
+
+  /** 当前 [PerfServerSocket], 启动前返回 null. */
+  fun server(): PerfServerSocket? = _server
+
+  /** 是否已 bind (UI 用此判断"等待 server 启动" vs "已连接"). */
+  fun isReady(): Boolean = _collector != null && _server != null
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/AnrMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/AnrMonitor.kt
@@ -1,0 +1,77 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.os.Handler
+import android.os.Looper
+import com.itsaky.androidide.perf.tracer.PerfTracer
+
+/**
+ * ANR Monitor (PR #4/5).
+ *
+ * Watchdog 线程每 [PROBE_INTERVAL_MS] 给主线程 post 一个 Runnable, 检测
+ * 往返时间, 超过 [ANR_THRESHOLD_MS] 视为 ANR 发生.
+ *
+ * ## 上报
+ *
+ * - `anr_warn_<latency>` — 接近阈值 (50%-100% of 5s), 记录 warning
+ * - `anr_<latency>` — 超过 5s 阈值, 记录 ANR (UI 用红色高亮)
+ *
+ * 上报的 `latency` 是主线程往返时间 (ms), UI 可排序看最长 ANR.
+ *
+ * ## 注意
+ *
+ * - 这是"软 ANR 检测" (类似 BlockCanary), 不能替代系统 ANR 弹窗
+ * - 多次连续 ANR 合并为最新一次, 避免刷屏
+ * - 调试时 (BuildConfig.DEBUG) 启用, Release 关闭
+ *
+ * @author android_zero
+ */
+class AnrMonitor : PerfMonitor(name = "Anr", intervalMs = PROBE_INTERVAL_MS) {
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private var pingSentAt: Long = 0L
+
+  override fun onStart() {
+    // 第一次 ping 在 PROBE_INTERVAL_MS 后
+  }
+
+  override fun tick() {
+    pingSentAt = System.currentTimeMillis()
+    mainHandler.post {
+      val latency = System.currentTimeMillis() - pingSentAt
+      when {
+        latency >= ANR_THRESHOLD_MS -> {
+          // 真正的 ANR (>5s)
+          PerfTracer.reportInstant("anr_$latency")
+        }
+        latency >= ANR_THRESHOLD_MS / 2 -> {
+          // 接近 ANR (>2.5s) — warning
+          PerfTracer.reportInstant("anr_warn_$latency")
+        }
+      }
+    }
+  }
+
+  companion object {
+    /** 探针间隔 (ms). 1s 是经验值: 不太频繁, 又能在 ANR 几秒内检测到. */
+    private const val PROBE_INTERVAL_MS = 1000L
+
+    /** ANR 阈值 (ms). 与系统 ANR 阈值一致 (5s). */
+    private const val ANR_THRESHOLD_MS = 5000L
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/FrameRateMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/FrameRateMonitor.kt
@@ -1,0 +1,69 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.os.Handler
+import android.os.Looper
+import com.itsaky.androidide.perf.tracer.PerfTracer
+
+/**
+ * 帧率 Monitor (PR #4/5).
+ *
+ * 用 [android.view.Choreographer] 监听 VSYNC, 计算 1 秒内帧数 = FPS.
+ *
+ * ## 实现细节
+ *
+ * - [Choreographer] 必须在有 Looper 的线程 (主线程) 创建并 callback
+ * - 我们用 [Handler] 切到 main thread 注册 callback
+ * - 每个 VSYNC 回调累计 frame 数, 每秒重置 + 上报
+ *
+ * ## 上报
+ *
+ * 用 `phase` 事件, name=`fps_<value>`, elapsed=帧数 (i.e. fps 值).
+ * 接收方 (PR #5 UI) 解析 `fps_*` 前缀识别为帧率指标.
+ *
+ * @author android_zero
+ */
+class FrameRateMonitor : PerfMonitor(name = "FrameRate", intervalMs = 1000L) {
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val choreographer = android.view.Choreographer.getInstance()
+
+  @Volatile private var frames: Int = 0
+
+  override fun onStart() {
+    mainHandler.post { postFrameCallback() }
+  }
+
+  override fun tick() {
+    // 上报上一秒累计帧数
+    val fps = frames
+    frames = 0
+    if (fps > 0) {
+      PerfTracer.reportInstant("fps_$fps")
+    }
+  }
+
+  private fun postFrameCallback() {
+    // Choreographer.postFrameCallback 必须在 main thread 调
+    // callback 自身也会跑在 main thread
+    choreographer.postFrameCallback { _ ->
+      frames++
+      postFrameCallback()
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/GcMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/GcMonitor.kt
@@ -1,0 +1,79 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.os.Build
+import com.itsaky.androidide.perf.tracer.PerfTracer
+
+/**
+ * GC Monitor (PR #4/5).
+ *
+ * 1Hz 采样 GC 计数与耗时, 检测 GC 频率.
+ *
+ * ## API 兼容性
+ *
+ * - API 26+ (Android 8.0 Oreo): [android.os.Debug.getRuntimeStats] 提供
+ *   详细 GC 统计 (gc_count, gc_time_ms). 我们用之.
+ * - API 24-25: 退化, 仅记录 [Runtime.totalMemory] / [freeMemory] 变化
+ *
+ * ## 上报
+ *
+ * - `gc_count` — 累计 GC 次数
+ * - `gc_time_ms` — 累计 GC 耗时 (ms)
+ * - `gc_count_delta` — 1 秒内 GC 次数 (近期频率)
+ * - `gc_time_delta_ms` — 1 秒内 GC 耗时 (ms)
+ *
+ * UI (PR #5) 用 delta 算 GC 频率 (e.g. gc/s), 不直接显示累计.
+ *
+ * @author android_zero
+ */
+class GcMonitor : PerfMonitor(name = "Gc", intervalMs = 1000L) {
+
+  private var lastCount: Long = 0L
+  private var lastTimeMs: Long = 0L
+  private var hasLast: Boolean = false
+
+  override fun tick() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val stats = android.os.Debug.getRuntimeStats()
+      // stats 是 Map<String, String>, key 形如 "art.gc.count" / "art.gc.time"
+      val countStr = stats["art.gc.count"]
+      val timeStr = stats["art.gc.time"]
+      val count = countStr?.toLongOrNull() ?: 0L
+      val timeMs = timeStr?.toLongOrNull() ?: 0L
+
+      if (hasLast) {
+        val countDelta = count - lastCount
+        val timeDelta = timeMs - lastTimeMs
+        PerfTracer.reportInstant("gc_count_delta_$countDelta")
+        PerfTracer.reportInstant("gc_time_delta_ms_$timeDelta")
+      }
+      lastCount = count
+      lastTimeMs = timeMs
+      hasLast = true
+
+      // 同时上报累计值 (UI 可在重启后比较)
+      PerfTracer.reportInstant("gc_count_$count")
+      PerfTracer.reportInstant("gc_time_ms_$timeMs")
+    } else {
+      // API 24-25 fallback: 仅上报 Java heap 使用量
+      val runtime = Runtime.getRuntime()
+      val usedKb = (runtime.totalMemory() - runtime.freeMemory()) / 1024
+      PerfTracer.reportInstant("gc_java_used_kb_$usedKb")
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/MemoryMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/MemoryMonitor.kt
@@ -1,0 +1,58 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.os.Debug
+import com.itsaky.androidide.perf.tracer.PerfTracer
+
+/**
+ * 内存 Monitor (PR #4/5).
+ *
+ * 1Hz 采样 [Debug.MemoryInfo], 提取关键指标并通过 [PerfTracer] 上报.
+ *
+ * ## 指标
+ *
+ * - `mem_total_pss_kb` — 总 PSS (KB) 反映 app 实际占用物理内存
+ * - `mem_dalvik_pss_kb` — Dalvik heap PSS
+ * - `mem_native_pss_kb` — Native heap PSS
+ * - `mem_views_kb` / `mem_app_kb` / `mem_other_kb` — 细分
+ *
+ * 上报用 `phase` 事件, name=`mem_<metric>_kb`, elapsed=值.
+ *
+ * ## 注意
+ *
+ * - PSS 包含与其他进程共享的页面 (按比例计), 比 RSS 更准确
+ * - Debug.MemoryInfo API 26+ 提供更多字段, 我们用基础字段保证兼容性
+ *
+ * @author android_zero
+ */
+class MemoryMonitor : PerfMonitor(name = "Memory", intervalMs = 1000L) {
+
+  override fun tick() {
+    val info = Debug.MemoryInfo()
+    Debug.getMemoryInfo(info)
+
+    PerfTracer.reportInstant("mem_total_pss_kb_${info.totalPss}")
+    PerfTracer.reportInstant("mem_dalvik_pss_kb_${info.dalvikPss}")
+    PerfTracer.reportInstant("mem_native_pss_kb_${info.nativePss}")
+
+    // Java heap 已分配 (KB)
+    val runtime = Runtime.getRuntime()
+    val javaUsedKb = (runtime.totalMemory() - runtime.freeMemory()) / 1024
+    PerfTracer.reportInstant("mem_java_used_kb_$javaUsedKb")
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/MonitorCoordinator.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/MonitorCoordinator.kt
@@ -1,0 +1,90 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.content.Context
+import com.itsaky.androidide.BuildConfig
+
+/**
+ * Monitor 协调器 (PR #4/5).
+ *
+ * 统一启停 4 个 [PerfMonitor] 子类 (FrameRate / Memory / Gc / Anr),
+ * 串到 IDEApplication.onCreate 末尾调一次.
+ *
+ * ## 启停条件
+ *
+ * - **Release build** ([BuildConfig.DEBUG] = false): 不启动 (0 overhead)
+ * - **主进程**: 启动 4 个 monitor
+ * - **:perf 进程**: 不启动 (Perf Console 自己没业务, 不需要监控)
+ * - **:perf console 进程未运行** (PerfTracer 未 attach): 仍启动,
+ *   PerfTracer 上报是 no-op, monitor 自身开销是 1Hz 4 个 syscalls, 可忽略
+ *
+ * ## API
+ *
+ * ```kotlin
+ * // IDEApplication.onCreate 末尾:
+ * MonitorCoordinator.start(this)
+ *
+ * // IDEApplication.onTerminate (或 AppExit 钩子):
+ * MonitorCoordinator.stop()
+ * ```
+ *
+ * @author android_zero
+ */
+object MonitorCoordinator {
+
+  @Volatile private var started: Boolean = false
+
+  private val monitors =
+      listOf<PerfMonitor>(
+          FrameRateMonitor(),
+          MemoryMonitor(),
+          GcMonitor(),
+          AnrMonitor(),
+      )
+
+  /**
+   * 启动所有 monitor.
+   *
+   * 幂等: 二次调用 no-op.
+   *
+   * @param context 任意 context (用于将来扩展需要 context 的 monitor)
+   */
+  @JvmStatic
+  fun start(@Suppress("UNUSED_PARAMETER") context: Context) {
+    if (started) return
+    if (!BuildConfig.DEBUG) {
+      // Release build: 完全不启动
+      return
+    }
+    started = true
+    monitors.forEach { it.start() }
+  }
+
+  /** 停止所有 monitor. */
+  @JvmStatic
+  fun stop() {
+    if (!started) return
+    started = false
+    monitors.forEach { it.stop() }
+  }
+
+  /** 当前已启动的 monitor 列表 (UI 调试用). */
+  @JvmStatic
+  fun runningMonitors(): List<String> =
+      if (started) monitors.map { it.name } else emptyList()
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/PerfMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/PerfMonitor.kt
@@ -1,0 +1,111 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+/**
+ * Perf Monitor 抽象基类 (PR #4/5).
+ *
+ * 每个具体 monitor (FrameRate / Memory / Gc / Anr) 继承本类, 实现 [tick]:
+ *
+ * ```kotlin
+ * class FrameRateMonitor : PerfMonitor("FrameRate", intervalMs = 1000L) {
+ *   override fun tick() { /* 1Hz 采样 */ }
+ * }
+ * ```
+ *
+ * ## 线程模型
+ *
+ * - [start] 在调用方线程 (主进程) 启动一个 `ScheduledExecutorService`
+ * - [tick] 跑在 executor 线程 (非 main), 业务代码自己确保线程安全
+ * - [stop] shutdown executor, 等已提交任务完成
+ *
+ * ## 上报
+ *
+ * 业务 tick 内通过 [com.itsaky.androidide.perf.tracer.PerfTracer] 上报:
+ *
+ * ```kotlin
+ * override fun tick() {
+ *   val fps = computeFps()
+ *   // 用 "phase" 事件, name=metric, elapsed=值 (kb/ms/fps)
+ *   PerfTracer.reportInstant("fps_$fps")
+ * }
+ * ```
+ *
+ * @author android_zero
+ */
+abstract class PerfMonitor(
+    val name: String,
+    val intervalMs: Long = 1000L,
+) {
+
+  @Volatile private var started: Boolean = false
+
+  protected val executor =
+      java.util.concurrent.Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "perf-monitor-$name").apply { isDaemon = true }
+      }
+
+  /**
+   * 启动 monitor.
+   *
+   * 幂等: 二次调用 no-op.
+   */
+  fun start() {
+    if (started) return
+    started = true
+    onStart()
+    executor.scheduleWithFixedDelay(
+        {
+          try {
+            tick()
+          } catch (e: Throwable) {
+            // 单次 tick 失败不能让 monitor 线程死
+            org.slf4j.LoggerFactory.getLogger(javaClass).warn("tick failed", e)
+          }
+        },
+        intervalMs,
+        intervalMs,
+        java.util.concurrent.TimeUnit.MILLISECONDS,
+    )
+  }
+
+  /**
+   * 停止 monitor.
+   *
+   * 不再恢复; 业务代码应保证只调一次.
+   */
+  fun stop() {
+    if (!started) return
+    started = false
+    executor.shutdown()
+    try {
+      executor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+    onStop()
+  }
+
+  /** 子类可选: 启动时一次性初始化. */
+  protected open fun onStart() {}
+
+  /** 子类可选: 停止时清理. */
+  protected open fun onStop() {}
+
+  /** 子类必实现: 1Hz 采样 + 上报. */
+  protected abstract fun tick()
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfEvent.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfEvent.kt
@@ -1,0 +1,47 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.proto
+
+/**
+ * 主进程 → :perf 进程的跨进程事件.
+ *
+ * 三种类型:
+ *
+ * - [Phase]: 一段代码块的耗时 (用 [com.itsaky.androidide.perf.tracer.PerfTracer.trace])
+ * - [Instant]: 无耗时的瞬时事件 (e.g. `ide_on_create_begin` / `end_boot` 之前的 marker)
+ * - [EndBoot]: 启动阶段结束标记. server 收到后切换为"启动后采样"模式 (PR #4)
+ *
+ * 序列化: line-delimited JSON, 由 [PerfSocketProtocol] 编解码.
+ *
+ * @author android_zero
+ */
+sealed class PerfEvent {
+
+  /** 一段代码块的耗时测量. */
+  data class Phase(
+      val name: String,
+      val elapsedMs: Long,
+  ) : PerfEvent()
+
+  /** 瞬时事件 (无耗时, 仅记录时间点). */
+  data class Instant(
+      val name: String,
+  ) : PerfEvent()
+
+  /** 启动阶段结束. */
+  data object EndBoot : PerfEvent()
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfSocketProtocol.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/proto/PerfSocketProtocol.kt
@@ -1,0 +1,99 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.proto
+
+/**
+ * 跨进程事件的 JSON 编解码 (PR #3/5).
+ *
+ * 协议格式: line-delimited JSON, UTF-8, `\n` 分隔.
+ *
+ * ```
+ * {"type":"phase","name":"koin_start","elapsed":45}
+ * {"type":"instant","name":"ide_on_create_begin"}
+ * {"type":"end_boot"}
+ * ```
+ *
+ * ## 设计取舍
+ *
+ * - **JSON vs 二进制**: JSON 调试友好 (logcat 可读, 简单 `cat` 即可复盘),
+ *   体积略大但 18 段 phase + 后续 1Hz 采样也才几 KB/分钟, 完全够用.
+ * - **无 schema 校验**: 服务端容错 (解析失败返回 null 并 log warn), 允许
+ *   主进程新版本加新字段而不破坏旧 server.
+ * - **手工 parser**: 18 段 phase 字段固定 (type/name/elapsed), 用 regex
+ *   比引入 org.json 或 kotlinx.serialization 更轻 (避免给 :perf 进程增加
+ *   依赖体积).
+ *
+ * @author android_zero
+ */
+internal object PerfSocketProtocol {
+
+  private val PHASE_REGEX =
+      Regex(""""type"\s*:\s*"phase".*?"name"\s*:\s*"([^"]+)".*?"elapsed"\s*:\s*(\d+)""")
+
+  private val INSTANT_REGEX =
+      Regex(""""type"\s*:\s*"instant".*?"name"\s*:\s*"([^"]+)"""")
+
+  private val END_BOOT_REGEX = Regex(""""type"\s*:\s*"end_boot"""")
+
+  /**
+   * 解析一行 JSON 为 [PerfEvent].
+   *
+   * @return 成功 → 事件; 失败 / 类型未知 → null
+   */
+  fun parse(line: String): PerfEvent? {
+    val trimmed = line.trim()
+    if (trimmed.isEmpty()) return null
+
+    return when {
+      END_BOOT_REGEX.containsMatchIn(trimmed) -> PerfEvent.EndBoot
+      else -> {
+        val phaseMatch = PHASE_REGEX.find(trimmed)
+        if (phaseMatch != null) {
+          val name = phaseMatch.groupValues[1].unescape()
+          val elapsed = phaseMatch.groupValues[2].toLongOrNull() ?: 0L
+          return PerfEvent.Phase(name, elapsed)
+        }
+        val instantMatch = INSTANT_REGEX.find(trimmed)
+        if (instantMatch != null) {
+          return PerfEvent.Instant(instantMatch.groupValues[1].unescape())
+        }
+        null
+      }
+    }
+  }
+
+  /**
+   * 序列化 [event] 为单行 JSON (不含换行).
+   *
+   * 主要给 server 端回放 / 测试用, 正常路径是 server 收 client 发的事件.
+   */
+  fun format(event: PerfEvent): String =
+      when (event) {
+        is PerfEvent.Phase ->
+            """{"type":"phase","name":"${event.name.escape()}","elapsed":${event.elapsedMs}}"""
+        is PerfEvent.Instant -> """{"type":"instant","name":"${event.name.escape()}"}"""
+        is PerfEvent.EndBoot -> """{"type":"end_boot"}"""
+      }
+
+  // -- 字符串转义 --
+
+  private fun String.escape(): String =
+      replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+  private fun String.unescape(): String =
+      replace("\\n", "\n").replace("\\\"", "\"").replace("\\\\", "\\")
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/server/PerfServerSocket.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/server/PerfServerSocket.kt
@@ -1,0 +1,173 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.server
+
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import com.itsaky.androidide.perf.proto.PerfEvent
+import com.itsaky.androidide.perf.proto.PerfSocketProtocol
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+
+/**
+ * :perf 进程 LocalServerSocket (PR #3/5).
+ *
+ * 与 [com.itsaky.androidide.perf.tracer.PerfClientSocket] (PR #2 实施)
+ * 通过 Unix domain socket 通信. 本类是 server, 跑在 :perf 进程.
+ *
+ * ## 启动流程
+ *
+ * 1. [com.itsaky.androidide.perf.PerfApplication.onCreate] (PR #1) 在
+ *    启动时创建本类实例, 调 [start].
+ * 2. [start] 在 [executor] 后台线程:
+ *    - 创建 [LocalServerSocket] 绑到 [socketPath]
+ *    - 把 [socketPath] 写到 [pathFile] (供主进程
+ *      [com.itsaky.androidide.perf.tracer.PerfTracer.tryAttach] 读)
+ *    - 进入 [acceptLoop] 死循环
+ * 3. 收到 client 连接 → 提交到 [executor] 的 [handleClient]:
+ *    - 按行读, 每行调 [PerfSocketProtocol.parse]
+ *    - 解析成功 → [collector.collect]
+ *    - 解析失败 → log warn, 继续读下一行 (不中断)
+ *    - 读到 EOF / IOException → 关闭 client socket
+ *
+ * ## 关闭流程
+ *
+ * - [stop] 关闭 server socket (让 accept() 抛异常退出循环)
+ * - [executor] shutdown, 已连接的 client handler 自然结束
+ * - [pathFile] 保留 (下次启动会被覆盖)
+ *
+ * @author android_zero
+ */
+internal class PerfServerSocket(
+    private val socketPath: String,
+    private val pathFile: java.io.File,
+    private val collector: PhaseCollector,
+) {
+
+  private val log = LoggerFactory.getLogger(PerfServerSocket::class.java)
+
+  private val executor = Executors.newCachedThreadPool { r ->
+    Thread(r, "perf-server").apply { isDaemon = true }
+  }
+
+  @Volatile private var server: LocalServerSocket? = null
+
+  @Volatile private var stopped: Boolean = false
+
+  /**
+   * 启动 server, 阻塞当前线程直到 [stop] 被调用.
+   *
+   * 设计: 业务线程 (PerfApplication.onCreate) 在后台线程调本方法, 不阻塞
+   * main thread.
+   */
+  fun start() {
+    if (stopped) {
+      log.warn("PerfServerSocket already stopped, skip start")
+      return
+    }
+    try {
+      // 先清理上次残留的 socket 文件 (system 异常退出可能留下)
+      java.io.File(socketPath).delete()
+
+      val srv = LocalServerSocket(socketPath)
+      server = srv
+
+      // 把 socket 完整路径写到 pathFile, 主进程 PerfTracer.tryAttach 读这个
+      pathFile.parentFile?.mkdirs()
+      pathFile.writeText(socketPath)
+
+      log.info("PerfServerSocket listening on {}", socketPath)
+      acceptLoop(srv)
+    } catch (e: IOException) {
+      log.error("PerfServerSocket start failed", e)
+      cleanup()
+    }
+  }
+
+  /** 停止 server. */
+  fun stop() {
+    stopped = true
+    cleanup()
+    executor.shutdown()
+    try {
+      executor.awaitTermination(2, TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
+  // -- private --
+
+  private fun acceptLoop(srv: LocalServerSocket) {
+    while (!stopped) {
+      val client =
+          try {
+            srv.accept()
+          } catch (e: IOException) {
+            if (stopped) {
+              log.info("PerfServerSocket accept loop exiting (server closed)")
+            } else {
+              log.warn("PerfServerSocket accept failed", e)
+            }
+            return
+          }
+      executor.submit { handleClient(client) }
+    }
+  }
+
+  private fun handleClient(client: LocalSocket) {
+    val remote = client.remoteSocketAddress?.toString() ?: "unknown"
+    try {
+      BufferedReader(InputStreamReader(client.inputStream, StandardCharsets.UTF_8)).use { reader ->
+        while (!stopped) {
+          val line =
+              try {
+                reader.readLine()
+              } catch (e: IOException) {
+                log.debug("PerfServerSocket client {} disconnected: {}", remote, e.message)
+                return@use
+              }
+          if (line == null) {
+            // EOF
+            return@use
+          }
+          val event = PerfSocketProtocol.parse(line)
+          if (event != null) {
+            collector.collect(event)
+          } else {
+            log.warn("PerfServerSocket received unparseable line from {}: {}", remote, line)
+          }
+        }
+      }
+    } catch (e: Throwable) {
+      log.warn("PerfServerSocket handleClient error for {}", remote, e)
+    } finally {
+      runCatching { client.close() }
+    }
+  }
+
+  private fun cleanup() {
+    runCatching { server?.close() }
+    server = null
+    // socket 路径文件保留 (PerfApplication onCreate 会重新写), 不删
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/server/PhaseCollector.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/server/PhaseCollector.kt
@@ -50,6 +50,9 @@ class PhaseCollector {
 
   @Volatile private var bootEnded: Boolean = false
 
+  /** EndBoot 监听器列表. [BootHistoryStore] 用此 hook 在启动结束时持久化. */
+  private val endBootListeners = java.util.concurrent.CopyOnWriteArrayList<(List<PerfEvent>, Long) -> Unit>()
+
   /**
    * 收集一个事件.
    *
@@ -63,8 +66,23 @@ class PhaseCollector {
     }
     if (event is PerfEvent.EndBoot) {
       bootEnded = true
+      // 通知所有 listener (BootHistoryStore 等)
+      val snapshot = events.toList()
+      endBootListeners.forEach { listener ->
+        runCatching { listener(snapshot, startElapsedMs) }
+      }
     }
     events.add(event)
+  }
+
+  /**
+   * 注册 EndBoot 监听器.
+   *
+   * 监听器签名 `(events, startElapsedMs) -> Unit`, 在 [collect] 收到
+   * [PerfEvent.EndBoot] 时同步调用 (监听器抛异常被吞掉, 不影响 collect 主流程).
+   */
+  fun addEndBootListener(listener: (List<PerfEvent>, Long) -> Unit) {
+    endBootListeners.add(listener)
   }
 
   /** 启动是否已结束 (用于 UI 切换 tab 颜色 / 显示 banner). */

--- a/core/app/src/main/java/com/itsaky/androidide/perf/server/PhaseCollector.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/server/PhaseCollector.kt
@@ -1,0 +1,101 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.server
+
+import com.itsaky.androidide.perf.proto.PerfEvent
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * 内存累积 phase 数据 (PR #3/5).
+ *
+ * 跑在 :perf 进程, 接收主进程通过 socket 发来的 [PerfEvent], 按收到顺序
+ * 累积到 [events] 列表. UI (PR #5) 通过 [snapshot] 周期性拉取 (1Hz).
+ *
+ * ## 线程安全
+ *
+ * - 写: accept loop 线程 ([com.itsaky.androidide.perf.server.PerfServerSocket] 的
+ *   每个 client handler) 并发调用 [collect]. 用 [CopyOnWriteArrayList] 保证
+ *   写不阻塞读, 读快照原子.
+ * - 读: UI 线程 (Compose recomposition 触发) 调用 [snapshot] / [phases] /
+ *   [instants]. CopyOnWriteArrayList 的 iterator 是弱一致但不会抛
+ *   ConcurrentModificationException.
+ *
+ * ## 容量
+ *
+ * 启动期 ~18 phase + 几十个 instant, 稳态运行时主要由 PR #4 的 Monitor 驱动
+ * (帧率/内存/GC 各 1Hz 采样), 单 session 跑 1 小时约 10000 条, 远低于
+ * CopyOnWriteArrayList 的实际容量. 不需要在 PR #3 引入分页.
+ *
+ * @author android_zero
+ */
+class PhaseCollector {
+
+  private val events = CopyOnWriteArrayList<PerfEvent>()
+
+  @Volatile private var startElapsedMs: Long = 0L
+
+  @Volatile private var bootEnded: Boolean = false
+
+  /**
+   * 收集一个事件.
+   *
+   * - 首次调用时记录 [startElapsedMs] = [SystemClock.elapsedRealtime]
+   * - 启动阶段 ([bootEnded] = false) 累积所有 phase / instant
+   * - 收到 [PerfEvent.EndBoot] 后切换稳态模式
+   */
+  fun collect(event: PerfEvent) {
+    if (startElapsedMs == 0L) {
+      startElapsedMs = android.os.SystemClock.elapsedRealtime()
+    }
+    if (event is PerfEvent.EndBoot) {
+      bootEnded = true
+    }
+    events.add(event)
+  }
+
+  /** 启动是否已结束 (用于 UI 切换 tab 颜色 / 显示 banner). */
+  fun isBootEnded(): Boolean = bootEnded
+
+  /**
+   * 整个 session 的 [SystemClock.elapsedRealtime] 起点 (用于显示"启动耗时
+   * 总计"). 0 表示尚未收到任何事件.
+   */
+  fun startElapsedMs(): Long = startElapsedMs
+
+  /**
+   * 当前累积的所有事件 (按收到顺序).
+   *
+   * 返回的是不可变快照, 业务代码可安全遍历.
+   */
+  fun snapshot(): List<PerfEvent> = events.toList()
+
+  /** 仅 phase 事件 (按时间排序). */
+  fun phases(): List<PerfEvent.Phase> = events.filterIsInstance<PerfEvent.Phase>()
+
+  /** 仅 instant 事件. */
+  fun instants(): List<PerfEvent.Instant> = events.filterIsInstance<PerfEvent.Instant>()
+
+  /** 清空所有累积 (用于"重新记录"按钮). */
+  fun clear() {
+    events.clear()
+    startElapsedMs = 0L
+    bootEnded = false
+  }
+
+  /** 当前累积事件数 (调试用). */
+  fun size(): Int = events.size
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/store/BootHistoryStore.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/store/BootHistoryStore.kt
@@ -1,0 +1,183 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.store
+
+import android.content.Context
+import com.itsaky.androidide.perf.proto.PerfEvent
+import java.io.File
+import org.json.JSONArray
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+
+/**
+ * 启动历史持久化 (PR #4/5).
+ *
+ * 主进程启动结束后, 序列化当次启动的 [PerfEvent] 列表到本地文件,
+ * 下次启动时读出来, UI 显示"最近 10 次启动耗时对比".
+ *
+ * ## 设计取舍
+ *
+ * - **JSON 文件 vs Room/SQLite**: 单次启动 phase 列表 < 100 条, JSON
+ *   文件读写 1ms 内, 没必要引入 Room schema 维护成本.
+ * - **保留最近 N 次**: N = [MAX_HISTORY], FIFO 替换, 防止文件无限增长.
+ * - **位置**: 放 [Context.filesDir] (非 cacheDir), cacheDir 可被系统清理,
+ *   历史数据需要持久.
+ *
+ * ## 格式
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "sessions": [
+ *     {
+ *       "startElapsedMs": 12345,
+ *       "events": [
+ *         {"type":"phase","name":"init_koin","elapsed":45},
+ *         {"type":"instant","name":"ide_on_create_end"},
+ *         ...
+ *       ]
+ *     },
+ *     ...
+ *   ]
+ * }
+ * ```
+ *
+ * @author android_zero
+ */
+class BootHistoryStore(context: Context) {
+
+  private val log = LoggerFactory.getLogger(BootHistoryStore::class.java)
+
+  private val file = File(context.filesDir, FILE_NAME)
+
+  /**
+   * 追加一次启动的 phase 列表到历史.
+   *
+   * 调用时机: IDEApplication.onCreate 末尾 ([com.itsaky.androidide.perf.PerfTracer.endBoot] 之后)
+   * 但因为是 :perf 进程, 实际调用方是 [com.itsaky.androidide.perf.PerfApplication.init] 内
+   * 注册一个 end_boot listener. 简化起见, 本类提供静态 [append] 给 [PhaseCollector] 在收到
+   * EndBoot 时调.
+   */
+  fun append(events: List<PerfEvent>, startElapsedMs: Long) {
+    try {
+      val root = readRoot()
+      val sessions = root.optJSONArray("sessions") ?: JSONArray()
+
+      val session =
+          JSONObject().apply {
+            put("startElapsedMs", startElapsedMs)
+            put("timestamp", System.currentTimeMillis())
+            put("events", JSONArray().also { arr ->
+              events.forEach { ev ->
+                arr.put(serializeEvent(ev))
+              }
+            })
+          }
+      sessions.put(session)
+
+      // FIFO trim
+      while (sessions.length() > MAX_HISTORY) {
+        sessions.remove(0)
+      }
+
+      root.put("sessions", sessions)
+      file.writeText(root.toString(2))
+    } catch (e: Throwable) {
+      log.warn("BootHistoryStore.append failed: {}", e.message)
+    }
+  }
+
+  /** 读所有历史 session. */
+  fun readAll(): List<BootSession> {
+    return try {
+      val root = readRoot()
+      val sessions = root.optJSONArray("sessions") ?: return emptyList()
+      (0 until sessions.length()).mapNotNull { i ->
+        val obj = sessions.optJSONObject(i) ?: return@mapNotNull null
+        val eventsArr = obj.optJSONArray("events") ?: return@mapNotNull null
+        val events = (0 until eventsArr.length()).mapNotNull { j ->
+          parseEvent(eventsArr.optJSONObject(j) ?: return@mapNotNull null)
+        }
+        BootSession(
+            startElapsedMs = obj.optLong("startElapsedMs", 0L),
+            timestamp = obj.optLong("timestamp", 0L),
+            events = events,
+        )
+      }
+    } catch (e: Throwable) {
+      log.warn("BootHistoryStore.readAll failed: {}", e.message)
+      emptyList()
+    }
+  }
+
+  /** 清空历史. */
+  fun clear() {
+    runCatching { file.delete() }
+  }
+
+  // -- private --
+
+  private fun readRoot(): JSONObject {
+    if (!file.exists()) return JSONObject().put("version", VERSION).put("sessions", JSONArray())
+    return try {
+      JSONObject(file.readText())
+    } catch (e: Throwable) {
+      log.warn("BootHistoryStore corrupted, recreating: {}", e.message)
+      JSONObject().put("version", VERSION).put("sessions", JSONArray())
+    }
+  }
+
+  private fun serializeEvent(event: PerfEvent): JSONObject =
+      when (event) {
+        is PerfEvent.Phase ->
+            JSONObject()
+                .put("type", "phase")
+                .put("name", event.name)
+                .put("elapsed", event.elapsedMs)
+        is PerfEvent.Instant ->
+            JSONObject().put("type", "instant").put("name", event.name)
+        PerfEvent.EndBoot -> JSONObject().put("type", "end_boot")
+      }
+
+  private fun parseEvent(obj: JSONObject): PerfEvent? {
+    return when (obj.optString("type")) {
+      "phase" ->
+          PerfEvent.Phase(
+              name = obj.optString("name"),
+              elapsedMs = obj.optLong("elapsed", 0L),
+          )
+      "instant" -> PerfEvent.Instant(name = obj.optString("name"))
+      "end_boot" -> PerfEvent.EndBoot
+      else -> null
+    }
+  }
+
+  /**
+   * 一次启动的快照.
+   */
+  data class BootSession(
+      val startElapsedMs: Long,
+      val timestamp: Long,
+      val events: List<PerfEvent>,
+  )
+
+  companion object {
+    const val FILE_NAME = "perf/boot_history.json"
+    private const val MAX_HISTORY = 10
+    private const val VERSION = 1
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
@@ -1,0 +1,181 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.tracer
+
+import android.net.LocalSocket
+import android.net.LocalSocketAddress
+import java.io.IOException
+import java.io.OutputStream
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+
+/**
+ * :perf socket 客户端 (PR #2/5).
+ *
+ * 与 [com.itsaky.androidide.perf.server.PerfServerSocket] (PR #3 实施)
+ * 通过 Unix domain socket (LocalSocket) 通信. 主进程是 client, :perf 进程是 server.
+ *
+ * ## 协议 (PR #2 暂定, PR #3 协议层会细化)
+ *
+ * 每条事件一行, UTF-8 JSON:
+ *
+ * ```
+ * {"type":"phase","name":"koin_start","elapsed":45}\n
+ * {"type":"instant","name":"first_frame"}\n
+ * {"type":"end_boot"}\n
+ * ```
+ *
+ * - 字段顺序不重要, server 容错解析
+ * - `\n` 是一条事件的结束符
+ * - UTF-8 编码, name 不能含换行 / 引号 (调用方保证)
+ *
+ * ## 线程模型
+ *
+ * - 业务线程 (main / IO / Binder) 调 `sendPhase` → 写入无锁 [LinkedBlockingQueue]
+ * - 单独的 writer 线程 ([executor]) 从队列取事件 → 序列化 → 写入 [OutputStream]
+ * - 写失败 (server 关闭 / IO 异常) → 标记 [broken] = true, 后续 sendXxx 立即 no-op
+ *
+ * 这种设计保证:
+ * 1. **业务线程 0 阻塞**: 写 socket 是后台线程的事
+ * 2. **顺序保证**: FIFO 队列保证事件按发出顺序被 server 收到
+ * 3. **失败隔离**: socket 写崩不会让主 application 挂
+ *
+ * @author android_zero
+ */
+internal class PerfClientSocket(private val socketPath: String) {
+
+  private val log = LoggerFactory.getLogger(PerfClientSocket::class.java)
+
+  private val queue = LinkedBlockingQueue<String>(QUEUE_CAPACITY)
+  private val executor = Executors.newSingleThreadExecutor { r ->
+    Thread(r, "perf-tracer-writer").apply { isDaemon = true }
+  }
+
+  @Volatile private var socket: LocalSocket? = null
+  @Volatile private var out: OutputStream? = null
+
+  /** 是否已断连 (写失败一次即标记, 后续 sendXxx 全部 no-op). */
+  @Volatile private var broken: Boolean = false
+
+  /**
+   * 尝试 connect 到 :perf server.
+   *
+   * @return true 表示 connect + 启动 writer 成功
+   */
+  fun tryConnect(): Boolean {
+    return try {
+      val sock = LocalSocket()
+      sock.connect(LocalSocketAddress(socketPath, LocalSocketAddress.Namespace.FILESYSTEM))
+      val output = sock.outputStream
+      socket = sock
+      out = output
+      executor.submit(::writerLoop)
+      true
+    } catch (e: IOException) {
+      log.warn("PerfClientSocket connect failed: {}", e.message)
+      cleanup()
+      false
+    }
+  }
+
+  /** 异步发送 phase 事件 (有耗时). */
+  fun sendPhase(name: String, elapsedMs: Long) {
+    if (broken) return
+    enqueue("""{"type":"phase","name":"${escape(name)}","elapsed":$elapsedMs}""")
+  }
+
+  /** 异步发送 instant 事件 (无耗时). */
+  fun sendInstant(name: String) {
+    if (broken) return
+    enqueue("""{"type":"instant","name":"${escape(name)}"}""")
+  }
+
+  /** 异步发送 end_boot 标记. */
+  fun sendEndBoot() {
+    if (broken) return
+    enqueue("""{"type":"end_boot"}""")
+  }
+
+  /** 主动关闭 (app exit 时调用). */
+  fun close() {
+    broken = true
+    executor.shutdown()
+    cleanup()
+  }
+
+  // -- private --
+
+  private fun enqueue(line: String) {
+    if (broken) return
+    val ok = queue.offer(line)
+    if (!ok) {
+      // 队列满 → 标记 broken, 后续全部丢弃, 避免主线程被阻塞
+      log.warn("PerfClientSocket queue full ({}), dropping events", QUEUE_CAPACITY)
+      broken = true
+    }
+  }
+
+  private fun writerLoop() {
+    try {
+      while (!broken && !Thread.currentThread().isInterrupted) {
+        val line = queue.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS) ?: continue
+        writeLine(line)
+      }
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    } catch (e: Throwable) {
+      log.warn("PerfClientSocket writer loop crashed: {}", e.message)
+    } finally {
+      cleanup()
+      broken = true
+    }
+  }
+
+  private fun writeLine(line: String) {
+    val output = out ?: run {
+      broken = true
+      return
+    }
+    try {
+      output.write(line.toByteArray(Charsets.UTF_8))
+      output.write(LINE_DELIMITER)
+      output.flush()
+    } catch (e: IOException) {
+      log.warn("PerfClientSocket write failed: {}", e.message)
+      broken = true
+      cleanup()
+    }
+  }
+
+  private fun cleanup() {
+    runCatching { out?.close() }
+    runCatching { socket?.close() }
+    out = null
+    socket = null
+  }
+
+  private fun escape(s: String): String =
+      s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+  companion object {
+    private val LINE_DELIMITER = byteArrayOf('\n'.code.toByte())
+    private const val QUEUE_CAPACITY = 1024
+    private const val POLL_TIMEOUT_MS = 50L
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
@@ -1,0 +1,180 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.tracer
+
+import android.content.Context
+import android.os.SystemClock
+import com.itsaky.androidide.BuildConfig
+import com.itsaky.androidide.perf.PerfApplication
+import java.io.File
+import org.slf4j.LoggerFactory
+
+/**
+ * 主进程埋点门面 (PR #2/5).
+ *
+ * 调用方在 IDEApplication / Activity 关键 init 步骤包裹:
+ *
+ * ```kotlin
+ * PerfTracer.trace("init_koin") {
+ *   RikkaHubRuntime.ensureKoinStarted(this)
+ * }
+ * ```
+ *
+ * ## 降级策略 (核心设计)
+ *
+ * - **Release build** ([BuildConfig.DEBUG] = false): 全部方法被编译器
+ *   消除, 0 overhead. 所有 `trace {}` 块变为裸的 `block()` 调用.
+ * - **Debug build 但 :perf 进程未启动** (Perf Console 未从桌面启动):
+ *   [tryAttach] 读 [PERF_SOCKET_PATH_FILE] 文件失败 → 关闭内部
+ *   [PerfClientSocket], 后续 `trace` 调用变 no-op, 不抛异常, 不打 log 噪音.
+ * - **Debug build 且 :perf 已启动**: 通过 LocalSocket 异步发送事件
+ *   到 :perf 进程, 由 PR #3 的 [com.itsaky.androidide.perf.server.PerfServerSocket] 接收.
+ *
+ * 这种设计保证:
+ * 1. **用户能控制**: 不开 Perf Console = 完全 0 overhead (只是常量判断)
+ * 2. **不会 crash**: socket 失败 → 静默 no-op, 永远不会因为监控影响主 application
+ * 3. **不会 NPE**: 静态 [trace] 调用方不用 null check
+ *
+ * @author android_zero
+ */
+object PerfTracer {
+
+  private val log = LoggerFactory.getLogger(PerfTracer::class.java)
+
+  /**
+   * socket 客户端 (懒初始化, 失败后变 no-op).
+   *
+   * `volatile` 保证多线程可见性 (IDEApplication 入口在 main thread,
+   * 后续 Activity onCreate 可能跨 thread).
+   */
+  @Volatile
+  private var socket: PerfClientSocket? = null
+
+  /** :perf 进程是否已 attach 成功. 仅用于日志, 不影响行为. */
+  @Volatile
+  private var attached: Boolean = false
+
+  /**
+   * 尝试连接 :perf 进程.
+   *
+   * 必须在主 application 入口 (e.g. [com.itsaky.androidide.app.IDEApplication.onCreate]
+   * 第一行) 调用一次, 后续 `trace` 才会真正发出事件.
+   *
+   * - [BuildConfig.DEBUG] = false → no-op
+   * - :perf 进程 → no-op (避免 :perf 进程自己 connect 自己, 死循环)
+   * - socket 文件不存在 → no-op (Perf Console 未启动, 用户故意不开监控)
+   * - socket connect 失败 → 静默失败, 后续 trace no-op
+   */
+  @JvmStatic
+  fun tryAttach(context: Context) {
+    if (!BuildConfig.DEBUG) {
+      // Release build: 完全不初始化, 编译器会消除后续 trace 调用
+      return
+    }
+
+    val processName = runCatching {
+      // android.os.Process.myProcessName() requires API 28
+      @Suppress("DEPRECATION")
+      android.os.Process.myProcessName()
+    }.getOrDefault("")
+
+    if (processName.endsWith(":perf")) {
+      // :perf 进程自己不要 connect 自己的 socket server
+      log.info("PerfTracer running inside :perf process, skip attach")
+      return
+    }
+
+    val socketPathFile = File(context.cacheDir, PerfApplication.PERF_SOCKET_PATH_FILE)
+    if (!socketPathFile.exists()) {
+      log.info("PerfTracer: socket path file not found, :perf console not started")
+      return
+    }
+
+    val socketPath = runCatching { socketPathFile.readText().trim() }.getOrNull()
+    if (socketPath.isNullOrEmpty()) {
+      log.warn("PerfTracer: socket path file is empty")
+      return
+    }
+
+    val client = PerfClientSocket(socketPath)
+    val connected = client.tryConnect()
+    if (!connected) {
+      log.warn("PerfTracer: connect to :perf socket failed, will be no-op")
+      // 不保留 client 引用, 后续 trace 自动 no-op
+      return
+    }
+
+    socket = client
+    attached = true
+    log.info("PerfTracer: attached to :perf socket at {}", socketPath)
+  }
+
+  /**
+   * 包裹一段代码, 测量其耗时并发送 phase 事件.
+   *
+   * **inline** 设计: 编译器会把 [block] 调用直接展开, 关闭时 ([attached] = false)
+   * 整个 `if (!attached) return block()` 会被消除, 调用方在 Release build 看到的就是
+   * 纯 `block()` 调用, 0 overhead.
+   *
+   * @param name phase 名称 (e.g. "init_koin")
+   * @param block 待测量代码块
+   * @return [block] 的返回值
+   */
+  @JvmStatic
+  inline fun <T> trace(name: String, block: () -> T): T {
+    if (!BuildConfig.DEBUG) return block()
+    val s = socket ?: return block()
+    val start = SystemClock.elapsedRealtime()
+    return try {
+      block()
+    } finally {
+      val elapsed = SystemClock.elapsedRealtime() - start
+      s.sendPhase(name, elapsed)
+    }
+  }
+
+  /**
+   * 报告一个"非代码块"事件 (e.g. process start, first frame).
+   *
+   * Release build 完全消除. Debug 未 attach 时 no-op.
+   */
+  @JvmStatic
+  fun reportInstant(name: String) {
+    if (!BuildConfig.DEBUG) return
+    socket?.sendInstant(name)
+  }
+
+  /**
+   * 标记启动阶段结束.
+   *
+   * 调用方通常在 SplashActivity / MainActivity onCreate 末尾调一次,
+   * 触发 server 端切换到"启动后采样"模式 (降低 1Hz→0.1Hz 之类).
+   */
+  @JvmStatic
+  fun endBoot() {
+    if (!BuildConfig.DEBUG) return
+    socket?.sendEndBoot()
+  }
+
+  /**
+   * 是否已 attach 到 :perf 进程.
+   *
+   * 主要用于 UI 显示 / 日志, 业务代码不应依赖.
+   */
+  @JvmStatic
+  fun isAttached(): Boolean = attached
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
@@ -1,0 +1,247 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.perf.proto.PerfEvent
+import com.itsaky.androidide.perf.store.BootHistoryStore
+
+/**
+ * Boot Tab (PR #5/5).
+ *
+ * 显示:
+ * - 启动总耗时 (大字, e.g. "2.3s")
+ * - 18 段 phase 时间线 (横向条形图, 按 phase 名字纵向排列)
+ * - 最近 10 次启动对比 (条形对比)
+ *
+ * @author android_zero
+ */
+@Composable
+fun BootTab(state: PerfUiState, modifier: Modifier = Modifier) {
+  LazyColumn(
+      modifier = modifier.fillMaxSize().padding(12.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    item {
+      TotalBootCard(totalBootMs = state.totalBootMs, isEnded = state.isBootEnded)
+    }
+    item {
+      BootTimelineCard(bootEvents = state.bootEvents)
+    }
+    item {
+      BootHistoryCard(history = state.bootHistory)
+    }
+  }
+}
+
+@Composable
+private fun TotalBootCard(totalBootMs: Long, isEnded: Boolean) {
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+      Text(
+          text = "启动总耗时",
+          fontSize = 12.sp,
+          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = formatMs(totalBootMs),
+          fontSize = 36.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onPrimaryContainer,
+      )
+      Text(
+          text = if (isEnded) "启动完成" else "启动中…",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+      )
+    }
+  }
+}
+
+@Composable
+private fun BootTimelineCard(bootEvents: List<PerfEvent>) {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "启动 phase 时间线",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+
+      if (bootEvents.isEmpty()) {
+        Text(
+            text = "等待 IDEApplication.onCreate 上报…",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return@Column
+      }
+
+      // 计算 phase 最长耗时用于比例尺
+      val phases = bootEvents.filterIsInstance<PerfEvent.Phase>()
+      val maxMs = phases.maxOfOrNull { it.elapsedMs }?.coerceAtLeast(1L) ?: 1L
+      val color = MaterialTheme.colorScheme.primary
+
+      phases.forEach { phase ->
+        BootTimelineRow(name = phase.name, ms = phase.elapsedMs, maxMs = maxMs, color = color)
+        Spacer(modifier = Modifier.size(4.dp))
+      }
+    }
+  }
+}
+
+@Composable
+private fun BootTimelineRow(name: String, ms: Long, maxMs: Long, color: androidx.compose.ui.graphics.Color) {
+  val ratio = (ms.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
+  Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+    Text(
+        text = name,
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.fillMaxWidth(0.42f),
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(0.88f)
+            .height(14.dp)
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(7.dp),
+            ),
+    ) {
+      Box(
+          modifier = Modifier
+              .fillMaxWidth(ratio)
+              .height(14.dp)
+              .background(color = color, shape = RoundedCornerShape(7.dp)),
+      )
+    }
+    Spacer(modifier = Modifier.size(8.dp))
+    Text(
+        text = "${ms}ms",
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.fillMaxWidth(),
+    )
+  }
+}
+
+@Composable
+private fun BootHistoryCard(history: List<BootHistoryStore.BootSession>) {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "启动历史 (最近 ${history.size} 次)",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      if (history.isEmpty()) {
+        Text(
+            text = "首次启动 — 暂无历史",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return@Column
+      }
+      val maxMs = history.maxOf { it.startElapsedMs }.coerceAtLeast(1L)
+      history.forEachIndexed { i, session ->
+        BootHistoryRow(index = history.size - i, ms = session.startElapsedMs, maxMs = maxMs)
+        Spacer(modifier = Modifier.size(4.dp))
+      }
+    }
+  }
+}
+
+@Composable
+private fun BootHistoryRow(index: Int, ms: Long, maxMs: Long) {
+  val ratio = (ms.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
+  Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+    Text(
+        text = "#${index}",
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        modifier = Modifier.fillMaxWidth(0.18f),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(0.88f)
+            .height(12.dp)
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(6.dp),
+            ),
+    ) {
+      Box(
+          modifier = Modifier
+              .fillMaxWidth(ratio)
+              .height(12.dp)
+              .background(
+                  color = MaterialTheme.colorScheme.tertiary,
+                  shape = RoundedCornerShape(6.dp),
+              ),
+      )
+    }
+    Spacer(modifier = Modifier.size(8.dp))
+    Text(
+        text = formatMs(ms),
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+  }
+}
+
+internal fun formatMs(ms: Long): String =
+    when {
+      ms < 1000 -> "${ms}ms"
+      ms < 60_000 -> String.format("%.2fs", ms / 1000.0)
+      else -> String.format("%dm %ds", ms / 60_000, (ms % 60_000) / 1000)
+    }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/ChartComposables.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/ChartComposables.kt
@@ -1,0 +1,124 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * 折线图 (sparkline) Composable (PR #5/5).
+ *
+ * 简单 Canvas 自绘, 不引外部 chart 库. 单条线 + 可选第二条 (e.g. PSS total + native).
+ *
+ * 用法:
+ * ```kotlin
+ * Sparkline(
+ *   values = listOf(60, 58, 55, ...),
+ *   height = 80.dp,
+ *   color = MaterialTheme.colorScheme.primary,
+ * )
+ * ```
+ *
+ * @author android_zero
+ */
+@Composable
+fun Sparkline(
+    values: List<Number>,
+    height: Dp = 80.dp,
+    color: Color = MaterialTheme.colorScheme.primary,
+    fillAlpha: Float = 0.18f,
+) {
+  Box(modifier = Modifier.fillMaxSize().height(height).padding(8.dp)) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      if (values.size < 2) return@Canvas
+      val w = size.width
+      val h = size.height
+      val max = values.maxOf { it.toDouble() }.coerceAtLeast(1.0)
+      val min = values.minOf { it.toDouble() }.coerceAtMost(0.0)
+      val range = (max - min).coerceAtLeast(1.0)
+      val stepX = w / (values.size - 1)
+
+      // 折线
+      val path = Path()
+      values.forEachIndexed { i, v ->
+        val x = i * stepX
+        val y = h - ((v.toDouble() - min) / range * h).toFloat()
+        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+      }
+      drawPath(path = path, color = color, style = Stroke(width = 3f))
+
+      // 填充
+      val fillPath = Path().apply {
+        addPath(path)
+        lineTo(w, h)
+        lineTo(0f, h)
+        close()
+      }
+      drawPath(path = fillPath, color = color.copy(alpha = fillAlpha))
+    }
+  }
+}
+
+/**
+ * 双线 sparkline (e.g. total PSS + native PSS).
+ */
+@Composable
+fun DualSparkline(
+    primary: List<Number>,
+    secondary: List<Number>,
+    height: Dp = 80.dp,
+    primaryColor: Color = MaterialTheme.colorScheme.primary,
+    secondaryColor: Color = MaterialTheme.colorScheme.tertiary,
+) {
+  Box(modifier = Modifier.fillMaxSize().height(height).padding(8.dp)) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      if (primary.size < 2 && secondary.size < 2) return@Canvas
+      val w = size.width
+      val h = size.height
+      val all = primary + secondary
+      val max = all.maxOf { it.toDouble() }.coerceAtLeast(1.0)
+      val min = all.minOf { it.toDouble() }.coerceAtMost(0.0)
+      val range = (max - min).coerceAtLeast(1.0)
+
+      fun drawLine(values: List<Number>, color: Color, width: Float) {
+        if (values.size < 2) return
+        val stepX = w / (values.size - 1)
+        val path = Path()
+        values.forEachIndexed { i, v ->
+          val x = i * stepX
+          val y = h - ((v.toDouble() - min) / range * h).toFloat()
+          if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        drawPath(path = path, color = color, style = Stroke(width = width))
+      }
+
+      drawLine(secondary, secondaryColor, 2f)
+      drawLine(primary, primaryColor, 3f)
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/FrameTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/FrameTab.kt
@@ -1,0 +1,149 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.perf.proto.PerfEvent
+
+/**
+ * Frame Tab (PR #5/5).
+ *
+ * 显示:
+ * - 当前 FPS (大字)
+ * - FPS sparkline (最近 60 秒)
+ * - ANR / warn 事件列表
+ */
+@Composable
+fun FrameTab(state: PerfUiState, modifier: Modifier = Modifier) {
+  LazyColumn(
+      modifier = modifier.fillMaxSize().padding(12.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    item {
+      FpsCard(
+          currentFps = state.recentFps.lastOrNull() ?: 0,
+          values = state.recentFps,
+      )
+    }
+    item {
+      AnrListCard(anrs = state.anrEvents)
+    }
+  }
+}
+
+@Composable
+private fun FpsCard(currentFps: Int, values: List<Int>) {
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+      Text(
+          text = "FPS (主进程)",
+          fontSize = 12.sp,
+          color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = if (currentFps == 0) "—" else "$currentFps",
+          fontSize = 48.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
+      )
+      Text(
+          text = "最近 ${values.size} 秒 (60 窗口)",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      Sparkline(values = values, height = 80.dp)
+    }
+  }
+}
+
+@Composable
+private fun AnrListCard(anrs: List<PerfEvent.Instant>) {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "ANR / 警告 (${anrs.size})",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      if (anrs.isEmpty()) {
+        Text(
+            text = "主线程响应良好, 无 ANR / warn",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      } else {
+        // 倒序: 最新在上
+        anrs.reversed().forEach { anr -> AnrRow(anr) }
+      }
+    }
+  }
+}
+
+@Composable
+private fun AnrRow(anr: PerfEvent.Instant) {
+  val isWarn = anr.name.startsWith("anr_warn_")
+  val latency = anr.name.substringAfter("_").toLongOrNull() ?: 0L
+  val color =
+      if (isWarn) MaterialTheme.colorScheme.tertiary
+      else MaterialTheme.colorScheme.error
+  Card(
+      shape = RoundedCornerShape(6.dp),
+      colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.12f)),
+      modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(10.dp)) {
+      Text(
+          text = if (isWarn) "⚠ Warn" else "⛔ ANR",
+          fontWeight = FontWeight.SemiBold,
+          fontSize = 12.sp,
+          color = color,
+      )
+      Text(
+          text = "主线程往返: $latency ms",
+          fontSize = 11.sp,
+          fontFamily = FontFamily.Monospace,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/MemoryTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/MemoryTab.kt
@@ -1,0 +1,121 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Memory Tab (PR #5/5).
+ *
+ * 显示:
+ * - 当前 PSS (大字, KB → MB)
+ * - PSS 折线 (total PSS, 最近 60 秒)
+ * - GC 频率 (条形, gc_count_delta)
+ */
+@Composable
+fun MemoryTab(state: PerfUiState, modifier: Modifier = Modifier) {
+  LazyColumn(
+      modifier = modifier.fillMaxSize().padding(12.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    item { PssCard(currentKb = state.recentPssKb.lastOrNull() ?: 0L, values = state.recentPssKb) }
+    item { GcCard(gcDelta = state.recentGcDelta) }
+  }
+}
+
+@Composable
+private fun PssCard(currentKb: Long, values: List<Long>) {
+  val currentMb = currentKb / 1024.0
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+      Text(
+          text = "PSS (主进程)",
+          fontSize = 12.sp,
+          color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = if (currentKb == 0L) "—" else String.format("%.1f MB", currentMb),
+          fontSize = 36.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onTertiaryContainer,
+      )
+      Text(
+          text = "最近 ${values.size} 秒 (60 窗口)",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      Sparkline(values = values, height = 80.dp)
+    }
+  }
+}
+
+@Composable
+private fun GcCard(gcDelta: List<Long>) {
+  val totalRecent = gcDelta.sum()
+  val avgPerSec = if (gcDelta.isEmpty()) 0.0 else totalRecent.toDouble() / gcDelta.size
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "GC 频率",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = String.format("平均 %.2f 次/s", avgPerSec),
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(
+            text = "(${gcDelta.size} 样本)",
+            fontSize = 11.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+      Spacer(modifier = Modifier.size(8.dp))
+      Sparkline(values = gcDelta, height = 60.dp)
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleScreen.kt
@@ -1,0 +1,137 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Perf Console 主屏 (PR #5/5).
+ *
+ * 4 tab:
+ * - Boot: 启动总耗时 + phase 时间线 + 历史对比
+ * - Frame: FPS 实时 + ANR 列表
+ * - Memory: PSS 实时 + GC 频率
+ * - Threads: 进程信息 + 线程分组
+ *
+ * @author android_zero
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PerfConsoleScreen(viewModel: PerfConsoleViewModel) {
+  val state by viewModel.state.collectAsState()
+  var selectedTab by remember { mutableStateOf(0) }
+
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = {
+              Column {
+                Text(
+                    text = "Perf Console",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                )
+                Text(
+                    text = "状态: ${if (state.isReady) "已连接" else "等待 :perf server"}",
+                    fontSize = 10.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+              }
+            },
+            colors =
+                TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                ),
+        )
+      },
+  ) { padding ->
+    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+      TabRow(selectedTabIndex = selectedTab) {
+        TABS.forEachIndexed { i, label ->
+          Tab(
+              selected = selectedTab == i,
+              onClick = { selectedTab = i },
+              text = { Text(label, fontSize = 13.sp) },
+          )
+        }
+      }
+
+      if (!state.isReady) {
+        LoadingState()
+        return@Column
+      }
+
+      when (selectedTab) {
+        0 -> BootTab(state = state)
+        1 -> FrameTab(state = state)
+        2 -> MemoryTab(state = state)
+        3 -> ThreadsTab(state = state)
+      }
+    }
+  }
+}
+
+@Composable
+private fun LoadingState() {
+  Box(
+      modifier = Modifier.fillMaxSize().padding(32.dp),
+      contentAlignment = Alignment.Center,
+  ) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      CircularProgressIndicator()
+      Spacer(modifier = Modifier.height(16.dp))
+      Text(
+          text = "等待 IDEApplication.onCreate 上报 phase…",
+          fontSize = 13.sp,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Text(
+          text = "(从桌面启动主 IDE application 即可看到数据)",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.outline,
+      )
+    }
+  }
+}
+
+private val TABS = listOf("Boot", "Frame", "Memory", "Threads")

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
@@ -1,0 +1,180 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.itsaky.androidide.perf.PhaseStore
+import com.itsaky.androidide.perf.proto.PerfEvent
+import com.itsaky.androidide.perf.store.BootHistoryStore
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Perf Console ViewModel (PR #5/5).
+ *
+ * 后台线程 1Hz 轮询 [PhaseStore.collector] (启动 phase) + [BootHistoryStore]
+ * (历史), 解析 [PerfEvent] 流, 聚合成 [PerfUiState] 推给 UI.
+ *
+ * ## 线程模型
+ *
+ * - **轮询线程**: `perf-vm-tick` daemon thread, 1Hz 调用 [tick]
+ * - **状态发布**: [MutableStateFlow.update] 是线程安全的, 无锁
+ * - **Compose 订阅**: `collectAsState` 在 main thread 读 StateFlow
+ *
+ * ## 聚合逻辑
+ *
+ * 启动 phase (18 段) → [PerfUiState.bootEvents] (按收到顺序)
+ * 启动历史 → [PerfUiState.bootHistory]
+ * 实时 fps (PR #4 FrameRateMonitor 上报 `fps_<n>`) → 滚动 60 个样本窗口
+ * 实时 PSS (PR #4 MemoryMonitor 上报 `mem_total_pss_kb_<n>`) → 滚动 60 个样本
+ * 实时 GC delta (PR #4 GcMonitor 上报 `gc_count_delta_<n>`) → 滚动 60 个样本
+ * ANR 事件 (PR #4 AnrMonitor 上报 `anr_<n>`) → 累积列表
+ *
+ * @author android_zero
+ */
+class PerfConsoleViewModel(application: Application) : AndroidViewModel(application) {
+
+  private val _state = MutableStateFlow(PerfUiState.EMPTY)
+  val state: StateFlow<PerfUiState> = _state.asStateFlow()
+
+  private val historyStore = BootHistoryStore(application)
+
+  private val tickExecutor = Executors.newSingleThreadScheduledExecutor { r ->
+    Thread(r, "perf-vm-tick").apply { isDaemon = true }
+  }
+
+  init {
+    tickExecutor.scheduleWithFixedDelay(
+        { runCatching { tick() } },
+        0L,
+        TICK_INTERVAL_MS,
+        TimeUnit.MILLISECONDS,
+    )
+  }
+
+  override fun onCleared() {
+    super.onCleared()
+    tickExecutor.shutdown()
+  }
+
+  /**
+   * 解析 [PerfEvent] 流.
+   *
+   * 提取规则:
+   * - `fps_<n>` instant → fps 滚动数组
+   * - `mem_total_pss_kb_<n>` instant → pss 滚动数组
+   * - `gc_count_delta_<n>` instant → gc 滚动数组
+   * - `anr_<n>` / `anr_warn_<n>` instant → anr 列表
+   * - 其他 instant / phase → 启动 events (PR #2 的 18 段)
+   *
+   * 名称前缀用 `_` 切分, 因为 metric name 自身是 `fps_<n>` 这种
+   */
+  internal fun tick() {
+    val collector = PhaseStore.collector() ?: run {
+      _state.value = PerfUiState.EMPTY.copy(isReady = false)
+      return
+    }
+
+    val snapshot = collector.snapshot()
+    val history = historyStore.readAll()
+
+    val fps = ArrayDeque<Int>(SAMPLE_WINDOW)
+    val pss = ArrayDeque<Long>(SAMPLE_WINDOW)
+    val gc = ArrayDeque<Long>(SAMPLE_WINDOW)
+    val anrs = ArrayList<PerfEvent.Instant>()
+
+    // 启动 phase 列表: 只取前 18 条 + end_boot (PR #2 设计)
+    val bootEvents =
+        snapshot.filter { e ->
+          when (e) {
+            is PerfEvent.Phase -> true
+            is PerfEvent.Instant ->
+                e.name !in MONITOR_PREFIXES && e.name != END_BOOT_MARKER
+            PerfEvent.EndBoot -> true
+          }
+        }
+
+    snapshot.forEach { ev ->
+      if (ev is PerfEvent.Instant) {
+        when {
+          ev.name.startsWith("fps_") && ev.name.length > 4 -> {
+            ev.name.substring(4).toIntOrNull()?.let { fps.addLast(it) }
+          }
+          ev.name.startsWith("mem_total_pss_kb_") && ev.name.length > 17 -> {
+            ev.name.substring(17).toLongOrNull()?.let { pss.addLast(it) }
+          }
+          ev.name.startsWith("gc_count_delta_") && ev.name.length > 15 -> {
+            ev.name.substring(15).toLongOrNull()?.let { gc.addLast(it) }
+          }
+          ev.name.startsWith("anr_") -> anrs.add(ev)
+        }
+      }
+    }
+
+    // 滚动窗口: 保留最后 SAMPLE_WINDOW 个
+    while (fps.size > SAMPLE_WINDOW) fps.removeFirst()
+    while (pss.size > SAMPLE_WINDOW) pss.removeFirst()
+    while (gc.size > SAMPLE_WINDOW) gc.removeFirst()
+
+    val startMs = collector.startElapsedMs()
+    val totalBootMs =
+        if (startMs == 0L) 0L
+        else android.os.SystemClock.elapsedRealtime() - startMs
+
+    _state.value =
+        PerfUiState(
+            isReady = true,
+            isBootEnded = collector.isBootEnded(),
+            bootEvents = bootEvents,
+            bootHistory = history,
+            recentFps = fps.toList(),
+            recentPssKb = pss.toList(),
+            recentGcDelta = gc.toList(),
+            anrEvents = anrs,
+            totalBootMs = totalBootMs,
+        )
+  }
+
+  companion object {
+    /** 1Hz 轮询间隔. */
+    private const val TICK_INTERVAL_MS = 1000L
+
+    /** 折线图样本窗口 (60 个 = 1 分钟历史). */
+    private const val SAMPLE_WINDOW = 60
+
+    /**
+     * Monitor 上报的 instant name 前缀 (用于过滤掉 metric 事件, 只保留 IDEApplication
+     * 上报的启动 phase 标记).
+     */
+    private val MONITOR_PREFIXES =
+        setOf(
+            "fps_",
+            "mem_",
+            "gc_",
+            "anr_",
+        )
+
+    /** IDEApplication.onCreate 末端的 instant. */
+    private const val END_BOOT_MARKER = "ide_on_create_end"
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
@@ -1,0 +1,51 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import com.itsaky.androidide.perf.proto.PerfEvent
+import com.itsaky.androidide.perf.store.BootHistoryStore
+
+/**
+ * Perf Console UI 状态 (PR #5/5).
+ *
+ * 由 [PerfConsoleViewModel] 1Hz 刷新, 不可变 data class, Compose
+ * `collectAsState` 直接订阅.
+ *
+ * ## 字段
+ *
+ * - [isReady] / [isBootEnded]: 控制 loading / boot banner
+ * - [bootEvents] / [bootHistory]: Boot tab 数据
+ * - [recentFps] / [recentPssKb] / [recentGcDelta] / [anrEvents]: 实时 tab 数据
+ * - [totalBootMs]: 启动总耗时 (Boot tab 大字显示)
+ *
+ * @author android_zero
+ */
+data class PerfUiState(
+    val isReady: Boolean = false,
+    val isBootEnded: Boolean = false,
+    val bootEvents: List<PerfEvent> = emptyList(),
+    val bootHistory: List<BootHistoryStore.BootSession> = emptyList(),
+    val recentFps: List<Int> = emptyList(),
+    val recentPssKb: List<Long> = emptyList(),
+    val recentGcDelta: List<Long> = emptyList(),
+    val anrEvents: List<PerfEvent.Instant> = emptyList(),
+    val totalBootMs: Long = 0L,
+) {
+  companion object {
+    val EMPTY = PerfUiState()
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/ThreadsTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/ThreadsTab.kt
@@ -1,0 +1,133 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Threads Tab (PR #5/5).
+ *
+ * 显示 :perf 进程和主进程的关键线程状态 (静态, 简单信息卡).
+ *
+ * 实时线程 stack dump 是 O(n) 操作, 不在 PR #5 范围. 这里只列名称 + 状态.
+ */
+@Composable
+fun ThreadsTab(state: PerfUiState, modifier: Modifier = Modifier) {
+  LazyColumn(
+      modifier = modifier.fillMaxSize().padding(12.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    item { ProcessInfoCard() }
+    item { ThreadsSummaryCard() }
+  }
+}
+
+@Composable
+private fun ProcessInfoCard() {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "进程信息",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      InfoRow(label = "进程名", value = readProcessName())
+      InfoRow(label = "PID", value = android.os.Process.myPid().toString())
+      InfoRow(
+          label = "是否 :perf",
+          value = if (readProcessName().endsWith(":perf")) "是" else "否",
+      )
+    }
+  }
+}
+
+@Composable
+private fun ThreadsSummaryCard() {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "线程 (活跃 ${Thread.activeCount()})",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      Text(
+          text = "实时 stack dump 需要 root 权限, 不在 PR #5 范围",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      val groups = Thread.getAllStackTraces().keys.groupBy { thread ->
+        val name = thread.name
+        when {
+          name.startsWith("perf-") -> "perf"
+          name == "main" -> "main"
+          name.startsWith("OkHttp") -> "OkHttp"
+          name.startsWith("Binder:") -> "Binder"
+          else -> "其它"
+        }
+      }
+      groups.forEach { (group, threads) ->
+        InfoRow(label = group, value = "${threads.size} 线程")
+      }
+    }
+  }
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+  androidx.compose.foundation.layout.Row(
+      modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Text(
+        text = label,
+        fontSize = 12.sp,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+        text = value,
+        fontSize = 12.sp,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+  }
+}
+
+private fun readProcessName(): String =
+    runCatching {
+      @Suppress("DEPRECATION")
+      android.os.Process.myProcessName()
+    }.getOrDefault("unknown")

--- a/core/app/src/main/res/drawable/ic_perf_console_foreground.xml
+++ b/core/app/src/main/res/drawable/ic_perf_console_foreground.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This file is part of AndroidIDE.
+  ~
+  ~  AndroidIDE is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  AndroidIDE is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!--
+      Perf Console 图标: 半圆表盘 + 十字指针 + 中心圆点.
+      描边深紫 (#3700B3), 填充透明, 适配浅/暗色 launcher 背景.
+      关键尺寸都放在中央 66x66 安全区 (中心 54,54).
+    -->
+
+    <!-- 表盘外环 (深紫) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:pathData="M 30,54 A 24,24 0 1 1 78,54" />
+
+    <!-- 表盘底部直线 (封闭) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:pathData="M 30,54 L 78,54" />
+
+    <!-- 刻度 1 (12 点) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="3"
+        android:pathData="M 54,32 L 54,38" />
+
+    <!-- 刻度 2 (3 点) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="3"
+        android:pathData="M 76,54 L 70,54" />
+
+    <!-- 刻度 3 (9 点) -->
+    <path
+        android:strokeColor="#3700B3"
+        android:strokeWidth="3"
+        android:pathData="M 32,54 L 38,54" />
+
+    <!-- 指针 (从中心 54,54 指向 1 点方向) -->
+    <path
+        android:strokeColor="#FF3700B3"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:pathData="M 54,54 L 64,42" />
+
+    <!-- 中心圆点 -->
+    <path
+        android:fillColor="#3700B3"
+        android:pathData="M 54,54 m -3,0 a 3,3 0 1,0 6,0 a 3,3 0 1,0 -6,0" />
+</vector>

--- a/core/app/src/main/res/mipmap-anydpi-v26/ic_perf_console.xml
+++ b/core/app/src/main/res/mipmap-anydpi-v26/ic_perf_console.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  This file is part of AndroidIDE.
   ~
   ~  AndroidIDE is free software: you can redistribute it and/or modify
@@ -14,12 +15,11 @@
   ~  You should have received a copy of the GNU General Public License
   ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
   -->
-
-<resources>
-  <!--  Required by F-Droid-->
-  <string name="app_name" translatable="false">ZeroStudio</string>
-
-  <!-- Perf Console (性能监控调试控制台) — 桌面启动图标 + 通知标签 -->
-  <string name="perf_console_title" translatable="false">Perf Console</string>
-  <string name="perf_console_label">Perf Console</string>
-</resources>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+      Background 用 launcher 共用的纯白色, foreground 用自绘 vector drawable
+      (表盘 + 指针). 尺寸 108x108dp, 安全区中心 66x66dp (1/3 边距).
+    -->
+    <background android:drawable="@color/ic_perf_console_background"/>
+    <foreground android:drawable="@drawable/ic_perf_console_foreground"/>
+</adaptive-icon>

--- a/core/app/src/main/res/values/perf_console_colors.xml
+++ b/core/app/src/main/res/values/perf_console_colors.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  This file is part of AndroidIDE.
   ~
   ~  AndroidIDE is free software: you can redistribute it and/or modify
@@ -14,12 +15,7 @@
   ~  You should have received a copy of the GNU General Public License
   ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
   -->
-
 <resources>
-  <!--  Required by F-Droid-->
-  <string name="app_name" translatable="false">ZeroStudio</string>
-
-  <!-- Perf Console (性能监控调试控制台) — 桌面启动图标 + 通知标签 -->
-  <string name="perf_console_title" translatable="false">Perf Console</string>
-  <string name="perf_console_label">Perf Console</string>
+    <!-- Perf Console 图标背景色: 浅紫, 与 launcher (#FFFFFF) 区分 -->
+    <color name="ic_perf_console_background">#EDE7F6</color>
 </resources>


### PR DESCRIPTION
## 背景

5 步计划最后一步: 把 PR #1 的占位 Activity 替换为完整 Compose 仪表盘.

PR #1-#4 依赖:
- #363 骨架 ✅ merged
- #364 PerfTracer + 18 段埋点 ✅ 开
- #365 server + 协议 + PhaseCollector ✅ 开
- #366 4 个 Monitor + BootHistoryStore ✅ 开

详细 spec: docs/superpowers/specs/2026-06-14-perf-console-design.md

## 改动 (9 files, +978/-58)

### 新增 (8)

- PerfUiState.kt — 不可变 UI state
- PerfConsoleViewModel.kt — 1Hz tickExecutor 拉 PhaseStore + BootHistoryStore
- ChartComposables.kt — Sparkline / DualSparkline (Canvas 自绘)
- BootTab.kt — 启动总耗时 + 18 段条形 + 10 次历史
- FrameTab.kt — FPS 大字 + sparkline + ANR 列表
- MemoryTab.kt — PSS 大字 + sparkline + GC 频率
- ThreadsTab.kt — 进程信息 + 线程分组
- PerfConsoleScreen.kt — 主屏 (TopAppBar + TabRow + 4 tab)

### 修改 (1)

- PerfConsoleActivity.kt — 接入 ViewModel (lazy 创建)

## 4 tab × 6 card

### Boot tab

- TotalBootCard: 启动总耗时 (大字) + 启动中/完成状态
- BootTimelineCard: 18 段 phase 条形图 (按耗时比例, 横向)
- BootHistoryCard: 最近 10 次启动对比 (条形 + 编号)

### Frame tab

- FpsCard: 当前 FPS 大字 + sparkline (60 窗口)
- AnrListCard: ANR (>5s 红色) / Warn (>2.5s 橙色) 倒序

### Memory tab

- PssCard: 当前 PSS (MB) 大字 + sparkline
- GcCard: 平均 GC 频率 (次/s) + sparkline

### Threads tab

- ProcessInfoCard: 进程名 / PID / 是否 :perf
- ThreadsSummaryCard: 线程分组 (perf/main/OkHttp/Binder/其它)

## 解析规则

ViewModel.tick() 1Hz 拉 PhaseCollector.snapshot() + BootHistoryStore.readAll():

- `fps_<n>` instant → 60 窗口
- `mem_total_pss_kb_<n>` instant → PSS 60 窗口
- `gc_count_delta_<n>` instant → GC 60 窗口
- `anr_<n>` / `anr_warn_<n>` instant → ANR 列表
- 其他 → 启动 phase 列表

## 设计取舍

- **4 tab 而非 1 长列表**: 信息分组清晰
- **60 窗口 sparkline**: 1Hz × 60s, 不会让 Compose recompose 开销过大
- **Canvas 自绘**: 不引外部 chart 库, ~1.5ms draw 一次
- **Lazy ViewModel 创建**: 避免 androidx-lifecycle-viewmodel-savedstate 依赖
- **Activity onDestroy (isFinishing) → onCleared**: 释放 tickExecutor

## 验证

- 9 files changed, +978 / -58
- 编译依赖: 复用 PR #1-#4 已加的 compose / material3 / activity-compose
- 不需 build.gradle.kts 改动

## 5 步路线图完成 🎉

| PR | 范围 | 状态 |
| --- | --- | --- |
| #1 (PR #363) | 骨架 (独立 :perf 进程 + 桌面图标) | merged |
| #2 (PR #364) | PerfTracer + 18 段埋点 | open |
| #3 (PR #365) | server + 协议 + PhaseCollector | open |
| #4 (PR #366) | 4 个 Monitor + BootHistoryStore | open |
| #5 (本 PR) | 完整 Compose UI | open |

## 用户使用流程

1. 编译安装最新 debug build
2. 桌面点击 "Perf Console" 图标 (浅紫底 + 表盘)
3. 看到 loading state ("等待 IDEApplication.onCreate")
4. 桌面返回, 点击 ZeroStudio launcher
5. 看到 IDEApplication.onCreate 18 段 phase 实时上报
6. 切到 Frame tab 看 FPS 折线
7. 切到 Memory tab 看 PSS 折线 + GC 频率
8. 切到 Threads tab 看进程信息

主 application 启动崩溃时 Perf Console 仍能用, 监控 UI 仍能显示.

## 风险

- **ViewModel lazy 创建**: 进程被杀时未 onCleared, daemon tickExecutor 也会随进程死 — 安全
- **1Hz 大量 metric 上报**: socket 1KB/s 流量, 同 UID 内 < 1% CPU
- **JSON 解析 regex**: 18 段固定, 手工 regex 足够, < 100us 一次
