### PR TITLE
fix(perf): 修 main 分支 PerfTracer _traceImpl block 需 noinline (CI 修 round 5)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
@@ -137,7 +137,37 @@ object PerfTracer {
    */
   @JvmStatic
   inline fun <T> trace(name: String, block: () -> T): T {
-    if (!BuildConfig.DEBUG) return block()
+    if (!BuildConfig.DEBUG) return block() // Release build 0 overhead
+    return _traceImpl(name, block)
+  }
+
+  /**
+   * `trace` 的实际工作体. 拆出来是为了避开 inline 跨 class 访问的
+   * @PublishedApi 链 + 让 `block` 能合法地在 non-inline 函数内调
+   * (noinline 修饰).
+   *
+   * - inline trace body 直接调 `s.sendPhase`, 编译期会递归检查
+   *   sendPhase body 的所有访问 (broken / escape 都是 PerfClientSocket
+   *   private), 这些都要加 @PublishedApi, 污染严重.
+   * - 拆出 _traceImpl 后, inline trace body 只调 _traceImpl (PerfTracer
+   *   自己的 internal fun), 不会跨 class, 也就不递归检查 _traceImpl
+   *   body. _traceImpl 是 non-inline, 调 sendPhase 不递归 body 检查.
+   * - @PublishedApi 让 _traceImpl 能被 inline trace 调.
+   *
+   * Release 0 overhead 由 inline trace 的 `if (!BuildConfig.DEBUG)`
+   * 保证 — _traceImpl 在 Release build 永远不会被调用.
+   *
+   * `block: noinline () -> T` 是因为 _traceImpl 是 non-inline, 不能
+   * 直接调 inline trace 的 lambda 参数 — Kotlin 编译期拒绝
+   * 'Illegal usage of inline parameter'. 加 noinline 后, block 在
+   * trace 调用点先被 evaluate, 然后以普通 Function0 引用传给
+   * _traceImpl. inline 优化效果 (trace 调用点 block 直接展开) 没
+   * 了, 但 Debug build + :perf 路径正常, Release build 走 0 overhead
+   * 那条 `if (!BuildConfig.DEBUG) return block()` — block 在原地展开,
+   * 0 overhead 保留.
+   */
+  @PublishedApi
+  internal fun <T> _traceImpl(name: String, noinline block: () -> T): T {
     val s = socket ?: return block()
     val start = SystemClock.elapsedRealtime()
     return try {


### PR DESCRIPTION
## 背景

PR #380 拆出 `_traceImpl` 把 inline 跨 class 访问问题修了, 但 CI 又报:

```
PerfTracer.kt:141:29 Illegal usage of inline parameter 'block: () -> T'.
Add 'noinline' modifier to the parameter declaration.
```

## 根因

`_traceImpl` 是 non-inline, 但调 `block()` (来自 inline `trace` 的 lambda 参数). Kotlin 编译期禁止 non-inline 函数体里调 inline 参数 — inline 参数在 non-inline 上下文无法被 inline 展开, 必须用 `noinline` 把它退化成普通 `Function0` 引用.

## 修法

把 `_traceImpl` 的 `block` 参数标 `noinline`:

```kotlin
@PublishedApi
internal fun <T> _traceImpl(name: String, noinline block: () -> T): T {
  val s = socket ?: return block()
  val start = SystemClock.elapsedRealtime()
  return try {
    block()
  } finally {
    val elapsed = SystemClock.elapsedRealtime() - start
    s.sendPhase(name, elapsed)
  }
}
```

trace 调用点变成 `evaluate block (作为普通 lambda) → 传给 _traceImpl`. inline 优化效果 (trace 调用点 block 直接展开) 没了, 但:
- **Debug build + :perf attached**: 路径正常, 同样调 `s.sendPhase` 上报事件
- **Release build 0 overhead**: 由 inline `trace` 的 `if (!BuildConfig.DEBUG) return block()` 保证 — block 在 if-true 分支原地展开, `_traceImpl` 永远不被调到

## 行为不变

- 0 个公开 API 变更
- 0 overhead 保留 (Release build 走 `if (!BuildConfig.DEBUG)` 那条)
- Debug build 行为完全一致, 同样调 `s.sendPhase` 上报事件

## 文件

```
1 file changed, 31 insertions(+), 1 deletion(-)

 .../androidide/perf/tracer/PerfTracer.kt  | 32 ++++++++++++++++++++++++++++++-
```

## 测试

跑 `./gradlew :core:app:compileDebugKotlin` 应该不再报任何编译错误.