### PR TITLE
fix(chatai/app): 恢复 R8 + 加 keep 规则保留 RikkaHubRuntime 整包 (替代 PR #388)

### DIFF
--- a/core/chatai/app/build.gradle.kts
+++ b/core/chatai/app/build.gradle.kts
@@ -28,6 +28,11 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // 把 consumer-rules.pro 显式列出来, AAR 消费方 (:core:app) 一旦开启
+        // isMinifyEnabled = true 就能自动拿到 chatai/app 的反射入口 keep 规则。
+        // 当前 :core:app 的 release 还是 false, 但写在这里以防未来切换。
+        consumerProguardFiles("consumer-rules.pro")
+
         ndk {
             abiFilters += listOf("arm64-v8a", "x86_64")
         }
@@ -73,15 +78,7 @@ android {
     buildTypes {
         release {
             // signingConfig = signingConfigs.getByName("release")
-            // NOTE: chatai/app 是被 :core:app 合并的 library，不是独立 APK。
-            // 若开启 R8/ProGuard，core/app 的 IDEApplication.onCreate 中
-            //   RikkaHubRuntime.ensureKoinStarted(this)
-            // 是该模块唯一被外部引用的入口，R8 会把整个 me.rerere.rikkahub.RikkaHubRuntime
-            // （以及它依赖的 appModule / viewModelModule / dataSourceModule / repositoryModule）
-            // 当作死代码从 AAR 中剥离，导致稳定版 APK 启动时
-            //   java.lang.NoClassDefFoundError: me.rerere.rikkahub.RikkaHubRuntime
-            // 其他 chatai 子模块（ai/common/document/highlight/search/speech/web）也是 false。
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             // isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/core/chatai/app/consumer-rules.pro
+++ b/core/chatai/app/consumer-rules.pro
@@ -1,0 +1,24 @@
+# consumer-rules.pro
+# ---------------------------------------------------------------------------
+# 这些规则会随 AAR 一起发布到消费方 (:core:app), 当消费方启用
+# isMinifyEnabled = true 时生效。 当前 :core:app 的 release 仍为
+# isMinifyEnabled = false, 所以这文件暂时不生效; 但写在这里能保证
+# 一旦 :core:app 启用 R8, chatai/app 的反射入口仍然能保留。
+# ---------------------------------------------------------------------------
+
+# 外部反射入口
+-keep class me.rerere.rikkahub.RikkaHubRuntime { *; }
+-keep class me.rerere.rikkahub.RikkaHubRuntime$* { *; }
+
+# DI 模块
+-keep class me.rerere.rikkahub.di.** { *; }
+-keep class me.rerere.rikkahub.di.**$* { *; }
+
+# Koin 反射式 DI
+-keep class org.koin.core.** { *; }
+-keep class org.koin.dsl.** { *; }
+-keep class * extends org.koin.core.module.Module { *; }
+-keepclassmembers class * extends org.koin.core.module.Module { *; }
+-keep class kotlin.reflect.jvm.internal.** { *; }
+-dontwarn org.koin.**
+-dontwarn kotlin.reflect.jvm.internal.**

--- a/core/chatai/app/proguard-rules.pro
+++ b/core/chatai/app/proguard-rules.pro
@@ -45,3 +45,46 @@
 -keepattributes Signature, InnerClasses, EnclosingMethod
 -keep class com.fasterxml.jackson.** { *; }
 -keep class com.auth0.jwt.** { *; }
+
+# ---------------------------------------------------------------------------
+# RikkaHub Koin bootstrap (被 :core:app IDEApplication 反射调用)
+# ---------------------------------------------------------------------------
+# chatai/app 合并进 :core:app 后, 自己的 AndroidManifest 没有注册
+#   android:name=".RikkaHubApp"
+# (否则会与 :core:app 的 IDEApplication 冲突, 见
+#  scripts/chatai/reapply-integrations.sh)。 因此 R8 看不到
+# RikkaHubApp.onCreate → RikkaHubRuntime.ensureKoinStarted 的调用链,
+# 会把 RikkaHubRuntime 整包当作死代码剥离。
+# :core:app 的 release 也是 isMinifyEnabled = false, 不会在消费方再跑 R8,
+# 所以 keep 规则必须放在 chatai/app 这一侧 (即本文件), 而不是
+# consumer-rules.pro (后者只在消费方跑 R8 时生效)。
+
+# 整个 RikkaHub 包: 包含被外部反射调用的入口 (RikkaHubRuntime) 与
+# Koin 模块 (appModule / viewModelModule / dataSourceModule /
+# repositoryModule) 及其 single { ... } 工厂 lambda 内引用的所有绑定类型。
+# 不保留此包会导致 NoClassDefFoundError 链式蔓延。
+-keep class me.rerere.rikkahub.** { *; }
+-keep interface me.rerere.rikkahub.** { *; }
+
+# Koin 反射式 DI: Module 实例 + 工厂 lambda 的 KFunction / KClass 反射
+-keep class org.koin.core.** { *; }
+-keep class org.koin.dsl.** { *; }
+-keep class * extends org.koin.core.module.Module { *; }
+-keepclassmembers class * extends org.koin.core.module.Module { *; }
+-keep class kotlin.reflect.jvm.internal.** { *; }
+-dontwarn org.koin.**
+-dontwarn kotlin.reflect.jvm.internal.**
+
+# kotlinx.coroutines 内 Koin scope 用到的协程服务
+-keepclassmembers class kotlinx.coroutines.** { volatile <fields>; }
+-dontwarn kotlinx.coroutines.**
+
+# kotlinx.serialization: RikkaHub 大量使用 @Serializable
+-keepattributes RuntimeVisibleAnnotations, AnnotationDefault
+-keep,includedescriptorclasses class me.rerere.rikkahub.**$$serializer { *; }
+-keepclassmembers class me.rerere.rikkahub.** {
+    *** Companion;
+}
+-keepclasseswithmembers class me.rerere.rikkahub.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}


### PR DESCRIPTION
## 背景
[PR #388](https://github.com/msmt2018/ZeroStudio/pull/388) 把 core/chatai/app release 的 isMinifyEnabled 改成了 false 来绕过 NoClassDefFoundError: me.rerere.rikkahub.RikkaHubRuntime。

这并不是长久的解:
- 放弃了 R8 的 shrink 优化, chatai/app AAR 体积明显变大
- 未来 :core:app 启用 isMinifyEnabled = true 时, 反射入口仍会被剥一次

## 真正的修复
让 R8 继续跑 + 加上正确的 keep 规则, 把 RikkaHub 整包 + Koin 反射依赖保留下来。

### 根因
chatai/app 是被 :core:app 合并的 library, 自己的 AndroidManifest.xml 没有注册 android:name=".RikkaHubApp" (否则与 :core:app 的 IDEApplication 冲突, 见 scripts/chatai/reapply-integrations.sh)。R8 在 chatai/app 自己的步骤里看不到 RikkaHubApp.onCreate -> RikkaHubRuntime.ensureKoinStarted 的调用链, 把整包当死代码剥离。

:core:app 的 release 当前是 isMinifyEnabled = false, 不会再跑 R8, 所以 keep 规则必须放在 chatai/app 这一侧 (即 proguard-rules.pro), 而不是 consumer-rules.pro (后者只在消费方跑 R8 时才生效)。

## 变更

### 1. core/chatai/app/build.gradle.kts
- release.isMinifyEnabled 改回 true (撤销 PR #388 的降级)
- defaultConfig.consumerProguardFiles("consumer-rules.pro") 显式声明, 给 AAR 消费方提供 keep 规则 (防 :core:app 未来启用 R8)

### 2. core/chatai/app/proguard-rules.pro 新增 keep 块

整个 RikkaHub 包 (入口 + Koin 模块 + 工厂 lambda 内引用的所有绑定类型):
```
-keep class me.rerere.rikkahub.** { *; }
-keep interface me.rerere.rikkahub.** { *; }
```

Koin 反射式 DI framework:
```
-keep class org.koin.core.** { *; }
-keep class org.koin.dsl.** { *; }
-keep class * extends org.koin.core.module.Module { *; }
-keepclassmembers class * extends org.koin.core.module.Module { *; }
-keep class kotlin.reflect.jvm.internal.** { *; }
-dontwarn org.koin.**
-dontwarn kotlin.reflect.jvm.internal.**
```

kotlinx.coroutines / kotlinx.serialization (RikkaHub 大量用 @Serializable):
```
-keepattributes RuntimeVisibleAnnotations, AnnotationDefault
-keep,includedescriptorclasses class me.rerere.rikkahub.**$$serializer { *; }
-keepclassmembers class me.rerere.rikkahub.** { *** Companion; }
-keepclasseswithmembers class me.rerere.rikkahub.** {
    kotlinx.serialization.KSerializer serializer(...);
}
```

### 3. core/chatai/app/consumer-rules.pro (新文件)

AAR 消费方用的轻量 keep 规则。覆盖 RikkaHubRuntime + di.** + Koin + KClass 反射。当前 :core:app release 还是 false, 所以此文件暂时不生效; 为未来切换做防御。

## 验证
- 整包 grep RikkaHubRuntime/org.koin/me.rerere.rikkahub 全工作区无 NoClassDefFoundError 引用
- proguard-rules.pro 语法 (用 proguard-android-optimize.txt 基础文件 + 已有 -dontobfuscate 风格一致)
- consumer-rules.pro 与 proguard-rules.pro 的 keep 规则子集对齐
- 沙箱里 gradle 包装器下载失败, 未跑 ./gradlew :core:chatai:app:assembleRelease 验证 APK 体积 / dex 列表
- 未跑 release 启动期 IDEApplication.onCreate 联调

## 风险
- 与 PR #388 互斥: 本 PR 是替代关系, 不能同时存在
- 整包 keep me.rerere.rikkahub.** 会让 chatai/app 内 RikkaHub 那部分代码 (Compose UI、ViewModel、数据模型、序列化类) 不再被 R8 shrink。这部分代码本来就是 R8 优化后 AAR 体积的次要贡献者, 影响可接受
- keep org.koin.core.** 同样让 Koin 框架不被 shrink。Koin 本身是反射式 DI 框架, R8 通常也保不住

## 关联 PR
- 替代 #388 (撤掉 isMinifyEnabled=false 那个)
- 上游 #387 (冷启动 / perf 移除)
