### PR TITLE
fix(od-sdk-install): 父节点点击可展开 + 底部 chip 标签语义化

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
@@ -254,6 +254,11 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
     var selectedJdk by remember { mutableStateOf("17") }
     var jdkExpanded by remember { mutableStateOf(false) }
 
+    // SDK 树父节点展开状态: 用 Compose 可观察的 mutableStateMap, 按节点 id 记录。
+    // 之前直接改 SdkTreeNode.isExpanded 不会触发重组 (StateFlow 拿到的 List 引用未变),
+    // 所以点击父节点子列表不展开。这里改成在 Screen 范围内持有可观察的展开 id 集合。
+    val expandedNodeIds = remember { mutableStateMapOf<String, Boolean>() }
+
     val currentAbi = IDEBuildConfigProvider.getInstance().cpuAbiName
     val context = LocalContext.current
 
@@ -294,6 +299,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
           OdSdkTreeSection(
               isLoading = isLoading,
               treeNodes = treeNodes,
+              expandedNodeIds = expandedNodeIds,
               onNodeCheckChange = { node, newState ->
                 // 强制安装的项 (android-sdk, cmdline-tools) 不可切换
                 if (node.componentType == "android-sdk" ||
@@ -317,7 +323,13 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
                 node.updateParentState()
                 setupViewModel.triggerPendingChangesCheck()
               },
-              onGroupToggle = { group -> group.isExpanded = !group.isExpanded },
+              onGroupToggle = { group ->
+                val isOpen = expandedNodeIds[group.id] == true
+                expandedNodeIds[group.id] = !isOpen
+                // 同步给 SdkTreeNode 自身的 isExpanded 字段, 保留给 SdkManagerViewModel
+                // / SdkRepository 等其他使用方继续读这个字段 (虽然本屏不再依赖它驱动 UI)
+                group.isExpanded = !isOpen
+              },
           )
         }
 
