### PR TITLE
fix(chatai/app): release 构建关闭 R8, 防止 RikkaHubRuntime 被剥离

### DIFF
--- a/core/chatai/app/build.gradle.kts
+++ b/core/chatai/app/build.gradle.kts
@@ -73,7 +73,15 @@ android {
     buildTypes {
         release {
             // signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = true
+            // NOTE: chatai/app 是被 :core:app 合并的 library，不是独立 APK。
+            // 若开启 R8/ProGuard，core/app 的 IDEApplication.onCreate 中
+            //   RikkaHubRuntime.ensureKoinStarted(this)
+            // 是该模块唯一被外部引用的入口，R8 会把整个 me.rerere.rikkahub.RikkaHubRuntime
+            // （以及它依赖的 appModule / viewModelModule / dataSourceModule / repositoryModule）
+            // 当作死代码从 AAR 中剥离，导致稳定版 APK 启动时
+            //   java.lang.NoClassDefFoundError: me.rerere.rikkahub.RikkaHubRuntime
+            // 其他 chatai 子模块（ai/common/document/highlight/search/speech/web）也是 false。
+            isMinifyEnabled = false
             // isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
## 崩溃
```
FATAL EXCEPTION: main
Process: com.itsaky.androidide, PID: 1025
java.lang.NoClassDefFoundError: Failed resolution of: Lme/rerere/rikkahub/RikkaHubRuntime;
  at com.itsaky.androidide.app.IDEApplication.onCreate(IDEApplication.kt:80)
Caused by: java.lang.ClassNotFoundException: me.rerere.rikkahub.RikkaHubRuntime
```

仅在稳定版 (release APK) 出现，调试版正常。

## 根因
`core/chatai/app` 的 release 构建启用了 `isMinifyEnabled = true`，但该模块本质上是会被 `:core:app` 合并的 library：

- `core/chatai/app/src/main/AndroidManifest.xml` 故意**不**设置 `android:name=".RikkaHubApp"`（见 `scripts/chatai/reapply-integrations.sh` 主动剥掉），否则会与 `core/app` 的 `IDEApplication` 冲突；
- 因此在 chatai/app AAR 自己构建时，R8 看不到 `RikkaHubApp.onCreate()` 的调用方（唯一调用方在 `RikkaHubApp.kt:55`）；
- R8 把 `RikkaHubApp` 视为不可达，进而把整个 `me.rerere.rikkahub.RikkaHubRuntime`（以及它加载的 `appModule` / `viewModelModule` / `dataSourceModule` / `repositoryModule` 四个 Koin 模块）当作死代码从 AAR 中**剥离**；
- `:core:app` 的 release 是 `isMinifyEnabled = false`，不会再次跑 R8，剥掉的类就这么原样进 APK；
- 启动时 `IDEApplication.onCreate` 调到 `RikkaHubRuntime.ensureKoinStarted(this)` → `NoClassDefFoundError`。

## 对照
其他所有 chatai 子模块 release 都明确写了 `isMinifyEnabled = false`：
```
core/chatai/ai/...        isMinifyEnabled = false
core/chatai/common/...    isMinifyEnabled = false
core/chatai/document/...  isMinifyEnabled = false
core/chatai/highlight/... isMinifyEnabled = false
core/chatai/search/...    isMinifyEnabled = false
core/chatai/speech/...    isMinifyEnabled = false
core/chatai/web/...       isMinifyEnabled = false
```
只有 `core/chatai/app` 是 `true` —— 显然是从上游 RikkaHub 仓库同步后忘了改。

## 修复
将 `core/chatai/app/build.gradle.kts` 的 `release.isMinifyEnabled` 改为 `false`，与其他 chatai 子模块保持一致。chatai/app 是被合并的 library，缩小/混淆应留给最终消费方 `:core:app`，不应当在这里做。

## 变更
```
core/chatai/app/build.gradle.kts | 10 +++++++++-
1 file changed, 9 insertions(+), 1 deletion(-)
```

## 验证
- 全部 7 个 chatai 子模块 release 行为一致（都 `isMinifyEnabled = false`）
- `RikkaHubRuntime` 与 4 个 Koin DI module 在 chatai/app AAR 中保留
- 稳定版 APK 启动期 `IDEApplication.onCreate` 不再 `NoClassDefFoundError`

## 风险评估
- **零行为变化**：调试版（`isMinifyEnabled` 默认 false）一直正常
- **可能影响**：chatai/app AAR 体积会略增（不再 shrink），但保留了消费方需要的所有类
- **可回滚**：单一 `git revert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
