### PR TITLE
fix(perf): 修 main 分支 PerfTracer inline 跨 class 访问 (CI 修 round 4)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
@@ -137,7 +137,27 @@ object PerfTracer {
    */
   @JvmStatic
   inline fun <T> trace(name: String, block: () -> T): T {
-    if (!BuildConfig.DEBUG) return block()
+    if (!BuildConfig.DEBUG) return block() // Release build 0 overhead
+    return _traceImpl(name, block)
+  }
+
+  /**
+   * `trace` 的实际工作体. 拆出来是为了避开 inline 跨 class 访问的
+   * @PublishedApi 链:
+   *
+   * - 原来 inline trace body 直接调 `s.sendPhase`, 编译期会递归检查
+   *   sendPhase body 的所有访问 (broken / escape 都是 PerfClientSocket
+   *   private), 这些都要加 @PublishedApi, 污染严重.
+   * - 拆出 _traceImpl 后, inline trace body 只调 _traceImpl (PerfTracer
+   *   自己的 internal fun), 不会跨 class, 也就不递归检查 _traceImpl
+   *   body. _traceImpl 是 non-inline, 调 sendPhase 不递归 body 检查.
+   * - @PublishedApi 让 _traceImpl 能被 inline trace 调.
+   *
+   * Release 0 overhead 由 inline trace 的 `if (!BuildConfig.DEBUG)`
+   * 保证 — _traceImpl 在 Release build 永远不会被调用.
+   */
+  @PublishedApi
+  internal fun <T> _traceImpl(name: String, block: () -> T): T {
     val s = socket ?: return block()
     val start = SystemClock.elapsedRealtime()
     return try {


### PR DESCRIPTION
## 背景

PR #379 把 enqueue/sendPhase/sendInstant/sendEndBoot 都加了 `@PublishedApi internal`, 但 CI 还报 line 147 'inline function cannot access non-public-API function'.

```
PerfTracer.kt:147:9 Public-API inline function cannot access non-public-API function
```

## 根因

inline `trace()` 跨 class 调 `s.sendPhase`, Kotlin 2.2 编译期会**递归**检查 sendPhase body 调的所有 private 成员 (`broken` / `escape` 都在 `PerfClientSocket` 私有). 全部都需要 `@PublishedApi` — 严重污染 (`PerfClientSocket` 6+ 个成员全要改).

## 解法

把 inline `trace` 的工作体拆成 `PerfTracer` 自己的 `@PublishedApi internal fun _traceImpl` (non-inline). 这样:
- inline `trace` body 只调 `_traceImpl` (同 class, 不跨边界), **不递归** 检查 `_traceImpl` body
- `_traceImpl` 调 `s.sendPhase` (non-inline, 跨 class, **不递归** sendPhase body)
- `@PublishedApi` 让 `_traceImpl` 能被 inline `trace` 调

```kotlin
@JvmStatic
inline fun <T> trace(name: String, block: () -> T): T {
  if (!BuildConfig.DEBUG) return block() // Release build 0 overhead
  return _traceImpl(name, block)
}

@PublishedApi
internal fun <T> _traceImpl(name: String, block: () -> T): T {
  val s = socket ?: return block()
  val start = SystemClock.elapsedRealtime()
  return try {
    block()
  } finally {
    val elapsed = SystemClock.elapsedRealtime() - start
    s.sendPhase(name, elapsed)
  }
}
```

## Release 0 overhead 保证

inline `trace` 的 `if (!BuildConfig.DEBUG) return block()` 在 Release build 仍被消除, 整个 `_traceImpl` 调用消失. 0 overhead 保留.

## 行为不变

- 0 个 API 变更
- Debug build + :perf attached: 行为完全一样, 同样调 `s.sendPhase` 上报事件
- Release build: `if (!BuildConfig.DEBUG) return block()` 整段被消除, 0 overhead 同 PR #2 设计

## 文件

```
1 file changed, 21 insertions(+), 1 deletion(-)

 .../androidide/perf/tracer/PerfTracer.kt  | 22 +++++++++++++++++++++-
```

## 测试

跑 `./gradlew :core:app:compileDebugKotlin` 应该不再报任何编译错误.