### PR TITLE
fix(perf): 修 main 分支 PR #8 残留 3 处 Kotlin 编译错误 (CI 修 round 6)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -38,6 +38,7 @@ import com.itsaky.androidide.events.LspJavaEventsIndex
 import com.itsaky.androidide.events.LspKotlinEventsIndex
 import com.itsaky.androidide.perf.PerfApplication
 import com.itsaky.androidide.perf.monitor.MonitorCoordinator
+import com.itsaky.androidide.perf.monitor.StrictModeViolationMonitor
 import com.itsaky.androidide.perf.tracer.PerfTracer
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.preferences.internal.GeneralPreferences

--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt
@@ -80,7 +80,7 @@ object StrictModeViolationMonitor {
     val threadPolicy = StrictMode.getThreadPolicy()
     val newThreadPolicy =
         StrictMode.ThreadPolicy.Builder(threadPolicy)
-            .onThreadViolation { violation ->
+            .onThreadViolation { _, violation ->
               reportViolation("thread", violation, sampleEveryNth)
             }
             .build()

--- a/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt
@@ -136,7 +136,7 @@ object PerfTracer {
    * @return [block] 的返回值
    */
   @JvmStatic
-  inline fun <T> trace(name: String, block: () -> T): T {
+  inline fun <T> trace(name: String, noinline block: () -> T): T {
     if (!BuildConfig.DEBUG) return block() // Release build 0 overhead
     return _traceImpl(name, block)
   }
@@ -167,7 +167,7 @@ object PerfTracer {
    * 0 overhead 保留.
    */
   @PublishedApi
-  internal fun <T> _traceImpl(name: String, noinline block: () -> T): T {
+  internal fun <T> _traceImpl(name: String, block: () -> T): T {
     val s = socket ?: return block()
     val start = SystemClock.elapsedRealtime()
     return try {


### PR DESCRIPTION
## 背景

PR #8 (`59b9ca62` AnrMonitor 自动 dump + StrictMode 违规上报) merge 后, CI 还在挂, 根因是 3 处编译期错误在 PR 评审时没被抓住:

1. **`IDEApplication.kt:151` — Unresolved reference 'StrictModeViolationMonitor'**
   IDEApplication 在 `com.itsaky.androidide.app` 包, StrictModeViolationMonitor 在 `com.itsaky.androidide.perf.monitor` 包, Kotlin 同包规则用不上, 必须显式 `import`.
2. **`StrictModeViolationMonitor.kt:83/93` — Unresolved reference 'onThreadViolation/onVmViolation' + Cannot infer type**
   `OnThreadViolationListener.onThreadViolation(Thread, Throwable)` 是双参 SAM, 单参 lambda Kotlin 直接拒; `OnVmViolationListener.onVmViolation(Throwable)` 是单参, 不动.
3. **`PerfTracer.kt:141/170` — 'Illegal usage of inline parameter' / 'Modifier is only allowed for inline function'**
   round 5 (a33eebdfa) 把 `noinline` 错加在 non-inline `_traceImpl` 的 block 上, 两个 modifier 错位. `noinline` 必须挂在 inline 函数的 lambda 参数上.

## 修改

- `core/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt`: 加 `import com.itsaky.androidide.perf.monitor.StrictModeViolationMonitor`
- `core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt`: thread lambda `{ violation -> ... }` → `{ _, violation -> ... }` (丢弃 Thread 引用, 保留 Throwable); vm lambda 单参不变
- `core/app/src/main/java/com/itsaky/androidide/perf/tracer/PerfTracer.kt`: `noinline` 从 `_traceImpl` 的 block 移到 `trace` 的 block (trace 是 inline 函数, 合法加 noinline; _traceImpl 是 non-inline, 普通 block 即可)

## 行为

- `trace` 调用点 lambda body 仍原地 inline 展开, 仅当传给 `_traceImpl` 时退化为 `Function0` 引用
- Release build 走 `if (!BuildConfig.DEBUG) return block()` 短路, `_traceImpl` 永不被调用, 0 overhead 保留
- Debug + :perf attached 路径不变

## 验证

- 3 files changed, 4 insertions(+), 3 deletions(-)
- 与 round 5 (a33eebdfa) 互不冲突: round 5 删了 proguard rules; round 6 修编译错误