### PR TITLE
fix(od-sdk-install): 修复 PR #389 遗留的编译错误

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
@@ -52,6 +52,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -62,12 +63,12 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Storage
-import androidx.compose.material.icons.outlined.Build
-import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material.icons.outlined.Wifi
 import androidx.compose.material.icons.outlined.WifiOff
@@ -794,7 +795,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Icon(
-            Icons.Outlined.Build,
+            Icons.Filled.Build,
             contentDescription = null,
             tint = colors.onSurfaceMuted,
             modifier = Modifier.size(36.dp),
@@ -1082,7 +1083,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
         verticalAlignment = Alignment.CenterVertically,
     ) {
       Icon(
-          Icons.Outlined.Build,
+          Icons.Filled.Build,
           contentDescription = null,
           tint = colors.primary,
           modifier = Modifier.size(18.dp),
@@ -1221,11 +1222,11 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
         "platform-tools" -> Icons.Filled.Speed
         "build-tools" -> Icons.Filled.Build
         "ndk" -> Icons.Filled.Memory
-        "cmake" -> Icons.Outlined.Code
+        "cmake" -> Icons.Filled.Code
         else ->
             when {
               node.name.contains("Platform", ignoreCase = true) -> Icons.Filled.Storage
-              else -> Icons.Outlined.Build
+              else -> Icons.Filled.Build
             }
       }
 
@@ -1318,7 +1319,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
         )
         OdConfigChip(
             label = "CMake",
-            icon = Icons.Outlined.Code,
+            icon = Icons.Filled.Code,
             checked = applyCmakePatch,
             onCheckedChange = onApplyCmakePatchChange,
             modifier = Modifier.weight(1f),


### PR DESCRIPTION
## 背景
[PR #389](https://github.com/msmt2018/ZeroStudio/pull/389) (redesign/od-sdk-install-fragment-ui) 合入 main 后, CI 仍报两类编译错误未消除。本 PR 把残留的两类问题一次性收尾。

## 问题与修复

### 1. `Icons.Outlined.Build` / `Icons.Outlined.Code` receiver type mismatch
material-icons-extended 1.7.8 中 `Outlined.Build` 和 `Outlined.Code` 这两个 outlined 图标已不再公开 (只剩 Filled 变体), 编译器报:
```
Unresolved reference. None of the following candidates is applicable because of a receiver type mismatch:
val Icons.Outlined.Build: ImageVector
```

5 处使用 outlined 的位置全部改成 Filled:
- `OdSdkTreeEmpty` (line 798)
- `OdSdkStandaloneRow` 的 REQUIRED 徽标 (line 1086)
- `odSdkGroupIcon()` when 分支: `cmake -> Icons.Filled.Code` 和 `else -> Icons.Filled.Build` (line 1225, 1229)
- `OdAdditionalConfigsBar` 的 CMake chip (line 1322)

注: 用户最早反馈行号 1222/1300/1314 对应的位置在 #389 合入 main 后已被部分手改成 Filled, 这次按合入后的实际状态补全剩下 5 处。

同步把失效的 `outlined.Build` / `outlined.Code` import 删掉, 换成 `filled.Build` / `filled.Code`。

### 2. `items(consoleLogs)` 被错误解析为 `items(count: Int, ...)`
`ActionConfirmAndRunDialog` 和 `OfflineConfirmAndRunDialog` 两个对话框里的 `LazyColumn` 调用了 `items(consoleLogs) { msg -> ... }`, 但文件漏 import `androidx.compose.foundation.lazy.items`, 编译器只能匹配到顶层 `items(count: Int, ...)`, 因此报:
```
Argument type mismatch: actual type is 'SnapshotStateList<String>', but 'Int' was expected.
Unresolved reference 'startsWith'.
None of the following candidates is applicable for `Text(text: ...)`
```

补上 `import androidx.compose.foundation.lazy.items` 即可一次性消除 1712/1715/1716/1719/1930/1933/1934/1937 全部 8 条错误。

## 验证
- `grep -n "Outlined\.\(Build\|Code\)" OdSdkToolInstallFragment.kt` → 0 处
- `grep -n "^import androidx.compose.material.icons.outlined.\(Build\|Code\)$"` → 0 处
- `grep -n "^import androidx.compose.foundation.lazy.items$"` → 1 处
- 沙箱里 gradle 包装器下载失败, 未跑 `./gradlew :core:app:compileApkKotlinStagingDebugKotlin` 验证

## 关联 PR
- 上游 #389 (redesign/od-sdk-install-fragment-ui): 引入这些编译错误的 PR
- #390 已在 main 上, 不受影响