### PR TITLE
fix(perf): 修 main 分支 2 处残留 Kotlin 编译错误 (CI 修 round 3)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/perf/export/ThreadDumper.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/export/ThreadDumper.kt
@@ -101,11 +101,9 @@ object ThreadDumper {
     val entries = Thread.getAllStackTraces().entries.sortedBy { it.key.name }
     entries.forEach { (thread, stack) ->
       sb.appendLine("--- Thread: ${thread.name} (id=${thread.id}, priority=${thread.priority}, state=${thread.state}) ---")
-      val sw = StringWriter()
-      val pw = PrintWriter(sw)
-      thread.printStackTrace(pw)
-      pw.flush()
-      sb.append(sw.toString())
+      // Thread 不是 Throwable, 没有 printStackTrace(PrintWriter) overload.
+      // Thread.getAllStackTraces() 已经返回 Array<StackTraceElement>, 直接遍历.
+      stack.forEach { frame -> sb.appendLine("\tat $frame") }
       sb.appendLine()
     }
     return sb.toString()

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfClientSocket.kt
@@ -126,8 +126,17 @@ internal class PerfClientSocket(private val socketPath: String) {
   }
 
   // -- private --
+  //
+  // 注: enqueue 必须是 @PublishedApi internal, 因为上面的
+  // @PublishedApi internal fun sendPhase/sendInstant/sendEndBoot
+  // 被 inline (e.g. PerfTracer.trace) 调, inline 展开时会把 enqueue
+  // 调用 inline 到 caller 字节码, 但 enqueue 本身是 private to this
+  // class — caller 编译期看不到 private, 报
+  // "inline function cannot access non-public-API function".
+  // 加 @PublishedApi internal 后, inline 知道怎么访问.
 
-  private fun enqueue(line: String) {
+  @PublishedApi
+  internal fun enqueue(line: String) {
     if (broken) return
     val ok = queue.offer(line)
     if (!ok) {


### PR DESCRIPTION
## 背景

PR #378 修了 3 个 Kotlin 编译错误, 但 main 还有 2 个 PR #369 引入的错误漏修:

```
ThreadDumper.kt:106 None of the following candidates is applicable
  fun Throwable.printStackTrace(): Unit
  fun Throwable.printStackTrace(writer: PrintWriter): Unit
  fun Throwable.printStackTrace(stream: PrintStream): Unit

PerfTracer.kt:147 Public-API inline function cannot access non-public-API function
```

## 修复

1. **ThreadDumper.kt:106** — `thread.printStackTrace(pw)` 编译失败. 原因: `thread` 是 `Thread` 类型, **不是 `Throwable`**, 没有 `printStackTrace(PrintWriter)` overload (只有 `Throwable` 有).

   `Thread.getAllStackTraces()` 已经返回 `Map<Thread, Array<StackTraceElement>>`, `entries.forEach` 里 destructure `(thread, stack)` 已有 `stack` 数组, 直接遍历:
   ```kotlin
   stack.forEach { frame -> sb.appendLine("\tat $frame") }
   ```
   效果跟 `Throwable.printStackTrace` 等价.

2. **PerfTracer.kt:147** — `s.sendPhase` 报 'cannot access non-public-API function'. PR #378 给 `sendPhase` / `sendInstant` / `sendEndBoot` 加了 `@PublishedApi internal`, 但 `sendPhase` body 内部调 `enqueue(line)` (private), inline 展开时把 `enqueue` 调用 inline 到 caller 字节码 — `enqueue` 是 private to `PerfClientSocket` class, caller 编译期看不到 private, 报错.

   给 `enqueue` 也加 `@PublishedApi internal`, inline 跨 class 边界也能访问.

## 行为不变

- `stack.forEach` 格式跟 `Throwable.printStackTrace(PrintWriter)` 等价 (都是 `	at <StackTraceElement>` 一行)
- `enqueue` 改 `@PublishedApi internal` 仅 module-internal 暴露, 对外 API 不变
- 0 个公开 API 变更

## 文件

```
2 files changed, 13 insertions(+), 6 deletions(-)

 .../androidide/perf/export/ThreadDumper.kt       |  8 +++---
 .../androidide/perf/tracer/PerfClientSocket.kt   | 11 ++++++++-
```

## 测试

跑 `./gradlew :core:app:compileDebugKotlin` 应该不再报任何编译错误.