@@ -700,6 +712,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
   private fun OdSdkTreeSection(
       isLoading: Boolean,
       treeNodes: List<SdkTreeNode>,
+      expandedNodeIds: SnapshotStateMap<String, Boolean>,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
       onGroupToggle: (SdkTreeNode) -> Unit,
   ) {
@@ -739,6 +752,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
             OdSdkTopLevelEntry(
                 node = node,
                 index = index,
+                expandedNodeIds = expandedNodeIds,
                 onNodeCheckChange = onNodeCheckChange,
                 onGroupToggle = onGroupToggle,
             )
@@ -814,6 +828,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
   private fun OdSdkTopLevelEntry(
       node: SdkTreeNode,
       index: Int,
+      expandedNodeIds: SnapshotStateMap<String, Boolean>,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
       onGroupToggle: (SdkTreeNode) -> Unit,
   ) {
@@ -830,6 +845,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
       if (node.isGroup) {
         OdSdkGroupCard(
             group = node,
+            expandedNodeIds = expandedNodeIds,
             onGroupToggle = onGroupToggle,
             onNodeCheckChange = onNodeCheckChange,
         )
@@ -842,12 +858,15 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
   @Composable
   private fun OdSdkGroupCard(
       group: SdkTreeNode,
+      expandedNodeIds: SnapshotStateMap<String, Boolean>,
       onGroupToggle: (SdkTreeNode) -> Unit,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
   ) {
     val colors = LocalOdSdkColors.current
     val children = group.children
-    val isExpanded = group.isExpanded
+    // 从可观察的 state map 读, 写入会触发父 / 子 Composable 重组。
+    // 默认未在 map 内的节点视为折叠, 跟 SdkTreeNode.isExpanded 初始 false 一致。
+    val isExpanded = expandedNodeIds[group.id] == true
     val selectedCount = children.count { it.checkedState == ToggleableState.On }
     val totalCount = children.size
     val isSingleSelect = children.firstOrNull()?.componentType in
@@ -1297,28 +1316,28 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
           horizontalArrangement = Arrangement.spacedBy(6.dp),
       ) {
         OdConfigChip(
-            label = "Git",
+            label = "Install Git",
             icon = Icons.Filled.Code,
             checked = installGit,
             onCheckedChange = onInstallGitChange,
             modifier = Modifier.weight(1f),
         )
         OdConfigChip(
-            label = "SSH",
+            label = "Install SSH",
             icon = Icons.Filled.Key,
             checked = installSsh,
             onCheckedChange = onInstallSshChange,
             modifier = Modifier.weight(1f),
         )
         OdConfigChip(
-            label = "NDK Fix",
+            label = "Fix NDK",
             icon = Icons.Filled.Build,
             checked = applyNdkFix,
             onCheckedChange = onApplyNdkFixChange,
             modifier = Modifier.weight(1f),
         )
         OdConfigChip(
-            label = "CMake",
+            label = "Fix CMake",
             icon = Icons.Filled.Code,
             checked = applyCmakePatch,
             onCheckedChange = onApplyCmakePatchChange,


### PR DESCRIPTION
## 背景
在 PR #389 重构后的 `OdSdkToolInstallFragment` 上还有两个交互 / 文案问题:

1. 点击 SDK 树父节点 (Build-Tools / Platform-Tools / NDK / CMake) 没有任何反应, 箭头不旋转, 子节点不展开。
2. 底部配置芯片的文字把动作 (Install / Fix) 和对象 (Git / SSH / NDK / CMake) 混在一起, 看着不像动作, 容易误解成镜像或徽标。

本 PR 把这两个一次性收掉。

## 1. 父节点点击不展开 - 根因 + 修复

**根因**: `SdkTreeNode.isExpanded` 是 data class 上的 `var`, 旧 callback `group.isExpanded = !group.isExpanded` 直接写它。但 `SetupConfigurationScreen` 拿到的 `treeNodes` 是 `StateFlow<List<SdkTreeNode>>`, 只在 list 引用变化时 `collectAsState()` 才会重新 emit; 改某个节点内部 `var` 不会动 list 引用, 所以下层 Composable 不重组, AnimatedVisibility / arrow rotate 都不动。

**修复**: 在 `SetupConfigurationScreen` 范围内持有 `mutableStateMapOf<String, Boolean>()`, 按节点 id 记展开状态, 透传到 `OdSdkTreeSection` -> `OdSdkTopLevelEntry` -> `OdSdkGroupCard`。`OdSdkGroupCard` 用 `expandedNodeIds[group.id] == true` 读 isExpanded, 写入 map 自身会触发父 / 子 Composable 重组。

同时回写 `SdkTreeNode.isExpanded`, 保留给 `SdkManagerViewModel` / `SdkRepository` / 旧 RecyclerView 树等下游消费者继续读这个字段 (虽然本屏不再依赖它驱动 UI)。

## 2. 底部 chip 标签语义化

| 旧 | 新 | 含义 |
|---|---|---|
| `Git` | `Install Git` | `installGit` 装的是 git 这个软件包 |
| `SSH` | `Install SSH` | `installSsh` 装的是 ssh 这个软件包 |
| `NDK Fix` | `Fix NDK` | 软件包是 NDK, 行为是 fix; `Fix` 从后缀改前缀跟下面对齐 |
| `CMake` | `Fix CMake` | 软件包是 CMake, 行为是 fix |

## 改动

```
1 file changed, 25 insertions(+), 6 deletions(-)
```

## 验证
- `grep -n "group.isExpanded = !group.isExpanded"` -> 0 处 (本屏直接写)  
- 4 处 chip 标签用 Edit 工具精确匹配, 不会误伤其他 Git/SSH/NDK/CMake 字样
- 沙箱内 gradle 包装器下载失败, 未跑 `./gradlew :core:app:compileApkKotlinStagingDebugKotlin` 验证

## 关联
- 上游 #389 (redesign): 引入本次要修的展开 bug + 编译错误
- #391 (已合): 收尾 #389 的编译错误
- 本 PR 紧跟 #391 修 #389 漏掉的交互 / 文案问题