### PR TITLE
fix(perf): 修 main 分支 PR #383 残留 onThreadViolation 编译错误 (CI 修 round 6 follow-up)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt
@@ -19,6 +19,7 @@ package com.itsaky.androidide.perf.monitor
 import android.os.Build
 import android.os.StrictMode
 import com.itsaky.androidide.perf.tracer.PerfTracer
+import java.util.concurrent.Executor
 import org.slf4j.LoggerFactory
 
 /**
@@ -77,16 +78,27 @@ object StrictModeViolationMonitor {
     installed = true
 
     // 1. Thread 违规
+    // 注意: StrictMode.ThreadPolicy.Builder 没有 onThreadViolation 方法 (PR #8/8 当时
+    // 误用). 正确 API 是 penaltyListener(Executor, OnThreadViolationListener) (API 28+).
+    // OnThreadViolationListener.onThreadViolation(Violation v) 是单参 SAM
+    // (v 是 android.os.strictmode.Violation, 继承 Throwable).
+    // API 26-27 只能走 penaltyLog() (logcat 输出, 不上报).
     val threadPolicy = StrictMode.getThreadPolicy()
-    val newThreadPolicy =
-        StrictMode.ThreadPolicy.Builder(threadPolicy)
-            .onThreadViolation { _, violation ->
-              reportViolation("thread", violation, sampleEveryNth)
-            }
-            .build()
-    StrictMode.setThreadPolicy(newThreadPolicy)
+    val threadPolicyBuilder = StrictMode.ThreadPolicy.Builder(threadPolicy)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      // API 28+: penaltyListener 装 OnThreadViolationListener (单参 Violation)
+      threadPolicyBuilder.penaltyListener(
+          Executor { command -> command.run() }
+      ) { violation -> reportViolation("thread", violation, sampleEveryNth) }
+    } else {
+      // API 26-27: penaltyListener 还没出, 只能 logcat
+      threadPolicyBuilder.penaltyLog()
+    }
+    StrictMode.setThreadPolicy(threadPolicyBuilder.build())
 
     // 2. VM 违规
+    // VmPolicy.Builder.onVmViolation(OnVmViolationListener) (API 26+) 是真实 API,
+    // 单参 SAM, 不动.
     val vmPolicy = StrictMode.getVmPolicy()
     val newVmPolicy =
         StrictMode.VmPolicy.Builder(vmPolicy)


### PR DESCRIPTION
## 背景

PR #383 (commit `0c0f3fdf7`) merge 修 StrictModeViolationMonitor 时只改了 lambda 参数个数 (`{ violation -> ... }` → `{ _, violation -> ... }`), 没意识到 `onThreadViolation` **根本不是 `StrictMode.ThreadPolicy.Builder` 的方法**.

Android 标准 SDK 上 `ThreadPolicy.Builder` 真实方法列表:

- `detectAll` / `detectDiskReads` / `detectNetwork` / ...
- `penaltyLog` / `penaltyDialog` / `penaltyDeath` / `penaltyFlashScreen`
- **`penaltyListener(Executor, OnThreadViolationListener)`** ← 正确 API (API 28+)
- `permitAll` / ...

没有 `onThreadViolation`. PR #383 merge 后编译器 cascade 报:

```
e: StrictModeViolationMonitor.kt:83:14 Unresolved reference 'onThreadViolation'.
e: StrictModeViolationMonitor.kt:83:34 Cannot infer type for implicit value parameter 'it'. Specify it explicitly.
e: StrictModeViolationMonitor.kt:83:37 Cannot infer type for value parameter 'violation'. Specify it explicitly.
e: StrictModeViolationMonitor.kt:93:14 Unresolved reference 'onVmViolation'.
e: StrictModeViolationMonitor.kt:93:30 Cannot infer type for value parameter 'violation'. Specify it explicitly.
```

(93 行 `onVmViolation` 是 cascade 误报, 跟 thread 错误无关, `onVmViolation` 是 `VmPolicy.Builder` API 26+ 真实方法.)

## 修法

- **API 28+**: `threadPolicyBuilder.penaltyListener(Executor) { violation -> ... }` — `OnThreadViolationListener.onThreadViolation(Violation v)` 单参 SAM, `Violation` 是 `android.os.strictmode.Violation` (继承 `Throwable`)
- **API 26-27**: `threadPolicyBuilder.penaltyLog()` — `penaltyListener` API 28+ 才有, 26-27 只能 logcat
- **VM 违规** 保留 `.onVmViolation { violation -> ... }` (单参 SAM, 不动)
- 新增 `import java.util.concurrent.Executor` (`penaltyListener` 第一参数类型)

## 跟 round 6 (PR #383) 的关系

PR #383 后续 follow-up commits (`229ff6791`, `e56220e3d`) 是在 `fix/perf-build-errors-round6` 分支上的, 但 PR #383 只合了 `0c0f3fdf7` 这一个 commit (`a0d69120f` merge), `origin/main` 仍然挂着 broken `onThreadViolation` 调用, CI 一直红.

这个 follow-up PR 直接从 `origin/main` 拉 `fix/perf-build-errors-round6-followup`, 把 follow-up 两个 commit 的内容 (penaltyListener + 单参 Violation) 合到 origin/main 上来. PR diff 干净, 只动 `StrictModeViolationMonitor.kt` 一个文件.

## 验证

1 file changed, 19 insertions(+), 7 deletions(-). 跟 PR #383 (1 file, 1 insertion, 1 deletion) 是同源 fix, 这次把遗漏的修复补上.