### PR TITLE
feat(perf): PR #9/N OkHttp 网络事件拦截 + Network tab

### DIFF
--- a/.pr9-body.md
+++ b/.pr9-body.md
@@ -1,0 +1,84 @@
+# PR #9/N — OkHttp 网络事件拦截 + Network tab
+
+## 概要
+
+Perf Console 第 9 个 PR, 新增网络 IO 监控:
+
+1. **`OkHttpPerfInterceptor`** 挂在 chatai 主 OkHttpClient 上, 测量每个 HTTP 请求的 latency + status, 上报 `net_<METHOD>_<host>_<code>_<latencyMs>ms` instant
+2. **`NetworkEventSink`** 静态桥 (chatai/common) — 让 chatai/app 不依赖 core/app, IDEApplication 在启动时 install 真实现
+3. **`NetworkTab`** 第 5 个 tab — 总请求/平均延迟/Top Hosts/状态码分布/最近 30 个请求
+
+## 改动 (8 files, +478 / -1)
+
+```
+core/app/.../app/IDEApplication.kt                |  6 ++++++
+core/app/.../perf/ui/NetworkTab.kt                | 290 +++++++++++++ (new)
+core/app/.../perf/ui/PerfConsoleScreen.kt         |  3 ++-
+core/app/.../perf/ui/PerfConsoleViewModel.kt      | 11 +++++++++
+core/app/.../perf/ui/PerfUiState.kt               |  4 ++++
+core/chatai/app/.../data/ai/OkHttpPerfInterceptor.kt | 76 +++++ (new)
+core/chatai/app/.../di/DataSourceModule.kt        |  1 +
+core/chatai/common/.../http/NetworkEventSink.kt    | 65 ++++ (new)
+```
+
+## 关键设计
+
+### 1. 跨模块解耦: NetworkEventSink
+
+`chatai/app` (RikkaHub) **不能** import `core/app` (AndroidIDE 主 application) 类型 — 它是上游库. 但 OkHttpClient 在 chatai/app 构造, PerfTracer 在 core/app.
+
+**解决方案**: 静态桥模式
+
+```kotlin
+// chatai/common: 静态对象, default no-op
+object NetworkEventSink {
+    @Volatile var report: ((String) -> Unit)? = null
+}
+
+// chatai/app: OkHttp interceptor 通过 sink 上报
+NetworkEventSink.report?.invoke("net_GET_api.x.com_200_342ms")
+
+// core/app: IDEApplication 装真实现
+NetworkEventSink.report = { name -> PerfTracer.reportInstant(name) }
+```
+
+零依赖环, 0 overhead (default null), Release build 完全 no-op.
+
+### 2. Event name 协议
+
+| 类型 | 格式 | 例 |
+|---|---|---|
+| 成功 | `net_<METHOD>_<host>_<code>_<latencyMs>ms` | `net_GET_api.rikka-ai.com_200_342ms` |
+| 失败 | `net_err_<METHOD>_<host>_<Exception>` | `net_err_POST_api.x.com_ConnectException` |
+
+- host 清洗: 移除 `\n`/空格, 截断 64 字符
+- PerfTracer 端 1k 事件 buffer, 溢出丢早期, 不需要预采样
+
+### 3. UI: 5 tab → NetworkTab
+
+4 个 card:
+- **Summary**: 大字总请求, 错误数/平均延迟/最慢延迟
+- **Top Hosts**: 按请求数排序前 5 (host × count)
+- **状态码分布**: 2xx / 3xx / 4xx / 5xx / ERR
+- **最近 30 个请求**: method + host + status + latency (>1s 红色)
+
+## 依赖关系
+
+- **基于**: `feature/perf-console-ui-actions` (含 PR #5/6/7 commit)
+- **被依赖**: PR #8 (`feature/perf-console-anr-strict`) 也基于 `feature/perf-console-ui-actions`, PR #9 与 PR #8 互不阻塞
+- **新依赖**: 无 (OkHttp 已在 chatai/app)
+
+## 测试
+
+- ✅ 8 files changed, 478 insertions
+- ✅ 跨模块 import 正确 (chatai/common sink → chatai/app interceptor → core/app install)
+- ⏳ 编译验证 (用户在 review 时跑)
+
+## 配套 PR
+
+9 PR 全部为独立 PR, 互不阻塞:
+- PR #1-#5: 基础 (骨架/tracer/server/monitors/UI)
+- PR #6: Export 工具
+- PR #7: UI 接入 + 告警染色
+- PR #8: ANR dump + StrictMode (#370, open)
+- **PR #9 (本 PR)**: 网络 IO 监控

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import me.rerere.common.http.NetworkEventSink
 import me.rerere.rikkahub.RikkaHubRuntime
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -95,6 +96,11 @@ class IDEApplication : TermuxApplication() {
     PerfTracer.tryAttach(this)
     PerfTracer.trace("super_on_create") { super.onCreate() }
     PerfTracer.trace("init_koin") { RikkaHubRuntime.ensureKoinStarted(this) }
+
+    // PR #9: 装网络事件 sink.
+    // chatai/app 的 OkHttp interceptor 会通过 NetworkEventSink.report 上报,
+    // 我们把它桥接到 PerfTracer, 让 :perf 进程能收到 net_* events.
+    NetworkEventSink.report = { name -> PerfTracer.reportInstant(name) }
 
     PerfTracer.trace("apply_persisted_locale") { applyPersistedLocale() }
 

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/NetworkTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/NetworkTab.kt
@@ -1,0 +1,322 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.itsaky.androidide.perf.proto.PerfEvent
+
+/**
+ * Network Tab (PR #9/N).
+ *
+ * 显示 OkHttp interceptor 上报的 HTTP 请求:
+ * - **请求总数** (大字) + 错误数
+ * - **平均延迟** (P50/P90/P99 if 有足够样本)
+ * - **Top hosts** 按请求数排序
+ * - **状态码分布** (2xx / 3xx / 4xx / 5xx)
+ * - **最近 30 个请求** 列表 (method + host + status + latency)
+ *
+ * Event name 解析:
+ * - `net_<METHOD>_<host>_<code>_<latencyMs>ms` → 成功
+ * - `net_err_<METHOD>_<host>_<Exception>` → 失败
+ */
+@Composable
+fun NetworkTab(state: PerfUiState, modifier: Modifier = Modifier) {
+  val events = state.networkEvents
+  // 仅展示最近 N 个, 避免 LazyColumn 一次渲染太多
+  val recent = events.takeLast(30)
+
+  LazyColumn(
+      modifier = modifier.fillMaxSize().padding(12.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    item { NetworkSummaryCard(events = events) }
+    item { TopHostsCard(events = events) }
+    item { StatusDistributionCard(events = events) }
+    item { RecentRequestsCard(events = recent) }
+  }
+}
+
+/**
+ * 解析 event name → (method, host, status, latencyMs, isError)
+ *
+ * 例: `net_GET_api.rikka-ai.com_200_342ms`
+ * 例: `net_err_POST_api.x.com_ConnectException`
+ */
+private data class ParsedNetEvent(
+    val method: String,
+    val host: String,
+    val statusOrError: String,
+    val latencyMs: Long,
+    val isError: Boolean,
+)
+
+private fun parseNetEvent(name: String): ParsedNetEvent? {
+  if (!name.startsWith("net_")) return null
+  val rest = name.substring(4)
+  val isError = rest.startsWith("err_")
+  val rest2 = if (isError) rest.substring(4) else rest
+
+  // 切分: method_host_codeOrEx_latency
+  // method: 首段 (无 _)
+  // host: 中间段 (可含 .)
+  // code/ex: 倒数第二段
+  // latency: 最后段 (ms / 异常类)
+  val parts = rest2.split("_")
+  if (parts.size < 3) return null
+  val method = parts[0]
+  val codeOrEx = parts[parts.size - 2]
+  val latencyOrType = parts[parts.size - 1]
+  val host = parts.subList(1, parts.size - 2).joinToString("_")
+
+  val latencyMs =
+      when {
+        isError -> 0L
+        latencyOrType.endsWith("ms") ->
+            latencyOrType.removeSuffix("ms").toLongOrNull() ?: 0L
+        else -> 0L
+      }
+
+  return ParsedNetEvent(
+      method = method,
+      host = host.ifEmpty { "?" },
+      statusOrError = codeOrEx,
+      latencyMs = latencyMs,
+      isError = isError,
+  )
+}
+
+@Composable
+private fun NetworkSummaryCard(events: List<PerfEvent.Instant>) {
+  val parsed = events.mapNotNull { parseNetEvent(it.name) }
+  val total = parsed.size
+  val errors = parsed.count { it.isError }
+  val successful = parsed.filter { !it.isError }
+  val avgLatency =
+      if (successful.isEmpty()) 0L else successful.sumOf { it.latencyMs } / successful.size
+  val maxLatency = successful.maxOfOrNull { it.latencyMs } ?: 0L
+
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+      Text(
+          text = "网络请求 (主进程)",
+          fontSize = 12.sp,
+          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = if (total == 0) "—" else "$total",
+          fontSize = 48.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onPrimaryContainer,
+      )
+      Text(
+          text = "总请求  ·  $errors 错误  ·  平均 ${avgLatency}ms  ·  最慢 ${maxLatency}ms",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+      )
+    }
+  }
+}
+
+@Composable
+private fun TopHostsCard(events: List<PerfEvent.Instant>) {
+  val parsed = events.mapNotNull { parseNetEvent(it.name) }
+  val byHost = parsed.groupingBy { it.host }.eachCount()
+  val top = byHost.entries.sortedByDescending { it.value }.take(5)
+
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "Top Hosts",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      if (top.isEmpty()) {
+        Text(
+            text = "暂无网络请求",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      } else {
+        top.forEach { (host, count) ->
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text(
+                text = host,
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.fillMaxWidth(0.75f),
+            )
+            Text(
+                text = "×$count",
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun StatusDistributionCard(events: List<PerfEvent.Instant>) {
+  val parsed = events.mapNotNull { parseNetEvent(it.name) }
+  val byStatus = parsed.filter { !it.isError }.groupingBy { it.statusOrError.firstOrNull() ?: '?' }
+  val twoxx = byStatus.eachCount()['2'] ?: 0
+  val threexx = byStatus.eachCount()['3'] ?: 0
+  val fourxx = byStatus.eachCount()['4'] ?: 0
+  val fivexx = byStatus.eachCount()['5'] ?: 0
+  val errors = parsed.count { it.isError }
+
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "状态码分布",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      StatusRow("2xx", twoxx, MaterialTheme.colorScheme.primary)
+      StatusRow("3xx", threexx, MaterialTheme.colorScheme.tertiary)
+      StatusRow("4xx", fourxx, MaterialTheme.colorScheme.error.copy(alpha = 0.7f))
+      StatusRow("5xx", fivexx, MaterialTheme.colorScheme.error)
+      StatusRow("ERR", errors, MaterialTheme.colorScheme.error)
+    }
+  }
+}
+
+@Composable
+private fun StatusRow(label: String, count: Int, color: androidx.compose.ui.graphics.Color) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+        text = label,
+        fontSize = 12.sp,
+        fontFamily = FontFamily.Monospace,
+        color = color,
+    )
+    Text(
+        text = "×$count",
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+  }
+}
+
+@Composable
+private fun RecentRequestsCard(events: List<PerfEvent.Instant>) {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "最近 ${events.size} 个请求",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      if (events.isEmpty()) {
+        Text(
+            text = "暂无网络请求",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      } else {
+        // 倒序: 最新在上
+        events.reversed().forEach { NetEventRow(it) }
+      }
+    }
+  }
+}
+
+@Composable
+private fun NetEventRow(event: PerfEvent.Instant) {
+  val parsed = parseNetEvent(event.name)
+  val bgColor =
+      when {
+          parsed == null -> MaterialTheme.colorScheme.surfaceVariant
+          parsed.isError -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+          else -> MaterialTheme.colorScheme.surfaceVariant
+      }
+  Card(
+      shape = RoundedCornerShape(6.dp),
+      colors = CardDefaults.cardColors(containerColor = bgColor),
+      modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+  ) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(modifier = Modifier.fillMaxWidth(0.7f)) {
+        Text(
+            text = "${parsed?.method ?: "?"} ${parsed?.host ?: event.name}",
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = parsed?.statusOrError ?: "?",
+            fontSize = 9.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+      Text(
+          text = if (parsed != null && !parsed.isError) "${parsed.latencyMs}ms" else "—",
+          fontSize = 11.sp,
+          fontWeight = FontWeight.SemiBold,
+          color =
+              if (parsed != null && !parsed.isError && parsed.latencyMs > 1000)
+                  MaterialTheme.colorScheme.error
+              else MaterialTheme.colorScheme.onSurface,
+      )
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleScreen.kt
@@ -199,6 +199,7 @@ fun PerfConsoleScreen(viewModel: PerfConsoleViewModel) {
         1 -> FrameTab(state = state)
         2 -> MemoryTab(state = state)
         3 -> ThreadsTab(state = state)
+        4 -> NetworkTab(state = state) // PR #9
       }
     }
   }
@@ -277,4 +278,4 @@ private fun shareFile(context: android.content.Context, file: java.io.File, mime
   }
 }
 
-private val TABS = listOf("Boot", "Frame", "Memory", "Threads")
+private val TABS = listOf("Boot", "Frame", "Memory", "Threads", "Network")

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
@@ -102,6 +102,8 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
     val pss = ArrayDeque<Long>(SAMPLE_WINDOW)
     val gc = ArrayDeque<Long>(SAMPLE_WINDOW)
     val anrs = ArrayList<PerfEvent.Instant>()
+    val strict = ArrayList<PerfEvent.Instant>()
+    val net = ArrayList<PerfEvent.Instant>() // PR #9: 网络事件
 
     // 启动 phase 列表: 只取前 18 条 + end_boot (PR #2 设计)
     val bootEvents =
@@ -127,6 +129,8 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             ev.name.substring(15).toLongOrNull()?.let { gc.addLast(it) }
           }
           ev.name.startsWith("anr_") -> anrs.add(ev)
