### PR TITLE
fix(perf): 修 main 分支 PR #384 残留 onVmViolation 编译错误 (CI 修 round 6 follow-up v3)

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/perf/monitor/StrictModeViolationMonitor.kt
@@ -97,14 +97,22 @@ object StrictModeViolationMonitor {
     StrictMode.setThreadPolicy(threadPolicyBuilder.build())
 
     // 2. VM 违规
-    // VmPolicy.Builder.onVmViolation(OnVmViolationListener) (API 26+) 是真实 API,
-    // 单参 SAM, 不动.
+    // VmPolicy.Builder 也没有 onVmViolation 方法 (跟 ThreadPolicy.Builder 一样).
+    // 正确 API 是 penaltyListener(Executor, OnVmViolationListener) (API 28+).
+    // OnVmViolationListener.onVmViolation(Throwable) 是单参 SAM.
+    // API 26-27 只能走 penaltyLog() (logcat 输出, 不上报).
     val vmPolicy = StrictMode.getVmPolicy()
-    val newVmPolicy =
-        StrictMode.VmPolicy.Builder(vmPolicy)
-            .onVmViolation { violation -> reportViolation("vm", violation, sampleEveryNth) }
-            .build()
-    StrictMode.setVmPolicy(newVmPolicy)
+    val vmPolicyBuilder = StrictMode.VmPolicy.Builder(vmPolicy)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      // API 28+: penaltyListener 装 OnVmViolationListener (单参 Throwable)
+      vmPolicyBuilder.penaltyListener(
+          Executor { command -> command.run() }
+      ) { violation -> reportViolation("vm", violation, sampleEveryNth) }
+    } else {
+      // API 26-27: penaltyListener 还没出, 只能 logcat
+      vmPolicyBuilder.penaltyLog()
+    }
+    StrictMode.setVmPolicy(vmPolicyBuilder.build())
 
     log.info("StrictModeViolationMonitor installed (sample rate: 1/{})", sampleEveryNth)
   }


### PR DESCRIPTION
## 背景

PR #384 ([`c7fb3ab3c`](https://github.com/msmt2018/ZeroStudio/pull/384/commits/c7fb3ab3c)) merge 时只合了 thread 修复 (onThreadViolation → penaltyListener), VM 违规的 `.onVmViolation { violation -> ... }` 调用**没改**, 注释也还是错的 ("onVmViolation (API 26+) 是真实 API, 不动"). 这是 PR #8 当年的原始 bug, `VmPolicy.Builder` 跟 `ThreadPolicy.Builder` 一样, 真实 API 只有 `penaltyListener(Executor, OnVmViolationListener)` (API 28+), 根本没有 `onVmViolation` 方法. PR #384 跟 PR #383 都漏了 VM 那一边.

CI 现在挂在 origin/main (`bb7ee7733`) 的 105:14:

```
e: StrictModeViolationMonitor.kt:105:14 Unresolved reference 'onVmViolation'.
e: StrictModeViolationMonitor.kt:105:30 Cannot infer type for value parameter 'violation'. Specify it explicitly.
```

## 修法 (跟 thread 违规对称)

- **API 28+**: `vmPolicyBuilder.penaltyListener(Executor) { violation -> ... }` (单参 SAM, `OnVmViolationListener.onVmViolation(Throwable)`)
- **API 26-27**: `vmPolicyBuilder.penaltyLog()` (`penaltyListener` API 28+ 才有)
- **API < 26**: 整体 skip (round 6 已有)

## 跟 PR #384 的关系

PR #384 在 fix/perf-build-errors-round6-followup 分支有 2 个 commits:
1. `c7fb3ab3c` — 修 thread (merged ✓)
2. `8bb8812ec` — 修 vm (NOT merged, 仍在我本地分支)

我怀疑是 GitHub merge UI 选了 "Squash" 模式, squash 时只挑了第一个 commit 进 main, vm 那一边被丢. 这个新 PR 直接从最新 origin/main 拉 `fix/perf-build-errors-round6-followup-v2`, 重新打 vm 修复 commit, 干净地只动 VM 那一边, 不动 PR #384 已修的 thread 那一边.

## 验证

- 1 file changed, 15 insertions(+), 7 deletions(-)
- 只动 `StrictModeViolationMonitor.kt` 一个文件
- diff 跟 thread 修复对称, 行为可预测
- 不需要新增 import (Executor 已经在 PR #384 引入)