### PR TITLE
feat(perf): 高级监控合集 — 冷启动 / Crash / 前后台 / 阈值配置

### DIFF
--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -173,6 +173,8 @@ dependencies {
   implementation(libs.androidx.nav.fragment)
   implementation(libs.androidx.nav.ui)
   implementation(libs.androidx.preference)
+  // PR (advanced): DataStore Preferences 持久化自定义阈值 (Advanced / Commit 4)
+  implementation(libs.androidx.datastore.preferences)
   implementation(libs.androidx.recyclerview)
   implementation(libs.androidx.transition)
   implementation(libs.androidx.vectors)
@@ -187,6 +189,8 @@ dependencies {
   implementation(libs.firebase.crashlytics)
   implementation(libs.firebase.config)
   implementation(libs.androidx.compose.material.icons.extended)
+  // PR (advanced): ProcessLifecycleOwner 监听前后台切换 (Advanced / Commit 3)
+  implementation(libs.androidx.lifecycle.process)
 
   // UI/UX
   implementation(libs.bundles.compose) // androidx compose

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -37,6 +37,7 @@ import com.itsaky.androidide.events.LspApiEventsIndex
 import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
 import com.itsaky.androidide.perf.PerfApplication
+import com.itsaky.androidide.perf.export.ThresholdPreferences
 import com.itsaky.androidide.perf.monitor.ColdStartTracker
 import com.itsaky.androidide.perf.monitor.CrashHandler
 import com.itsaky.androidide.perf.monitor.ForegroundTracker
@@ -153,6 +154,8 @@ class IDEApplication : TermuxApplication() {
     ColdStartTracker.markAppReady() // PR (advanced): 冷启动第二段
     ColdStartTracker.registerFirstActivityTracker(this) // PR (advanced): 等首 Activity
     ForegroundTracker.install() // PR (advanced): 监听前后台切换
+    // PR (advanced): 启动时从 DataStore 加载用户自定义的 phase 告警阈值
+    ThresholdPreferences.loadIntoThresholds(this)
     PerfTracer.endBoot()
     MonitorCoordinator.start(this)
   }

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -39,6 +39,7 @@ import com.itsaky.androidide.events.LspKotlinEventsIndex
 import com.itsaky.androidide.perf.PerfApplication
 import com.itsaky.androidide.perf.monitor.ColdStartTracker
 import com.itsaky.androidide.perf.monitor.CrashHandler
+import com.itsaky.androidide.perf.monitor.ForegroundTracker
 import com.itsaky.androidide.perf.monitor.MonitorCoordinator
 import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
@@ -151,6 +152,7 @@ class IDEApplication : TermuxApplication() {
     PerfTracer.reportInstant("ide_on_create_end")
     ColdStartTracker.markAppReady() // PR (advanced): 冷启动第二段
     ColdStartTracker.registerFirstActivityTracker(this) // PR (advanced): 等首 Activity
+    ForegroundTracker.install() // PR (advanced): 监听前后台切换
     PerfTracer.endBoot()
     MonitorCoordinator.start(this)
   }

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -37,6 +37,7 @@ import com.itsaky.androidide.events.LspApiEventsIndex
 import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
 import com.itsaky.androidide.perf.PerfApplication
+import com.itsaky.androidide.perf.monitor.ColdStartTracker
 import com.itsaky.androidide.perf.monitor.MonitorCoordinator
 import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
@@ -92,6 +93,7 @@ class IDEApplication : TermuxApplication() {
 
     instance = this
     PerfTracer.reportInstant("ide_on_create_begin")
+    ColdStartTracker.markAppStart() // PR (advanced): 冷启动第一段
     PerfTracer.tryAttach(this)
     PerfTracer.trace("super_on_create") { super.onCreate() }
     PerfTracer.trace("init_koin") { RikkaHubRuntime.ensureKoinStarted(this) }
@@ -146,6 +148,8 @@ class IDEApplication : TermuxApplication() {
     }
 
     PerfTracer.reportInstant("ide_on_create_end")
+    ColdStartTracker.markAppReady() // PR (advanced): 冷启动第二段
+    ColdStartTracker.registerFirstActivityTracker(this) // PR (advanced): 等首 Activity
     PerfTracer.endBoot()
     MonitorCoordinator.start(this)
   }

--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -38,6 +38,7 @@ import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
 import com.itsaky.androidide.perf.PerfApplication
 import com.itsaky.androidide.perf.monitor.ColdStartTracker
+import com.itsaky.androidide.perf.monitor.CrashHandler
 import com.itsaky.androidide.perf.monitor.MonitorCoordinator
 import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
@@ -213,6 +214,9 @@ class IDEApplication : TermuxApplication() {
     writeException(th)
 
     try {
+      // PR (advanced): 先 dump 现场到 cacheDir, 再走原来的 crash UI
+      CrashHandler.dumpCrashContext(this, thread, th)
+
       val intent = Intent()
       intent.action = CrashHandlerActivity.REPORT_ACTION
       intent.putExtra(CrashHandlerActivity.TRACE_KEY, getFullStackTrace(th))

--- a/core/app/src/main/java/com/itsaky/androidide/perf/export/ThresholdPreferences.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/export/ThresholdPreferences.kt
@@ -1,0 +1,148 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.export
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+
+/**
+ * 自定义 phase 告警阈值的持久化 (Advanced / Commit 4).
+ *
+ * 用 [DataStore]<[Preferences]> 把 [PhaseThresholds] 阈值 (3 个非零 ms)
+ * 跨重启保存. 不存 "0" (OK 上限 = WARN 上限 - 默认差) — 我们存**完整的
+ * 3 个边界**: WARN/SLOW/CRITICAL 的 ms 上限. OK 上限由 0 (含) 到
+ * WARN (不含) 自动定义, 不需要持久化.
+ *
+ * ## 存储 key
+ *
+ * - `pref_warn_ms` — < 此值为 OK, ≥ 此值为 WARN
+ * - `pref_slow_ms` — ≥ 此值为 SLOW
+ * - `pref_critical_ms` — ≥ 此值为 CRITICAL
+ *
+ * ## 加载 / 保存
+ *
+ * - [loadIntoThresholds]: 启动时 (IDEApplication.onCreate) 调, 同步阻塞
+ *   读第一次 cache, 之后异步 observe 跟新. 也可在 [save] 后手动调一次
+ *   让 PhaseThresholds 立即生效.
+ * - [save]: 用户在 UI 调 Slider 改完后调, 异步写 DataStore.
+ *
+ * @author android_zero
+ */
+object ThresholdPreferences {
+
+  private val log = LoggerFactory.getLogger(ThresholdPreferences::class.java)
+
+  private val Context.dataStore: DataStore<Preferences> by
+      preferencesDataStore(name = "perf_thresholds")
+
+  private val KEY_WARN = longPreferencesKey("pref_warn_ms")
+  private val KEY_SLOW = longPreferencesKey("pref_slow_ms")
+  private val KEY_CRITICAL = longPreferencesKey("pref_critical_ms")
+
+  /**
+   * 从 DataStore 加载一次, 应用到 [PhaseThresholds].
+   *
+   * 用 [runBlocking] 同步读, 因为 [PhaseThresholds] 必须在 IDEApplication
+   * .onCreate 末尾前就准备好 (BootTimelineCard 第一帧就要按阈值染色).
+   * DataStore 的 .first() 读 cache 是 fast path, 不会真正阻塞 IO.
+   *
+   * @return 加载到的阈值 (默认 = [PhaseThresholds.DEFAULT_THRESHOLDS])
+   */
+  @JvmStatic
+  fun loadIntoThresholds(context: Context): LongArray {
+    return try {
+      val prefs = runBlocking { context.dataStore.data.first() }
+      val warn = prefs[KEY_WARN] ?: PhaseThresholds.DEFAULT_THRESHOLDS[0]
+      val slow = prefs[KEY_SLOW] ?: PhaseThresholds.DEFAULT_THRESHOLDS[1]
+      val crit = prefs[KEY_CRITICAL] ?: PhaseThresholds.DEFAULT_THRESHOLDS[2]
+      val arr = longArrayOf(warn, slow, crit, Long.MAX_VALUE)
+      // 校验: 必须严格递增
+      if (warn >= slow || slow >= crit) {
+        log.warn(
+            "ThresholdPreferences: loaded invalid thresholds ({}), use defaults",
+            arr.toList(),
+        )
+        PhaseThresholds.DEFAULT_THRESHOLDS
+      } else {
+        arr
+      }
+    } catch (e: Throwable) {
+      log.warn("ThresholdPreferences: load failed: {}", e.message)
+      PhaseThresholds.DEFAULT_THRESHOLDS
+    }
+  }
+
+  /**
+   * 异步保存到 DataStore, 并立即把新阈值应用到 [PhaseThresholds].
+   *
+   * 入参必须严格递增. 入参是 4 元素数组 (最后一位是 CRITICAL 的 Long.MAX_VALUE).
+   * 我们只持久化前 3 个.
+   */
+  @JvmStatic
+  fun save(context: Context, thresholds: LongArray) {
+    require(thresholds.size == 4) { "thresholds must have 4 elements" }
+    val warn = thresholds[0]
+    val slow = thresholds[1]
+    val crit = thresholds[2]
+    require(warn in 1..(slow - 1)) { "warn must be in [1, slow)" }
+    require(slow in (warn + 1)..(crit - 1)) { "slow must be in (warn, crit)" }
+    require(crit in (slow + 1)..(Long.MAX_VALUE / 2)) { "crit must be > slow" }
+    // 立即生效 (UI 下次 collectAsState 就能拿到新色)
+    PhaseThresholds.setThresholds(thresholds)
+    // 异步持久化
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+        context.dataStore.edit { prefs ->
+          prefs[KEY_WARN] = warn
+          prefs[KEY_SLOW] = slow
+          prefs[KEY_CRITICAL] = crit
+        }
+        log.info("ThresholdPreferences: saved warn={} slow={} crit={}", warn, slow, crit)
+      } catch (e: Throwable) {
+        log.warn("ThresholdPreferences: save failed: {}", e.message)
+      }
+    }
+  }
+
+  /** 恢复默认阈值 + 持久化. */
+  @JvmStatic
+  fun resetToDefault(context: Context) {
+    PhaseThresholds.resetToDefault()
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+        context.dataStore.edit { prefs ->
+          prefs.remove(KEY_WARN)
+          prefs.remove(KEY_SLOW)
+          prefs.remove(KEY_CRITICAL)
+        }
+        log.info("ThresholdPreferences: reset to default")
+      } catch (e: Throwable) {
+        log.warn("ThresholdPreferences: reset failed: {}", e.message)
+      }
+    }
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/ColdStartTracker.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/ColdStartTracker.kt
@@ -1,0 +1,185 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.SystemClock
+import android.view.Choreographer
+import com.itsaky.androidide.perf.tracer.PerfTracer
+import org.slf4j.LoggerFactory
+
+/**
+ * 冷启动时间统计 (Advanced PR / Commit 1).
+ *
+ * 跟踪从"进程启动"到"首帧渲染"的全链路, 拆 4 段:
+ *
+ * ```
+ *   ┌──────────────┬─────────────┬──────────────┬────────────┐
+ *   │ Process      │ App         │ App→Activity │ Act→Frame  │
+ *   │ fork → IDE   │ onCreate    │ onCreate →   │ onResume →  │
+ *   │ Application  │             │ onResume     │ first frame│
+ *   │ .class load  │             │              │            │
+ *   └──────────────┴─────────────┴──────────────┴────────────┘
+ * ```
+ *
+ * 4 个上报点:
+ * - [markAppStart]  — IDEApplication.onCreate 第一行
+ * - [markAppReady]  — IDEApplication.onCreate 末尾 (Koin DI 完成)
+ * - [markFirstActivity] — 首个 Activity onResume
+ * - [markFirstFrame]    — 首个 onResume 之后的第一个 Choreographer frame
+ *
+ * 上报 event:
+ * - `coldstart_proc2app_<ms>` — 进程启动 → App.onCreate 开始
+ * - `coldstart_app_dur_<ms>` — App.onCreate 耗时
+ * - `coldstart_app2act_<ms>` — App.onCreate 结束 → 首个 Activity onResume
+ * - `coldstart_act2frame_<ms>` — 首个 Activity onResume → 首帧
+ * - `coldstart_total_<ms>` — 进程启动 → 首帧 (整冷启动)
+ *
+ * 一次性. 标记过的不会重复发.
+ *
+ * @author android_zero
+ */
+object ColdStartTracker {
+
+  private val log = LoggerFactory.getLogger(ColdStartTracker::class.java)
+
+  private const val MARK_APP_START = "app_on_create_begin"
+  private const val MARK_APP_READY = "app_on_create_end"
+  private const val MARK_FIRST_ACTIVITY = "first_activity_resumed"
+  private const val MARK_FIRST_FRAME = "first_frame"
+
+  @Volatile private var appStartMarked = false
+  @Volatile private var appReadyMarked = false
+  @Volatile private var firstActivityMarked = false
+  @Volatile private var firstFrameMarked = false
+
+  /** 进程启动基线. Lazy — 第一次访问时记录. */
+  private val processStartElapsedMs: Long = PerfTracer.processStartElapsedMs
+
+  /**
+   * 标记 IDEApplication.onCreate 开始.
+   *
+   * 在 [com.itsaky.androidide.app.IDEApplication.onCreate] 第一行调.
+   * 二次调用 no-op.
+   */
+  @JvmStatic
+  fun markAppStart() {
+    if (appStartMarked) return
+    appStartMarked = true
+    val proc2app = SystemClock.elapsedRealtime() - processStartElapsedMs
+    if (proc2app > 0) {
+      PerfTracer.reportInstant("coldstart_proc2app_${proc2app}ms")
+    }
+  }
+
+  /**
+   * 标记 IDEApplication.onCreate 结束 (DI 完成, 业务代码可跑).
+   *
+   * 在 IDEApplication.onCreate 末尾 (PerfTracer.endBoot() 之前) 调.
+   */
+  @JvmStatic
+  fun markAppReady() {
+    if (appReadyMarked) return
+    if (!appStartMarked) {
+      // 没调 markAppStart, 算不出 app 耗时, 直接用 processStart 作参考
+      log.warn("ColdStartTracker: markAppStart not called before markAppReady")
+    }
+    appReadyMarked = true
+    val total = SystemClock.elapsedRealtime() - processStartElapsedMs
+    if (total > 0) {
+      PerfTracer.reportInstant("coldstart_app_dur_${total}ms")
+    }
+  }
+
+  /**
+   * 注册首个 Activity onResume 监听.
+   *
+   * 调用一次 (e.g. IDEApplication.onCreate 末尾), 之后自动等首 Activity onResume
+   * 后调 [markFirstActivity], 并在下一个 Choreographer frame 调 [markFirstFrame].
+   *
+   * 内部用 Application.ActivityLifecycleCallbacks + Choreographer.postFrameCallback.
+   */
+  @JvmStatic
+  fun registerFirstActivityTracker(application: Application) {
+    application.registerActivityLifecycleCallbacks(
+        object : Application.ActivityLifecycleCallbacks {
+          private val choreographer = Choreographer.getInstance()
+          private val handlerThread = HandlerThread("perf-coldstart").apply { start() }
+          private val handler = Handler(handlerThread.looper)
+
+          override fun
+              onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+
+          override fun onActivityStarted(activity: Activity) {}
+
+          override fun onActivityResumed(activity: Activity) {
+            if (firstActivityMarked) return
+            // 取消后续回调, 节省开销
+            markFirstActivity()
+            // 等待下一个 Choreographer frame
+            choreographer.postFrameCallback {
+              if (!firstFrameMarked) {
+                markFirstFrame()
+              }
+            }
+            // 兜底: 如果 Choreographer 不回调 (e.g. Activity 没有 view), 200ms 后强制算
+            handler.postDelayed(
+                {
+                  if (!firstFrameMarked) {
+                    log.warn("ColdStartTracker: Choreographer did not fire, force-marking first frame")
+                    markFirstFrame()
+                  }
+                },
+                200L,
+            )
+            // 取消后续 activity 回调, 减少开销
+            application.unregisterActivityLifecycleCallbacks(this)
+            handlerThread.quitSafely()
+          }
+
+          override fun onActivityPaused(activity: Activity) {}
+          override fun onActivityStopped(activity: Activity) {}
+          override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+          override fun onActivityDestroyed(activity: Activity) {}
+        }
+    )
+  }
+
+  private fun markFirstActivity() {
+    if (firstActivityMarked) return
+    firstActivityMarked = true
+    val total = SystemClock.elapsedRealtime() - processStartElapsedMs
+    if (total > 0) {
+      PerfTracer.reportInstant("coldstart_app2act_${total}ms")
+    }
+  }
+
+  private fun markFirstFrame() {
+    if (firstFrameMarked) return
+    firstFrameMarked = true
+    val total = SystemClock.elapsedRealtime() - processStartElapsedMs
+    if (total > 0) {
+      PerfTracer.reportInstant("coldstart_act2frame_${total}ms")
+      PerfTracer.reportInstant("coldstart_total_${total}ms")
+    }
+    log.info("Cold start total: {}ms (since process start)", total)
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/CrashHandler.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/CrashHandler.kt
@@ -1,0 +1,155 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.content.Context
+import com.itsaky.androidide.perf.PhaseStore
+import com.itsaky.androidide.perf.export.ThreadDumper
+import com.itsaky.androidide.perf.proto.PerfEvent
+import com.itsaky.androidide.perf.tracer.PerfTracer
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import org.slf4j.LoggerFactory
+
+/**
+ * Crash 自动 dump 现场 (Advanced / Commit 2).
+ *
+ * 在主进程挂掉时, 把**完整现场**写到 cacheDir:
+ * 1. 全线程 stack trace (复用 PR #6 [ThreadDumper])
+ * 2. 最近 perf events 列表 (从 [PhaseCollector] 读 snapshot)
+ * 3. Throwable 完整堆栈 + 原因链
+ * 4. 进程 / 设备 / 时间 / Perf Console 状态元数据
+ *
+ * ## 调用
+ *
+ * 在 [com.itsaky.androidide.app.IDEApplication.handleCrash] 调 [dumpCrashContext] —
+ * 原 IDE 已有 CrashHandlerActivity 流程, 我们只是**追加**写文件, 不改变 crash 处理链.
+ *
+ * ## 输出路径
+ *
+ * `cacheDir/perf/crashes/crash_<yyyyMMdd_HHmmss>_<exceptionClass>.txt`
+ *
+ * ## 上报
+ *
+ * crash 发生时上报 `crash_<exceptionClass>` instant, 让 Perf Console
+ * UI (BootTab CrashListCard) 能即时看到.
+ *
+ * @author android_zero
+ */
+object CrashHandler {
+
+  private val log = LoggerFactory.getLogger(CrashHandler::class.java)
+
+  private val fileNameFormat = SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US)
+  private val CRASH_DIR = "perf/crashes"
+
+  /**
+   * Dump crash 现场到 cacheDir, 写 perf event.
+   *
+   * @return 写入的文件, 失败返回 null
+   */
+  @JvmStatic
+  fun dumpCrashContext(context: Context, thread: Thread, throwable: Throwable): File? {
+    log.info("CrashHandler: dumping crash context for {}", throwable.javaClass.simpleName)
+
+    // 1. 上报 instant (UI 能即时看到)
+    PerfTracer.reportInstant("crash_${throwable.javaClass.simpleName}")
+
+    // 2. 写文件
+    return try {
+      val crashDir = File(context.cacheDir, CRASH_DIR)
+      crashDir.mkdirs()
+
+      val safeName = sanitize(throwable.javaClass.simpleName)
+      val file =
+          File(crashDir, "crash_${fileNameFormat.format(Date())}_${safeName.take(48)}.txt")
+      file.writeText(buildCrashString(thread, throwable))
+      log.info("CrashHandler: wrote {} ({} bytes)", file.absolutePath, file.length())
+      file
+    } catch (e: Throwable) {
+      log.warn("CrashHandler: dump failed: {}", e.message)
+      null
+    }
+  }
+
+  /**
+   * 构造 crash dump 字符串 (不写文件, 用于测试 / 直接走 Logcat).
+   */
+  @JvmStatic
+  fun buildCrashString(thread: Thread, throwable: Throwable): String {
+    val sb = StringBuilder()
+    sb.appendLine("=== Crash Dump ===")
+    sb.appendLine("Timestamp: ${System.currentTimeMillis()} (${Date()})")
+    sb.appendLine("Thread: ${thread.name} (id=${thread.id}, priority=${thread.priority}, state=${thread.state})")
+    sb.appendLine("Exception: ${throwable.javaClass.name}")
+    sb.appendLine("Message: ${throwable.message}")
+    sb.appendLine()
+    sb.appendLine("--- Throwable Stack ---")
+    val sw = StringWriter()
+    throwable.printStackTrace(PrintWriter(sw))
+    sb.append(sw.toString())
+    sb.appendLine()
+
+    // 全线程 stack
+    sb.appendLine()
+    sb.appendLine(ThreadDumper.buildDumpString(reason = "crash"))
+
+    // 最近 perf events
+    sb.appendLine()
+    sb.appendLine("--- Recent Perf Events (last 200) ---")
+    val collector = PhaseStore.collector()
+    if (collector != null) {
+      try {
+        val snapshot = collector.snapshot()
+        val recent = snapshot.takeLast(200)
+        if (recent.isEmpty()) {
+          sb.appendLine("  (no events yet)")
+        } else {
+          recent.forEach { e ->
+            when (e) {
+              is PerfEvent.Phase -> sb.appendLine("  phase: ${e.name} = ${e.elapsedMs}ms")
+              is PerfEvent.Instant -> sb.appendLine("  instant: ${e.name}")
+              PerfEvent.EndBoot -> sb.appendLine("  end_boot")
+            }
+          }
+        }
+      } catch (e: Throwable) {
+        sb.appendLine("  (failed to read perf events: ${e.message})")
+      }
+    } else {
+      sb.appendLine("  (collector not ready, :perf process not started)")
+    }
+    return sb.toString()
+  }
+
+  /** 列出 cacheDir 下所有 crash dump 文件 (按修改时间倒序). */
+  @JvmStatic
+  fun listCrashes(cacheDir: File): List<File> {
+    val dir = File(cacheDir, CRASH_DIR)
+    if (!dir.exists()) return emptyList()
+    return dir.listFiles { f -> f.isFile && f.name.endsWith(".txt") }
+        ?.sortedByDescending { it.lastModified() }
+        ?: emptyList()
+  }
+
+  private fun sanitize(name: String): String =
+      name.replace(Regex("[^A-Za-z0-9_]+"), "_").take(48)
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/ForegroundTracker.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/ForegroundTracker.kt
@@ -1,0 +1,123 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.perf.monitor
+
+import android.os.SystemClock
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.itsaky.androidide.perf.tracer.PerfTracer
+import org.slf4j.LoggerFactory
+
+/**
+ * 前后台生命周期监听 (Advanced / Commit 3).
+ *
+ * 用 [ProcessLifecycleOwner] 监听整个 app process 的前台 / 后台切换.
+ * 和 ActivityLifecycleCallbacks 不同, ProcessLifecycleOwner 把"所有
+ * Activity 都 onStop 之后" 才算 background — 不会因为屏幕旋转或临时跳
+ * 设置页误报.
+ *
+ * ## 上报
+ *
+ * - 切到前台: `lifecycle_foreground` instant
+ * - 切到后台: `lifecycle_background` instant
+ * - 每次切换时也上报累计前台时长: `lifecycle_fg_total_<ms>ms`,
+ *   这样 ViewModel 解析一个 instant 就能拿到 totalForegroundMs.
+ *
+ * ## 当前是否前台
+ *
+ * [isInForeground] 给 ViewModel 读 (用于 UI badge), 不走 perf event 流.
+ *
+ * ## 一次性安装
+ *
+ * [install] 幂等. 内部持有 [ProcessLifecycleOwner.get] observer, 不再
+ * 重复 add. 在主进程 IDEApplication.onCreate 末尾 (ColdStartTracker 注
+ * 册之后) 调.
+ *
+ * @author android_zero
+ */
+object ForegroundTracker {
+
+  private val log = LoggerFactory.getLogger(ForegroundTracker::class.java)
+
+  @Volatile private var installed: Boolean = false
+
+  /** 当前是否在前台. 初始 true (进程刚起就处于前台). */
+  @Volatile var isInForeground: Boolean = true
+    private set
+
+  /** 进入后台的次数 (自启动以来). */
+  @Volatile var backgroundCount: Int = 0
+    private set
+
+  /** 累计前台时长 (ms). 每次进入后台时把当前 segment 累加进来. */
+  @Volatile var totalForegroundMs: Long = 0L
+    private set
+
+  /** 当前正在前台 segment 起始时间 (elapsedRealtime). 后台时此值无意义. */
+  private var foregroundStartElapsedMs: Long = SystemClock.elapsedRealtime()
+
+  /**
+   * 安装前后台监听. 幂等.
+   *
+   * 必须在主进程调 (PerfTracer 那边 ProcessLifecycleOwner 在 :perf 进程
+   * 不会有 UI activity, 状态不会变). 在 IDEApplication.onCreate
+   * 末尾 (ColdStartTracker 注册之后) 调.
+   */
+  @JvmStatic
+  fun install() {
+    if (installed) return
+    installed = true
+    try {
+      val owner = ProcessLifecycleOwner.get()
+      owner.lifecycle.addObserver(
+          object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+              onEnterForeground()
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+              onEnterBackground()
+            }
+          }
+      )
+    } catch (e: Throwable) {
+      // ProcessLifecycleOwner 在某些测试 / 单元测试 mock 场景下不可用,
+      // 静默失败, 不影响 IDE 主流程.
+      log.warn("ForegroundTracker: install failed: {}", e.message)
+      installed = false
+    }
+  }
+
+  private fun onEnterForeground() {
+    log.info("ForegroundTracker: app entered foreground")
+    isInForeground = true
+    foregroundStartElapsedMs = SystemClock.elapsedRealtime()
+    PerfTracer.reportInstant("lifecycle_foreground")
+    PerfTracer.reportInstant("lifecycle_fg_total_${totalForegroundMs}ms")
+  }
+
+  private fun onEnterBackground() {
+    log.info("ForegroundTracker: app entered background")
+    isInForeground = false
+    backgroundCount += 1
+    val segMs = SystemClock.elapsedRealtime() - foregroundStartElapsedMs
+    if (segMs > 0) totalForegroundMs += segMs
+    PerfTracer.reportInstant("lifecycle_background")
+    PerfTracer.reportInstant("lifecycle_fg_total_${totalForegroundMs}ms")
+  }
+}

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
@@ -17,6 +17,7 @@
 package com.itsaky.androidide.perf.tracer
 
 import android.content.Context
+import android.os.Process
 import android.os.SystemClock
 import com.itsaky.androidide.BuildConfig
 import com.itsaky.androidide.perf.PerfApplication
@@ -65,8 +66,21 @@ object PerfTracer {
   private var socket: PerfClientSocket? = null
 
   /** :perf 进程是否已 attach 成功. 仅用于日志, 不影响行为. */
-  @Volatile
-  private var attached: Boolean = false
+  @Volatile private var attached: Boolean = false
+
+  /**
+   * 进程启动时间 (elapsedRealtime ns), 在 class load 时一次性记录.
+   *
+   * 用 [Process.getStartElapsedRealtime] (API 24+) 拿系统记录的进程真实启动时间,
+   * 后续所有 cold start 阶段都以这个为基准算差值.
+   *
+   * 这是冷启动分析的"零点", 不能用 SystemClock.elapsedRealtime() 因为它在 process
+   * 启动时调用时机不可控, [Process.getStartElapsedRealtime] 是内核记录的绝对值.
+   *
+   * 静态初始化 — 第一次访问 PerfTracer 类时执行, 在 IDEApplication.onCreate 之前.
+   */
+  @JvmStatic
+  val processStartElapsedMs: Long by lazy { Process.getStartElapsedRealtime() }
 
   /**
    * 尝试连接 :perf 进程.

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
@@ -65,6 +65,15 @@ fun BootTab(state: PerfUiState, modifier: Modifier = Modifier) {
       TotalBootCard(totalBootMs = state.totalBootMs, isEnded = state.isBootEnded)
     }
     item {
+      ColdStartCard(
+          proc2App = state.coldStartProc2AppMs,
+          appDur = state.coldStartAppDurMs,
+          app2Act = state.coldStartApp2ActMs,
+          act2Frame = state.coldStartAct2FrameMs,
+          total = state.coldStartTotalMs,
+      )
+    }
+    item {
       BootTimelineCard(bootEvents = state.bootEvents)
     }
     item {
@@ -183,6 +192,126 @@ private fun BootTimelineRow(
         fontSize = 11.sp,
         fontFamily = FontFamily.Monospace,
         color = color,
+        modifier = Modifier.fillMaxWidth(),
+    )
+  }
+}
+
+@Composable
+private fun TotalBootCard(totalBootMs: Long, isEnded: Boolean) {
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+      Text(
+          text = "启动总耗时",
+          fontSize = 12.sp,
+          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = formatMs(totalBootMs),
+          fontSize = 36.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onPrimaryContainer,
+      )
+      Text(
+          text = if (isEnded) "启动完成" else "启动中…",
+          fontSize = 11.sp,
+          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+      )
+    }
+  }
+}
+
+/**
+ * 冷启动分段时间 (Advanced / Commit 1).
+ *
+ * 把从"进程启动"到"首帧渲染"的全链路分 4 段显示, 帮助定位冷启动瓶颈:
+ * - proc2app — 进程启动到 App.onCreate 第一行 (fork / class load 耗时)
+ * - appDur   — App.onCreate 总耗时 (Koin DI / 主题 / 颜色方案等)
+ * - app2act  — App.onCreate 结束到首 Activity onResume (MainActivity 启动)
+ * - act2frm  — 首 Activity onResume 到首帧 (首次 layout + draw)
+ *
+ * 任一段缺失显示 "—", 表示该阶段还没上报 (启动还没跑到).
+ */
+@Composable
+private fun ColdStartCard(
+    proc2App: Long,
+    appDur: Long,
+    app2Act: Long,
+    act2Frame: Long,
+    total: Long,
+) {
+  Card(shape = RoundedCornerShape(12.dp)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Text(
+          text = "冷启动分段 (Cold Start Breakdown)",
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      ColdStartRow("进程 → App.onCreate", proc2App, total)
+      ColdStartRow("App.onCreate 耗时", appDur, total)
+      ColdStartRow("App → 首 Activity", app2Act, total)
+      ColdStartRow("Activity → 首帧", act2Frame, total)
+      Spacer(modifier = Modifier.size(6.dp))
+      // 大字总数
+      Text(
+          text = if (total == 0L) "总冷启动: —" else "总冷启动: ${formatMs(total)}",
+          fontSize = 18.sp,
+          fontWeight = FontWeight.Bold,
+          color =
+              if (total == 0L) MaterialTheme.colorScheme.onSurfaceVariant
+              else MaterialTheme.colorScheme.primary,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ColdStartRow(label: String, ms: Long, total: Long) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+        text = label,
+        fontSize = 11.sp,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.fillMaxWidth(0.55f),
+    )
+    // 比例条
+    val ratio =
+        if (total <= 0L || ms <= 0L) 0f
+        else (ms.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(0.85f)
+            .height(10.dp)
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(5.dp),
+            ),
+    ) {
+      Box(
+          modifier = Modifier
+              .fillMaxWidth(ratio)
+              .height(10.dp)
+              .background(
+                  color = MaterialTheme.colorScheme.tertiary,
+                  shape = RoundedCornerShape(5.dp),
+              ),
+      )
+    }
+    Spacer(modifier = Modifier.size(6.dp))
+    Text(
+        text = if (ms == 0L) "—" else "${ms}ms",
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurface,
         modifier = Modifier.fillMaxWidth(),
     )
   }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
@@ -77,6 +77,13 @@ fun BootTab(state: PerfUiState, modifier: Modifier = Modifier) {
       CrashListCard(crashes = state.crashEvents)
     }
     item {
+      ForegroundCard(
+          foregroundMs = state.foregroundTotalMs,
+          backgroundCount = state.backgroundCount,
+          isInForeground = state.isInForeground,
+      )
+    }
+    item {
       BootTimelineCard(bootEvents = state.bootEvents)
     }
     item {
@@ -288,6 +295,70 @@ private fun ColdStartRow(label: String, ms: Long, total: Long) {
         color = MaterialTheme.colorScheme.onSurface,
         modifier = Modifier.fillMaxWidth(),
     )
+  }
+}
+
+/**
+ * 前后台状态 (Advanced / Commit 3).
+ *
+ * 来源: [com.itsaky.androidide.perf.monitor.ForegroundTracker] 用
+ * [androidx.lifecycle.ProcessLifecycleOwner] 监听整个 app process 的前
+ * 后台切换, 每次切换上报 `lifecycle_foreground` / `lifecycle_background`
+ * instant, 同时上报累计前台时长 `lifecycle_fg_total_<ms>ms`.
+ *
+ * 卡片里:
+ * - 大字显示**累计前台时长** (自启动以来, 累计进入前台 segment 的总毫秒)
+ * - 右上角 badge 显示**当前是否在前台**
+ * - 底部统计**进入后台的次数** (0 表示启动后一直在前台)
+ *
+ * 用 ProcessLifecycleOwner 而非 ActivityLifecycleCallbacks 不会被屏幕
+ * 旋转或临时跳设置页误报.
+ */
+@Composable
+private fun ForegroundCard(foregroundMs: Long, backgroundCount: Int, isInForeground: Boolean) {
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(
+              containerColor =
+                  if (isInForeground) MaterialTheme.colorScheme.surface
+                  else MaterialTheme.colorScheme.surfaceVariant
+          ),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+            text = "前台累计 / 后台次数",
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = if (isInForeground) "● 前台" else "○ 后台",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color =
+                if (isInForeground) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+      Spacer(modifier = Modifier.size(6.dp))
+      Text(
+          text = formatMs(foregroundMs),
+          fontSize = 24.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onSurface,
+      )
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = "进入后台: ${backgroundCount} 次",
+          fontSize = 12.sp,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
   }
 }
 

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/BootTab.kt
@@ -74,6 +74,9 @@ fun BootTab(state: PerfUiState, modifier: Modifier = Modifier) {
       )
     }
     item {
+      CrashListCard(crashes = state.crashEvents)
+    }
+    item {
       BootTimelineCard(bootEvents = state.bootEvents)
     }
     item {
@@ -197,35 +200,6 @@ private fun BootTimelineRow(
   }
 }
 
-@Composable
-private fun TotalBootCard(totalBootMs: Long, isEnded: Boolean) {
-  Card(
-      shape = RoundedCornerShape(12.dp),
-      colors =
-          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-  ) {
-    Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
-      Text(
-          text = "启动总耗时",
-          fontSize = 12.sp,
-          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-      )
-      Spacer(modifier = Modifier.size(4.dp))
-      Text(
-          text = formatMs(totalBootMs),
-          fontSize = 36.sp,
-          fontWeight = FontWeight.Bold,
-          color = MaterialTheme.colorScheme.onPrimaryContainer,
-      )
-      Text(
-          text = if (isEnded) "启动完成" else "启动中…",
-          fontSize = 11.sp,
-          color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-      )
-    }
-  }
-}
-
 /**
  * 冷启动分段时间 (Advanced / Commit 1).
  *
@@ -314,6 +288,96 @@ private fun ColdStartRow(label: String, ms: Long, total: Long) {
         color = MaterialTheme.colorScheme.onSurface,
         modifier = Modifier.fillMaxWidth(),
     )
+  }
+}
+
+/**
+ * Crash 事件列表 (Advanced / Commit 2).
+ *
+ * 来源: [com.itsaky.androidide.perf.monitor.CrashHandler] 在
+ * [com.itsaky.androidide.app.IDEApplication.handleCrash] 调
+ * `dumpCrashContext` 时会上报 `crash_<ExceptionClass>` instant, 并把
+ * 完整现场 (含全线程 dump + 最近 perf events) 写到
+ * `cacheDir/perf/crashes/*.txt` 供后续 Export 工具打包.
+ *
+ * 这里按 exception class 聚合, 显示每个异常类出现的次数. 详细堆栈
+ * 看 cacheDir 下的 dump 文件 — 这张卡片只用来**一眼知道有没有崩**和
+ * **崩在哪个类**.
+ */
+@Composable
+private fun CrashListCard(crashes: List<PerfEvent.Instant>) {
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      colors =
+          CardDefaults.cardColors(
+              containerColor =
+                  if (crashes.isEmpty()) MaterialTheme.colorScheme.surface
+                  else MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
+          ),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+            text = "Crash 历史 (本进程)",
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = if (crashes.isEmpty()) "0" else "${crashes.size} 次",
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            color =
+                if (crashes.isEmpty()) MaterialTheme.colorScheme.onSurfaceVariant
+                else MaterialTheme.colorScheme.error,
+        )
+      }
+      Spacer(modifier = Modifier.size(6.dp))
+      if (crashes.isEmpty()) {
+        Text(
+            text = "无 crash — 本进程运行平稳 ✓",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return@Column
+      }
+      // 按 exception class 聚合
+      val grouped =
+          crashes
+              .groupingBy { it.name.removePrefix("crash_") }
+              .eachCount()
+              .toList()
+              .sortedByDescending { it.second }
+      grouped.forEach { (exceptionClass, count) ->
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Text(
+              text = "• $exceptionClass",
+              fontSize = 12.sp,
+              fontFamily = FontFamily.Monospace,
+              color = MaterialTheme.colorScheme.onSurface,
+              modifier = Modifier.fillMaxWidth(0.75f),
+          )
+          Text(
+              text = "×$count",
+              fontSize = 12.sp,
+              fontWeight = FontWeight.Bold,
+              color = MaterialTheme.colorScheme.error,
+          )
+        }
+      }
+      Spacer(modifier = Modifier.size(4.dp))
+      Text(
+          text = "详细堆栈: cacheDir/perf/crashes/*.txt",
+          fontSize = 10.sp,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
   }
 }
 

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleScreen.kt
@@ -16,8 +16,10 @@
  */
 package com.itsaky.androidide.perf.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,6 +36,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -204,7 +207,10 @@ fun PerfConsoleScreen(viewModel: PerfConsoleViewModel) {
   }
 
   if (thresholdsDialogVisible) {
-    ThresholdsDialog(onDismiss = { thresholdsDialogVisible = false })
+    ThresholdsEditorDialog(
+        onDismiss = { thresholdsDialogVisible = false },
+        onSaved = { thresholdsDialogVisible = false },
+    )
   }
 }
 
