### PR TITLE
fix(od-sdk-install): 补上 SnapshotStateMap 缺失的 import

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
@@ -74,6 +74,7 @@ import androidx.compose.material.icons.outlined.Wifi
 import androidx.compose.material.icons.outlined.WifiOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip


### PR DESCRIPTION
## 背景
[PR #392](https://github.com/msmt2018/ZeroStudio/pull/392) 把 `mutableStateMapOf` 的返回类型标成 `SnapshotStateMap<String, Boolean>` 用作参数类型, 但 `SnapshotStateMap` 实际定义在 `androidx.compose.runtime.snapshots` 包, `import androidx.compose.runtime.*` 没有把它的子包导进来, CI 编译失败。

## 编译错误
```
e: OdSdkToolInstallFragment.kt:715:24 Unresolved reference 'SnapshotStateMap'.
e: OdSdkToolInstallFragment.kt:831:24 Unresolved reference 'SnapshotStateMap'.
e: OdSdkToolInstallFragment.kt:861:24 Unresolved reference 'SnapshotStateMap'.
e: OdSdkToolInstallFragment.kt:869:22 Operator '==' cannot be applied to 'MatchGroup?' and 'Boolean'.
```

前 3 条是直接未解析。第 4 条 (`Operator '==' cannot be applied to 'MatchGroup?'`) 是参数类型解析失败导致的连带错误: `expandedNodeIds[group.id]` 推不出 `Boolean?`, 编译器回退到 `Any?` / 错的 overload, 变成 `MatchGroup?`, 所以 `Boolean? == true` 不再合法。

## 修复
新增一行 import:
```kotlin
import androidx.compose.runtime.snapshots.SnapshotStateMap
```

补上后 `expandedNodeIds[group.id]` 类型回到 `Boolean?`, `Boolean? == true` 合法, 4 条错误一次性消除。

## 改动
```
1 file changed, 1 insertion(+)
```

## 验证
- 沙箱内 gradle 包装器下载失败, 未跑 `./gradlew :core:app:compileDebugKotlin`

## 关联
- 上游 #392 (PR #392 的引入)  修复 #392 的编译错误