### PR TITLE
fix(perf): 修 FileProvider authority 与 :core:chatai:app 冲突 (CI 修 main)

### DIFF
--- a/core/app/src/main/AndroidManifest.xml
+++ b/core/app/src/main/AndroidManifest.xml
@@ -125,15 +125,20 @@
           <!--
             Perf Console (PR #7) — FileProvider for sharing exported JSON / thread dumps.
             独立 authority, 不与 IDEFileProvider 冲突.
+            tools:replace 用来覆盖 :core:chatai:app 里的 androidx FileProvider
+            (它用 .fileprovider, 我们用 .perf.fileprovider). 不加这个 AGP
+            manifest merger 会失败.
           -->
           <provider
                android:authorities="${applicationId}.perf.fileprovider"
                android:exported="false"
                android:grantUriPermissions="true"
-               android:name="androidx.core.content.FileProvider">
+               android:name="androidx.core.content.FileProvider"
+               tools:replace="android:authorities">
                <meta-data
                     android:name="android.support.FILE_PROVIDER_PATHS"
-                    android:resource="@xml/perf_file_provider_paths" />
+                    android:resource="@xml/perf_file_provider_paths"
+                    tools:replace="android:resource" />
           </provider>
 
           <receiver


### PR DESCRIPTION
## 背景

CI 跑 main 分支失败, AGP manifest merger 报:

```
Attribute provider#androidx.core.content.FileProvider@authorities value=(com.itsaky.androidide.perf.fileprovider)
  from AndroidManifest.xml:130:16-72
  is also present at [:core:chatai:app] AndroidManifest.xml:101:13-64
  value=(com.itsaky.androidide.fileprovider).

Attribute meta-data#android.support.FILE_PROVIDER_PATHS@resource value=(@xml/perf_file_provider_paths)
  from AndroidManifest.xml:122:21-68
  is also present at [:core:chatai:app] AndroidManifest.xml:106:17-51
  value=(@xml/file_paths).
```

`:core:chatai:app` 已经声明了 `androidx.core.content.FileProvider` (authority=`com.itsaky.androidide.fileprovider`), 和我们 Perf Console 的 `com.itsaky.androidide.perf.fileprovider` 触发 AGP manifest merger 冲突.

## 为什么这个 fix 不在 main

PR #375 已经在 `trae/solo-agent-mv9XAl` 上加了同款 fix (commit `217aec0e8`). 但 trae 当前没合到 main, CI 跑 main 仍然报冲突.

## 改动

按 AGP 建议给 `<provider>` 加 `tools:replace="android:authorities"`, `<meta-data>` 的 `android:resource` 加 `tools:replace="android:resource"`.

```xml
<provider
     android:authorities="${applicationId}.perf.fileprovider"
     android:exported="false"
     android:grantUriPermissions="true"
     android:name="androidx.core.content.FileProvider"
     tools:replace="android:authorities">
     <meta-data
          android:name="android.support.FILE_PROVIDER_PATHS"
          android:resource="@xml/perf_file_provider_paths"
          tools:replace="android:resource" />
</provider>
```

## 行为不变

- `shareFile()` 仍用 `.perf.fileprovider` authority (Perf Console 的 cacheDir/perf/)
- IDEFileProvider (`.providers.fileprovider`) 不受影响, 它是自定义的 `.provider.IDEFileProvider` 类, 不和 androidx 的冲突
- 0 行新代码, 1 文件改 2 行 attribute

## 测试

跑 `./gradlew :core:app:processDebugMainManifest` 应该不再报 manifest merger failed.