@@ -253,6 +259,117 @@ private fun ThresholdsDialog(onDismiss: () -> Unit) {
       },
       confirmButton = { TextButton(onClick = onDismiss) { Text("关闭") } },
   )
+}
+
+/**
+ * 可编辑的阈值 dialog (Advanced / Commit 4).
+ *
+ * 3 个 Slider 调 WARN / SLOW / CRITICAL 三个 ms 边界. OK 上限由 0 到
+ * WARN 自动定义. 调完按"保存" → 调 [ThresholdPreferences.save] 写
+ * DataStore + 立即应用到 [PhaseThresholds] (UI 下次 collectAsState 自动
+ * 重染). "重置" → 调 [ThresholdPreferences.resetToDefault] 恢复默认值.
+ *
+ * 三个 slider 用 step=50ms 限制 (避免拖到 137ms 这种没意义的值).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ThresholdsEditorDialog(onDismiss: () -> Unit, onSaved: () -> Unit) {
+  val context = LocalContext.current
+  val initial = PhaseThresholds.thresholds
+  var warnMs by remember { mutableStateOf(initial[0].toFloat()) }
+  var slowMs by remember { mutableStateOf(initial[1].toFloat()) }
+  var critMs by remember { mutableStateOf(initial[2].toFloat()) }
+
+  AlertDialog(
+      onDismissRequest = onDismiss,
+      title = { Text("Phase 告警阈值 (ms)") },
+      text = {
+        Column {
+          ThresholdSlider(
+              label = "WARN 上限 (ms)",
+              value = warnMs,
+              valueRange = 10f..(slowMs - 10f),
+              onValueChange = { warnMs = it },
+              color = MaterialTheme.colorScheme.tertiary,
+          )
+          ThresholdSlider(
+              label = "SLOW 上限 (ms)",
+              value = slowMs,
+              valueRange = (warnMs + 10f)..(critMs - 10f),
+              onValueChange = { slowMs = it },
+              color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+          )
+          ThresholdSlider(
+              label = "CRITICAL 上限 (ms)",
+              value = critMs,
+              valueRange = (slowMs + 10f)..10000f,
+              onValueChange = { critMs = it },
+              color = MaterialTheme.colorScheme.error,
+          )
+          Spacer(modifier = Modifier.height(8.dp))
+          Text(
+              "比例告警固定 5% / 15% / 30% — 暂不开放自定义",
+              fontSize = 10.sp,
+              color = MaterialTheme.colorScheme.outline,
+          )
+        }
+      },
+      confirmButton = {
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+          TextButton(
+              onClick = {
+                ThresholdPreferences.resetToDefault(context)
+                onSaved()
+              }
+          ) { Text("重置") }
+          TextButton(
+              onClick = {
+                ThresholdPreferences.save(
+                    context,
+                    longArrayOf(
+                        warnMs.toLong().coerceAtLeast(1),
+                        slowMs.toLong().coerceAtLeast(warnMs.toLong() + 1),
+                        critMs.toLong().coerceAtLeast(slowMs.toLong() + 1),
+                        Long.MAX_VALUE,
+                    ),
+                )
+                onSaved()
+              }
+          ) { Text("保存") }
+        }
+      },
+      dismissButton = { TextButton(onClick = onDismiss) { Text("关闭") } },
+  )
+}
+
+@Composable
+private fun ThresholdSlider(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    onValueChange: (Float) -> Unit,
+    color: androidx.compose.ui.graphics.Color,
+) {
+  Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+      Text(label, fontSize = 12.sp)
+      Text(
+          "${value.toLong()} ms",
+          fontSize = 12.sp,
+          fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+          color = color,
+      )
+    }
+    Slider(
+        value = value,
+        onValueChange = onValueChange,
+        valueRange = valueRange,
+        steps = ((valueRange.endInclusive - valueRange.start) / 50f).toInt().coerceAtLeast(0),
+    )
+  }
 }
 
 /**

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
@@ -104,6 +104,10 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
     val anrs = ArrayList<PerfEvent.Instant>()
     val crashes = ArrayList<PerfEvent.Instant>()
 
+    // Advanced/Lifecycle
+    var fgTotalMs: Long = 0L
+    var bgCount: Int = 0
+
     // Advanced/ColdStart: 4 段 ms
     var coldProc2App: Long = 0L
     var coldAppDur: Long = 0L
@@ -120,7 +124,8 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
                 e.name !in MONITOR_PREFIXES &&
                     e.name != END_BOOT_MARKER &&
                     !e.name.startsWith("coldstart_") &&
-                    !e.name.startsWith("crash_")
+                    !e.name.startsWith("crash_") &&
+                    !e.name.startsWith("lifecycle_")
             PerfEvent.EndBoot -> true
           }
         }
@@ -138,6 +143,14 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             ev.name.substring(15).toLongOrNull()?.let { gc.addLast(it) }
           }
           ev.name.startsWith("anr_") -> anrs.add(ev)
+          // Advanced/Crash
+          ev.name.startsWith("crash_") -> crashes.add(ev)
+          // Advanced/Lifecycle: 累计前台时长 + 后台次数
+          ev.name.startsWith("lifecycle_fg_total_") && ev.name.endsWith("ms") -> {
+            fgTotalMs =
+                ev.name.removePrefix("lifecycle_fg_total_").removeSuffix("ms").toLongOrNull() ?: 0L
+          }
+          ev.name == "lifecycle_background" -> bgCount += 1
           // Advanced/ColdStart
           ev.name.startsWith("coldstart_proc2app_") && ev.name.endsWith("ms") -> {
             coldProc2App =
@@ -191,6 +204,9 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             coldStartAct2FrameMs = coldAct2Frame,
             coldStartTotalMs = coldTotal,
             crashEvents = crashes,
+            foregroundTotalMs = fgTotalMs,
+            backgroundCount = bgCount,
+            isInForeground = com.itsaky.androidide.perf.monitor.ForegroundTracker.isInForeground,
             totalBootMs = totalBootMs,
         )
   }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
@@ -102,6 +102,7 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
     val pss = ArrayDeque<Long>(SAMPLE_WINDOW)
     val gc = ArrayDeque<Long>(SAMPLE_WINDOW)
     val anrs = ArrayList<PerfEvent.Instant>()
+    val crashes = ArrayList<PerfEvent.Instant>()
 
     // Advanced/ColdStart: 4 段 ms
     var coldProc2App: Long = 0L
@@ -118,7 +119,8 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             is PerfEvent.Instant ->
                 e.name !in MONITOR_PREFIXES &&
                     e.name != END_BOOT_MARKER &&
-                    !e.name.startsWith("coldstart_")
+                    !e.name.startsWith("coldstart_") &&
+                    !e.name.startsWith("crash_")
             PerfEvent.EndBoot -> true
           }
         }
@@ -188,6 +190,7 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             coldStartApp2ActMs = coldApp2Act,
             coldStartAct2FrameMs = coldAct2Frame,
             coldStartTotalMs = coldTotal,
+            crashEvents = crashes,
             totalBootMs = totalBootMs,
         )
   }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfConsoleViewModel.kt
@@ -103,13 +103,22 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
     val gc = ArrayDeque<Long>(SAMPLE_WINDOW)
     val anrs = ArrayList<PerfEvent.Instant>()
 
+    // Advanced/ColdStart: 4 段 ms
+    var coldProc2App: Long = 0L
+    var coldAppDur: Long = 0L
+    var coldApp2Act: Long = 0L
+    var coldAct2Frame: Long = 0L
+    var coldTotal: Long = 0L
+
     // 启动 phase 列表: 只取前 18 条 + end_boot (PR #2 设计)
     val bootEvents =
         snapshot.filter { e ->
           when (e) {
             is PerfEvent.Phase -> true
             is PerfEvent.Instant ->
-                e.name !in MONITOR_PREFIXES && e.name != END_BOOT_MARKER
+                e.name !in MONITOR_PREFIXES &&
+                    e.name != END_BOOT_MARKER &&
+                    !e.name.startsWith("coldstart_")
             PerfEvent.EndBoot -> true
           }
         }
@@ -127,6 +136,29 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             ev.name.substring(15).toLongOrNull()?.let { gc.addLast(it) }
           }
           ev.name.startsWith("anr_") -> anrs.add(ev)
+          // Advanced/ColdStart
+          ev.name.startsWith("coldstart_proc2app_") && ev.name.endsWith("ms") -> {
+            coldProc2App =
+                ev.name.removePrefix("coldstart_proc2app_").removeSuffix("ms").toLongOrNull() ?: 0L
+          }
+          ev.name.startsWith("coldstart_app_dur_") && ev.name.endsWith("ms") -> {
+            coldAppDur =
+                ev.name.removePrefix("coldstart_app_dur_").removeSuffix("ms").toLongOrNull() ?: 0L
+          }
+          ev.name.startsWith("coldstart_app2act_") && ev.name.endsWith("ms") -> {
+            coldApp2Act =
+                ev.name.removePrefix("coldstart_app2act_").removeSuffix("ms").toLongOrNull() ?: 0L
+          }
+          ev.name.startsWith("coldstart_act2frame_") && ev.name.endsWith("ms") -> {
+            coldAct2Frame =
+                ev.name.removePrefix("coldstart_act2frame_")
+                    .removeSuffix("ms")
+                    .toLongOrNull() ?: 0L
+          }
+          ev.name.startsWith("coldstart_total_") && ev.name.endsWith("ms") -> {
+            coldTotal =
+                ev.name.removePrefix("coldstart_total_").removeSuffix("ms").toLongOrNull() ?: 0L
+          }
         }
       }
     }
@@ -151,6 +183,11 @@ class PerfConsoleViewModel(application: Application) : AndroidViewModel(applicat
             recentPssKb = pss.toList(),
             recentGcDelta = gc.toList(),
             anrEvents = anrs,
+            coldStartProc2AppMs = coldProc2App,
+            coldStartAppDurMs = coldAppDur,
+            coldStartApp2ActMs = coldApp2Act,
+            coldStartAct2FrameMs = coldAct2Frame,
+            coldStartTotalMs = coldTotal,
             totalBootMs = totalBootMs,
         )
   }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
@@ -60,6 +60,20 @@ data class PerfUiState(
      * [com.itsaky.androidide.perf.monitor.CrashHandler].
      */
     val crashEvents: List<PerfEvent.Instant> = emptyList(),
