### PR TITLE
fix(perf): 修 main 分支 3 处残留 Kotlin 编译错误 (CI 修 round 2)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -38,6 +38,7 @@ import com.itsaky.androidide.fragments.onboarding.GreetingFragment
 import com.itsaky.androidide.fragments.onboarding.OdSdkToolInstallFragment
 import com.itsaky.androidide.fragments.onboarding.OnboardingInfoFragment
 import com.itsaky.androidide.fragments.onboarding.PermissionsFragment
+import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.prefManager
 import com.itsaky.androidide.repository.sdkmanager.SdkChecker
 import com.itsaky.androidide.ui.themes.IThemeManager

--- a/core/app/src/main/java/com/itsaky/androidide/perf/export/ThreadDumper.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/export/ThreadDumper.kt
@@ -102,7 +102,9 @@ object ThreadDumper {
     entries.forEach { (thread, stack) ->
       sb.appendLine("--- Thread: ${thread.name} (id=${thread.id}, priority=${thread.priority}, state=${thread.state}) ---")
       val sw = StringWriter()
-      PrintWriter(sw).use { pw: PrintWriter -> thread.printStackTrace(pw) }
+      val pw = PrintWriter(sw)
+      thread.printStackTrace(pw)
+      pw.flush()
       sb.append(sw.toString())
       sb.appendLine()
     }

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
@@ -94,20 +94,26 @@ internal class PerfClientSocket(private val socketPath: String) {
     }
   }
 
-  /** 异步发送 phase 事件 (有耗时). */
-  fun sendPhase(name: String, elapsedMs: Long) {
+  /**
+   * 异步发送 phase 事件 (有耗时). `inline` (e.g. [PerfTracer.trace]) 调,
+   * 必须 `@PublishedApi internal` 才能 inline 访问.
+   */
+  @PublishedApi
+  internal fun sendPhase(name: String, elapsedMs: Long) {
     if (broken) return
     enqueue("""{"type":"phase","name":"${escape(name)}","elapsed":$elapsedMs}""")
   }
 
-  /** 异步发送 instant 事件 (无耗时). */
-  fun sendInstant(name: String) {
+  /** 异步发送 instant 事件 (无耗时). `inline` 调用, 同上. */
+  @PublishedApi
+  internal fun sendInstant(name: String) {
     if (broken) return
     enqueue("""{"type":"instant","name":"${escape(name)}"}""")
   }
 
-  /** 异步发送 end_boot 标记. */
-  fun sendEndBoot() {
+  /** 异步发送 end_boot 标记. `inline` 调用, 同上. */
+  @PublishedApi
+  internal fun sendEndBoot() {
     if (broken) return
     enqueue("""{"type":"end_boot"}""")
   }


### PR DESCRIPTION
## 背景

PR #377 修了 8 个 Kotlin 编译错误, 但 main 还有 3 个 PR #369 引入的错误漏修:

```
OnboardingActivity.kt:64 Unresolved reference 'PerfTracer'

ThreadDumper.kt:105 Cannot infer type for type parameter 'R'
ThreadDumper.kt:105 None of the following candidates is applicable
  fun Throwable.printStackTrace(): Unit
  fun Throwable.printStackTrace(writer: PrintWriter): Unit
  fun Throwable.printStackTrace(stream: PrintStream): Unit

PerfTracer.kt:147 Public-API inline function cannot access non-public-API function
```

## 修复

1. **OnboardingActivity.kt:64** — PR #369 把 `PerfTracer.trace` 调用塞进 onCreate 但没加 import. 补 `import com.itsaky.androidide.perf.tracer.PerfTracer`.

2. **ThreadDumper.kt:105** — 原代码 `PrintWriter(sw).use { thread.printStackTrace(it) }`. use 函数的 R 推断被 throwable.printStackTrace 的 overload 选择卡住, Kotlin 推不出 it 的实际类型. PR #377 之前尝试显式标 `pw: PrintWriter` 也没解决. 改成不用 use:
   ```kotlin
   val sw = StringWriter()
   val pw = PrintWriter(sw)
   thread.printStackTrace(pw)
   pw.flush()
   sb.append(sw.toString())
   ```
   语义相同 (PrintWriter sw 不持 IO 资源, 不需要 close).

3. **PerfTracer.kt:147** — inline `trace` 函数访问 `socket.sendPhase` 报 'cannot access non-public-API function'. `PerfClientSocket` 是 internal class, `sendPhase` / `sendInstant` / `sendEndBoot` 是 public (实际 visibility = internal), inline 访问需要 `@PublishedApi`. 三个方法都加 `@PublishedApi internal`. `close()` 不被 inline 访问, 保留 public 不动.

## 行为不变

0 个 API 变更. 所有改动是修编译错误, 不改运行时行为.

## 文件

```
3 files changed, 16 insertions(+), 7 deletions(-)

 .../androidide/activities/OnboardingActivity.kt  |  1 +
 .../androidide/perf/export/ThreadDumper.kt        |  4 +++-
 .../androidide/perf/tracer/PerfClientSocket.kt    | 18 ++++++++------
```

## 测试

跑 `./gradlew :core:app:compileDebugKotlin` 应该不再报任何编译错误.