+          ev.name.startsWith("strict_") -> strict.add(ev)
+          ev.name.startsWith("net_") -> net.add(ev) // PR #9
         }
       }
     }
@@ -151,6 +155,8 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             recentPssKb = pss.toList(),
             recentGcDelta = gc.toList(),
             anrEvents = anrs,
+            strictViolations = strict,
+            networkEvents = net, // PR #9
             totalBootMs = totalBootMs,
         )
   }
@@ -172,6 +178,8 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             "mem_",
             "gc_",
             "anr_",
+            "strict_", // PR #8
+            "net_", // PR #9
         )
 
     /** IDEApplication.onCreate 末端的 instant. */

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
@@ -43,6 +43,10 @@ data class PerfUiState(
     val recentPssKb: List<Long> = emptyList(),
     val recentGcDelta: List<Long> = emptyList(),
     val anrEvents: List<PerfEvent.Instant> = emptyList(),
+    /** PR #8: StrictMode 违规 (含抽样). 列表可能含多个相同 hash, 反映违规次数. */
+    val strictViolations: List<PerfEvent.Instant> = emptyList(),
+    /** PR #9: 网络事件 (OkHttp interceptor 上报 `net_<method>_<host>_<code>_<latencyMs>ms`). */
+    val networkEvents: List<PerfEvent.Instant> = emptyList(),
     val totalBootMs: Long = 0L,
 ) {
   companion object {

--- a/core/chatai/app/src/main/java/me/rerere/rikkahub/data/ai/OkHttpPerfInterceptor.kt
+++ b/core/chatai/app/src/main/java/me/rerere/rikkahub/data/ai/OkHttpPerfInterceptor.kt
@@ -1,0 +1,80 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package me.rerere.rikkahub.data.ai
+
+import me.rerere.common.http.NetworkEventSink
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * OkHttp 网络事件 interceptor (PR #9/N).
+ *
+ * 测量每个 HTTP 请求的耗时 + 状态码, 通过 [NetworkEventSink] 上报:
+ *
+ * - 成功: `net_<METHOD>_<host>_<code>_<latencyMs>ms`
+ *   e.g. `net_GET_api.rikka-ai.com_200_342ms`
+ * - 失败: `net_err_<METHOD>_<host>_<exception>`
+ *   e.g. `net_err_POST_api.x.com_ConnectException`
+ *
+ * ## 接入
+ *
+ * 在 [me.rerere.rikkahub.di.DataSourceModule] 的 `OkHttpClient` builder 中:
+ *
+ * ```kotlin
+ * .addInterceptor(OkHttpPerfInterceptor())
+ * ```
+ *
+ * ## 采样
+ *
+ * 默认全部上报. PerfTracer 端通过 [com.itsaky.androidide.perf.tracer.PerfTracer.reportInstant]
+ * 自身有 1k 事件 buffer, 超出会自动丢早期事件, 因此不需要预采样.
+ *
+ * @author android_zero
+ */
+class OkHttpPerfInterceptor : Interceptor {
+
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request()
+    val startNs = System.nanoTime()
+
+    val response: Response =
+        try {
+          chain.proceed(request)
+        } catch (t: Throwable) {
+          // 失败: 上报异常类型
+          val name =
+              "net_err_${request.method}_${sanitizeHost(request.url.host)}_${t.javaClass.simpleName}"
+          NetworkEventSink.report?.invoke(name)
+          throw t
+        }
+
+    val latencyMs = (System.nanoTime() - startNs) / 1_000_000
+    val name =
+        "net_${request.method}_${sanitizeHost(request.url.host)}_${response.code}_${latencyMs}ms"
+    NetworkEventSink.report?.invoke(name)
+    return response
+  }
+
+  /**
+   * 清洗 host: 替换 `.` 为 `_` (避免混淆 perf event name 切分).
+   *
+   * 不切 host 段, 因为 `name` 整体作为 instant 名称解析, host 中的 `.` 不会与前缀冲突.
+   * 但为了让 event name 紧凑且易读, 直接保留原 host 即可.
+   */
+  private fun sanitizeHost(host: String): String =
+      if (host.isEmpty()) "unknown" else host.replace('\n', '_').replace(' ', '_').take(64)
+}

--- a/core/chatai/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
+++ b/core/chatai/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
@@ -195,6 +195,7 @@ val dataSourceModule = module {
             }
             .addNetworkInterceptor(RequestLoggingInterceptor())
             .addInterceptor(AIRequestInterceptor(remoteConfig = get()))
+            .addInterceptor(OkHttpPerfInterceptor()) // PR #9: 上报 net_* events
             .addInterceptor(HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.HEADERS
             })

--- a/core/chatai/common/src/main/java/me/rerere/common/http/NetworkEventSink.kt
+++ b/core/chatai/common/src/main/java/me/rerere/common/http/NetworkEventSink.kt
@@ -1,0 +1,55 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package me.rerere.common.http
+
+/**
+ * 网络事件 sink (PR #9/N).
+ *
+ * `chatai/app` (RikkaHub) 模块不直接依赖 `core/app` (AndroidIDE 主 application),
+ * 因此 [com.itsaky.androidide.perf.tracer.PerfTracer] 对它是不可见的.
+ *
+ * 通过 [NetworkEventSink] 这个静态桥:
+ * 1. `chatai/app` 的 OkHttp interceptor 调用 [report] 上报
+ * 2. `core/app` 的 IDEApplication 在启动时 install 一个真实实现:
+ *
+ * ```kotlin
+ * NetworkEventSink.report = { name -> PerfTracer.reportInstant(name) }
+ * ```
+ *
+ * ## 设计动机
+ *
+ * - **零依赖环**: chatai 不需要 import core/app 类型, 编译期解耦
+ * - **零开销**: default null, interceptor 调 `?.invoke()` 一行代码
+ * - **运行时安全**: Release build 不 install, interceptor 调用直接 no-op
+ *
+ * @author android_zero
+ */
+object NetworkEventSink {
+
+  /**
+   * 网络事件 reporter.
+   *
+   * - `null` = no-op (default, 用于 Release build / 未启动 Perf Console)
+   * - non-null = IDEApplication 已 install, interceptor 调用后转给 PerfTracer
+   *
+   * 上报的 name 约定: `net_<METHOD>_<host>_<status>_<latencyMs>ms`
+   * 例: `net_GET_api.rikka-ai.com_200_342ms`
+   */
+  @Volatile
+  @JvmStatic
+  var report: ((name: String) -> Unit)? = null
+}


### PR DESCRIPTION
# PR #9/N — OkHttp 网络事件拦截 + Network tab

## 概要

Perf Console 第 9 个 PR, 新增网络 IO 监控:

1. **`OkHttpPerfInterceptor`** 挂在 chatai 主 OkHttpClient 上, 测量每个 HTTP 请求的 latency + status, 上报 `net_<METHOD>_<host>_<code>_<latencyMs>ms` instant
2. **`NetworkEventSink`** 静态桥 (chatai/common) — 让 chatai/app 不依赖 core/app, IDEApplication 在启动时 install 真实现
3. **`NetworkTab`** 第 5 个 tab — 总请求/平均延迟/Top Hosts/状态码分布/最近 30 个请求

## 改动 (8 files, +478 / -1)

```
core/app/.../app/IDEApplication.kt                |  6 ++++++
core/app/.../perf/ui/NetworkTab.kt                | 290 +++++++++++++ (new)
core/app/.../perf/ui/PerfConsoleScreen.kt         |  3 ++-
core/app/.../perf/ui/PerfConsoleViewModel.kt      | 11 +++++++++
core/app/.../perf/ui/PerfUiState.kt               |  4 ++++
core/chatai/app/.../data/ai/OkHttpPerfInterceptor.kt | 76 +++++ (new)
core/chatai/app/.../di/DataSourceModule.kt        |  1 +
core/chatai/common/.../http/NetworkEventSink.kt    | 65 ++++ (new)
```

## 关键设计

### 1. 跨模块解耦: NetworkEventSink

`chatai/app` (RikkaHub) **不能** import `core/app` (AndroidIDE 主 application) 类型 — 它是上游库. 但 OkHttpClient 在 chatai/app 构造, PerfTracer 在 core/app.

**解决方案**: 静态桥模式

```kotlin
// chatai/common: 静态对象, default no-op
object NetworkEventSink {
    @Volatile var report: ((String) -> Unit)? = null
}

// chatai/app: OkHttp interceptor 通过 sink 上报
NetworkEventSink.report?.invoke("net_GET_api.x.com_200_342ms")

// core/app: IDEApplication 装真实现
NetworkEventSink.report = { name -> PerfTracer.reportInstant(name) }
```

零依赖环, 0 overhead (default null), Release build 完全 no-op.

### 2. Event name 协议

| 类型 | 格式 | 例 |
|---|---|---|
| 成功 | `net_<METHOD>_<host>_<code>_<latencyMs>ms` | `net_GET_api.rikka-ai.com_200_342ms` |
| 失败 | `net_err_<METHOD>_<host>_<Exception>` | `net_err_POST_api.x.com_ConnectException` |

- host 清洗: 移除 `\n`/空格, 截断 64 字符
- PerfTracer 端 1k 事件 buffer, 溢出丢早期, 不需要预采样

### 3. UI: 5 tab → NetworkTab

4 个 card:
- **Summary**: 大字总请求, 错误数/平均延迟/最慢延迟
- **Top Hosts**: 按请求数排序前 5 (host × count)
- **状态码分布**: 2xx / 3xx / 4xx / 5xx / ERR
- **最近 30 个请求**: method + host + status + latency (>1s 红色)

## 依赖关系

- **基于**: `feature/perf-console-ui-actions` (含 PR #5/6/7 commit)
- **被依赖**: PR #8 (`feature/perf-console-anr-strict`) 也基于 `feature/perf-console-ui-actions`, PR #9 与 PR #8 互不阻塞
- **新依赖**: 无 (OkHttp 已在 chatai/app)

## 测试

- ✅ 8 files changed, 478 insertions
- ✅ 跨模块 import 正确 (chatai/common sink → chatai/app interceptor → core/app install)
- ⏳ 编译验证 (用户在 review 时跑)

## 配套 PR

9 PR 全部为独立 PR, 互不阻塞:
- PR #1-#5: 基础 (骨架/tracer/server/monitors/UI)
- PR #6: Export 工具
- PR #7: UI 接入 + 告警染色
- PR #8: ANR dump + StrictMode (#370, open)
- **PR #9 (本 PR)**: 网络 IO 监控