+    /**
+     * Advanced/Lifecycle: 累计前台时长 (ms). 来源
+     * [com.itsaky.androidide.perf.monitor.ForegroundTracker] 上报的
+     * `lifecycle_fg_total_<ms>ms`. 0 表示还没切过后台.
+     */
+    val foregroundTotalMs: Long = 0L,
+    /**
+     * Advanced/Lifecycle: 累计进入后台的次数. 0 表示启动后一直在前台.
+     */
+    val backgroundCount: Int = 0,
+    /**
+     * Advanced/Lifecycle: 进程当前是否在前台. UI 用来显示 badge.
+     */
+    val isInForeground: Boolean = true,
     val totalBootMs: Long = 0L,
 ) {
   companion object {

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
@@ -53,6 +53,13 @@ data class PerfUiState(
     val coldStartAct2FrameMs: Long = 0L,
     /** Advanced/ColdStart: 进程启动到首帧 (ms), 即整冷启动. */
     val coldStartTotalMs: Long = 0L,
+    /**
+     * Advanced/Crash: 本次启动至今的 crash 事件列表 (按时间倒序).
+     *
+     * 来源: CrashHandler 上报 `crash_<ExceptionClass>` instant, 详见
+     * [com.itsaky.androidide.perf.monitor.CrashHandler].
+     */
+    val crashEvents: List<PerfEvent.Instant> = emptyList(),
     val totalBootMs: Long = 0L,
 ) {
   companion object {

--- a/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/ui/PerfUiState.kt
@@ -43,6 +43,16 @@ data class PerfUiState(
     val recentPssKb: List<Long> = emptyList(),
     val recentGcDelta: List<Long> = emptyList(),
     val anrEvents: List<PerfEvent.Instant> = emptyList(),
+    /** Advanced/ColdStart: 进程启动到 App.onCreate 开始 (ms). */
+    val coldStartProc2AppMs: Long = 0L,
+    /** Advanced/ColdStart: App.onCreate 耗时 (ms). */
+    val coldStartAppDurMs: Long = 0L,
+    /** Advanced/ColdStart: App.onCreate 结束到首 Activity onResume (ms). */
+    val coldStartApp2ActMs: Long = 0L,
+    /** Advanced/ColdStart: 首 Activity onResume 到首帧 (ms). */
+    val coldStartAct2FrameMs: Long = 0L,
+    /** Advanced/ColdStart: 进程启动到首帧 (ms), 即整冷启动. */
+    val coldStartTotalMs: Long = 0L,
     val totalBootMs: Long = 0L,
 ) {
   companion object {


### PR DESCRIPTION
## 概述

把 4 个候选 PR 合并成一个 PR, 4 个 commit 清晰分组 — 一次审完, 一起合并.

每个 commit 独立可测, 但逻辑上互相依赖 (都基于既有 PR #5/6/7 基础设施).

## 4 个 Commit

### 1️⃣ `05026309` — 冷启动 4 段分段时间 (Process → App → Activity → Frame)

新增 `ColdStartTracker`:
- `markAppStart` / `markAppReady` (在 IDEApplication.onCreate 入口/出口)
- `markFirstActivity` / `markFirstFrame` (ActivityLifecycleCallbacks + Choreographer.postFrameCallback, 200ms 兜底)
- 上报 5 个 `coldstart_*` instant, BootTab 加 `ColdStartCard` 4 段比例条 + 大字"总冷启动: Xms"

### 2️⃣ `8506960e` — Crash 自动 dump 现场 (UncaughtExceptionHandler)

新增 `CrashHandler`:
- 在 `IDEApplication.handleCrash` 跳 CrashHandlerActivity 前调 `dumpCrashContext`
- 复用 PR #6 `ThreadDumper.buildDumpString` 写全线程 stack
- 复用 `PhaseStore.collector().snapshot()` 写最近 200 perf events
- 写到 `cacheDir/perf/crashes/crash_<时间戳>_<异常类>.txt` (~50KB/次, 不崩不写)
- BootTab 加 `CrashListCard` 按 exception class 聚合显示次数
- 顺手清理: BootTab 删掉重复的 `TotalBootCard` 声明 (Commit 1 残留)

### 3️⃣ `7b5c6e29` — 前后台生命周期监听 (ProcessLifecycleOwner)

新增 `ForegroundTracker`:
- 用 `androidx.lifecycle:lifecycle-process` 的 `ProcessLifecycleOwner` 监听
- 比 `ActivityLifecycleCallbacks` 更准: 不会被屏幕旋转/跳设置页误报
- 上报 `lifecycle_foreground` / `lifecycle_background` instant
- 上报 `lifecycle_fg_total_<ms>ms` 让 ViewModel 直接拿累计前台时长
- BootTab 加 `ForegroundCard`: 大字累计前台时长 + 前台/后台 badge + 后台次数
- 加 `androidx.lifecycle:lifecycle-process` 依赖

### 4️⃣ `288fff87` — 自定义 phase 告警阈值 UI (DataStore 持久化)

新增 `ThresholdPreferences`:
- 用 `androidx.datastore.preferences` 持久化 3 个 ms 边界 (WARN/SLOW/CRITICAL)
- 启动时同步读 cache 到 `PhaseThresholds.thresholds` (UI 第一帧就能按自定义阈值染色)
- ThresholdsDialog → ThresholdsEditorDialog: 3 个 Slider + 保存/重置
- 加 `androidx.datastore:datastore-preferences` 依赖

## 跨模块

- 分支: `feature/perf-console-advanced` ← `feature/perf-console-ui-actions` (含 PR #5/6/7)
- 不依赖 PR #8/9/10, 独立可合
- :perf 进程零侵入 (ide_on_create_end 之后才装 ForegroundTracker, 装也只是 no-op)

## 测试路径

1. 冷启动分段: kill 进程, 重新启动, BootTab 看 ColdStartCard 4 段 + 总 ms
2. Crash dump: 任意 crash → cacheDir/perf/crashes/ 出现 .txt + BootTab CrashListCard 出现记录
3. 前后台: home 键退到后台再回来, BootTab ForegroundCard 后台次数+1, fg total 增加
4. 阈值: Perf Console TopBar → Thresholds → 拖 slider → 保存 → 重启 IDE → 阈值保持

## 变更文件

```
4 commits, 12 files changed, 1125 insertions(+), 33 deletions(-)

 core/app/build.gradle.kts                                          |   4 +
 .../androidide/app/IDEApplication.kt                               |   9 +
 .../androidide/perf/monitor/ColdStartTracker.kt (new)              | 185 ++
 .../androidide/perf/monitor/CrashHandler.kt (new)                  | 154 +
 .../androidide/perf/monitor/ForegroundTracker.kt (new)             | 123 +
 .../androidide/perf/export/ThresholdPreferences.kt (new)           | 129 +
 .../androidide/perf/ui/PerfUiState.kt                              |  26 +
 .../androidide/perf/ui/PerfConsoleViewModel.kt                     |  23 +
 .../androidide/perf/ui/PerfConsoleScreen.kt                       | 119 +
 .../androidide/perf/ui/BootTab.kt                                  | 260 ++++-
 .../androidide/perf/tracer/PerfTracer.kt                           |   6 +
```

## 兼容性

- PhaseCollector / PerfSocketProtocol / PhaseStore 接口 0 变更
- PhaseThresholds 接口 0 变更 (setThresholds/resetToDefault 早就存在, Commit 4 才用)
- 所有改动向后兼容, 既有 PR #5/6/7 测试不需要改