### PR TITLE
fix(od-sdk-install): 子节点可勾选 + build-tools 多选 + chip 自适应

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
@@ -57,6 +57,8 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
@@ -90,6 +92,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
@@ -260,6 +263,14 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
     // 所以点击父节点子列表不展开。这里改成在 Screen 范围内持有可观察的展开 id 集合。
     val expandedNodeIds = remember { mutableStateMapOf<String, Boolean>() }
 
+    // SDK 树节点勾选状态: 同样用 Compose 可观察的 map, 按节点 id 记录。
+    // 跟 expandedNodeIds 同根问题: 直接改 SdkTreeNode.checkedState 不会触发重组,
+    // 造成子节点点击 "没反应", 折叠再展开又会重新读 data class 字段, 视觉上像
+    // "自动勾选/取消"。这里 map 自身作为可观察 state, 写入即触发子行 + 父徽标
+    // 重组, 同步回写到 data class.checkedState 是给 ViewModel (getInstallTasks
+    // / triggerPendingChangesCheck) 用的, 不能省。
+    val checkedNodeStates = remember { mutableStateMapOf<String, ToggleableState>() }
+
     val currentAbi = IDEBuildConfigProvider.getInstance().cpuAbiName
     val context = LocalContext.current
 
@@ -301,6 +312,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
               isLoading = isLoading,
               treeNodes = treeNodes,
               expandedNodeIds = expandedNodeIds,
+              checkedNodeStates = checkedNodeStates,
               onNodeCheckChange = { node, newState ->
                 // 强制安装的项 (android-sdk, cmdline-tools) 不可切换
                 if (node.componentType == "android-sdk" ||
@@ -308,20 +320,32 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
                   return@OdSdkTreeSection
                 }
                 val parent = node.parent
-                // 单选组: build-tools / platform-tools (同组内只允许一个被勾选)
+                // 单选组: platform-tools 同组内只允许一个被勾选 (build-tools 已
+                // 改多选, 因为用户经常需要并存多个版本用于不同项目)。
                 val isSingleSelectGroup =
                     parent != null &&
                         parent.children
                             .firstOrNull()
                             ?.componentType in
-                            setOf("build-tools", "platform-tools")
+                        setOf("platform-tools")
                 if (isSingleSelectGroup && newState == ToggleableState.On && parent != null) {
                   parent.children.forEach { sibling ->
-                    if (sibling !== node) sibling.checkedState = ToggleableState.Off
+                    if (sibling !== node) {
+                      checkedNodeStates[sibling.id] = ToggleableState.Off
+                      sibling.checkedState = ToggleableState.Off
+                    }
                   }
                 }
+                // 1) 写可观察 map, 触发子行 + 父徽标 重组 (这是修 "子节点无法勾选")
+                checkedNodeStates[node.id] = newState
+                // 2) 回写 data class, 供 ViewModel.getInstallTasks /
+                //    triggerPendingChangesCheck 读 (否则 Action 弹窗列表为空)
                 node.checkedState = newState
+                // 3) 同步更新父级状态, 也写两份
                 node.updateParentState()
+                if (parent != null) {
+                  checkedNodeStates[parent.id] = parent.checkedState
+                }
                 setupViewModel.triggerPendingChangesCheck()
               },
               onGroupToggle = { group ->
@@ -714,6 +738,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
       isLoading: Boolean,
       treeNodes: List<SdkTreeNode>,
       expandedNodeIds: SnapshotStateMap<String, Boolean>,
+      checkedNodeStates: SnapshotStateMap<String, ToggleableState>,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
       onGroupToggle: (SdkTreeNode) -> Unit,
   ) {
@@ -754,6 +779,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
                 node = node,
                 index = index,
                 expandedNodeIds = expandedNodeIds,
+                checkedNodeStates = checkedNodeStates,
                 onNodeCheckChange = onNodeCheckChange,
                 onGroupToggle = onGroupToggle,
             )
@@ -830,6 +856,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
       node: SdkTreeNode,
       index: Int,
       expandedNodeIds: SnapshotStateMap<String, Boolean>,
+      checkedNodeStates: SnapshotStateMap<String, ToggleableState>,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
       onGroupToggle: (SdkTreeNode) -> Unit,
   ) {
@@ -847,6 +874,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
         OdSdkGroupCard(
             group = node,
             expandedNodeIds = expandedNodeIds,
+            checkedNodeStates = checkedNodeStates,
             onGroupToggle = onGroupToggle,
             onNodeCheckChange = onNodeCheckChange,
         )
@@ -860,6 +888,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
   private fun OdSdkGroupCard(
       group: SdkTreeNode,
       expandedNodeIds: SnapshotStateMap<String, Boolean>,
+      checkedNodeStates: SnapshotStateMap<String, ToggleableState>,
       onGroupToggle: (SdkTreeNode) -> Unit,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
   ) {
@@ -868,10 +897,15 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
     // 从可观察的 state map 读, 写入会触发父 / 子 Composable 重组。
     // 默认未在 map 内的节点视为折叠, 跟 SdkTreeNode.isExpanded 初始 false 一致。
     val isExpanded = expandedNodeIds[group.id] == true
-    val selectedCount = children.count { it.checkedState == ToggleableState.On }
+    // 选中数 / 总数: 优先读可观察 map, 没设置过的用 data class 的字段。
+    // 这样用户点击会立刻反映在父徽标, 不再依赖折叠再展开触发重组。
+    val selectedCount =
+        children.count {
+          (checkedNodeStates[it.id] ?: it.checkedState) == ToggleableState.On
+        }
     val totalCount = children.size
-    val isSingleSelect = children.firstOrNull()?.componentType in
-        setOf("build-tools", "platform-tools")
+    // build-tools 改多选, 只剩 platform-tools 单选。
+    val isSingleSelect = children.firstOrNull()?.componentType == "platform-tools"
     val groupIcon = odSdkGroupIcon(group)
     val groupTint = odSdkGroupTint(group, colors)
 
@@ -923,7 +957,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
             modifier = Modifier.weight(1f),
             maxLines = 1,
         )
-        OdSdkGroupStateBadge(group = group, selectedCount = selectedCount, tint = groupTint)
+        OdSdkGroupStateBadge(group = group, selectedCount = selectedCount, checkedNodeStates = checkedNodeStates, tint = groupTint)
       }
 
       // 子节点 - 向右缩进, 形成视觉层次
@@ -950,6 +984,7 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
             OdSdkChildRow(
                 child = child,
                 isSingleSelect = isSingleSelect,
+                checkedNodeStates = checkedNodeStates,
                 onNodeCheckChange = onNodeCheckChange,
             )
             if (i < children.lastIndex) {
@@ -971,12 +1006,15 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
   private fun OdSdkGroupStateBadge(
       group: SdkTreeNode,
       selectedCount: Int,
+      checkedNodeStates: SnapshotStateMap<String, ToggleableState>,
       tint: Color,
   ) {
     val colors = LocalOdSdkColors.current
     val total = group.children.size
+    // 从可观察 map 读父节点状态, 这样子行勾选变化能立刻让父徽标刷新。
+    val groupState = checkedNodeStates[group.id] ?: group.checkedState
     val (text, show) =
-        when (group.checkedState) {
+        when (groupState) {
           ToggleableState.On -> "已选 $selectedCount" to true
           ToggleableState.Indeterminate -> "$selectedCount / $total" to true
           ToggleableState.Off -> "" to false
@@ -1000,10 +1038,14 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
   private fun OdSdkChildRow(
       child: SdkTreeNode,
       isSingleSelect: Boolean,
+      checkedNodeStates: SnapshotStateMap<String, ToggleableState>,
       onNodeCheckChange: (SdkTreeNode, ToggleableState) -> Unit,
   ) {
     val colors = LocalOdSdkColors.current
-    val isChecked = child.checkedState == ToggleableState.On
+    // 读可观察 map, 没设置过就回落到 data class (例如首次进入, 跟 SdkManager
+    // 同步过来的"已安装"状态)。这样用户点完 checkbox / radio 立即可见。
+    val isChecked =
+        (checkedNodeStates[child.id] ?: child.checkedState) == ToggleableState.On
     val isForced =
         child.componentType == "android-sdk" || child.componentType == "cmdline-tools"
 
@@ -1538,12 +1580,26 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
       Spacer(Modifier.width(6.dp))
       Icon(icon, contentDescription = null, tint = fg, modifier = Modifier.size(13.dp))
       Spacer(Modifier.width(4.dp))
-      Text(
-          label,
-          fontSize = 11.sp,
+      // 文字长度不一 ("Install Git" / "Install SSH" / "Fix NDK" / "Fix CMake"),
+      // 4 个 chip 在一行均分宽度, 在 360dp 屏每 chip 约 ~77dp, 11sp 下 "Install
+      // Git" 完整宽度 ≈ 60-65dp, 加 checkbox+icon+padding 容易超界, 之前
+      // maxLines=1 触发了直接截断 (省略号都看不到)。改用 BasicText + autoSize
+      // StepBased: 在 8sp~11sp 之间逐级自动收缩, 保证整词完整显示 + 不换行。
+      BasicText(
+          text = label,
+          autoSize =
+              TextAutoSize.StepBased(
+                  minFontSize = 8.sp,
+                  maxFontSize = 11.sp,
+                  stepSize = 0.5.sp,
+              ),
           fontWeight = if (checked) FontWeight.SemiBold else FontWeight.Medium,
-          color = if (checked) colors.onSurface else colors.onSurfaceVariant,
+          color =
+              if (checked) colors.onSurface else colors.onSurfaceVariant,
           maxLines = 1,
+          softWrap = false,
+          overflow = TextOverflow.Visible,
+          modifier = Modifier.weight(1f).fillMaxWidth(),
       )
     }
   }


### PR DESCRIPTION
## 背景
在 [PR #392](https://github.com/msmt2018/ZeroStudio/pull/392) / [PR #393](https://github.com/msmt2018/ZeroStudio/pull/393) 把父节点展开修好之后, SDK 树还有三个交互 / 排版问题:

1. 子节点点了没反应, 折叠再展开又自己跳一下 (像自动勾选 / 取消)
2. build-tools 只能单选, 但用户经常需要并存多个版本给不同项目
3. 底部 4 个 chip 文字 ("Install Git" / "Install SSH" / "Fix NDK" / "Fix CMake") 在 360dp 屏被硬截断, 看不到省略号

本 PR 把这三个一次性收掉。

## 1. 子节点勾选 (含折叠后自动勾选 / 取消)

**根因**: 跟 #392 修过的 `isExpanded` 是同一个根因。`SdkTreeNode.checkedState` 是 data class 的 `var`, `node.checkedState = newState` 不会触发 Compose 重组 - `treeNodes` 是 `StateFlow<List<SdkTreeNode>>`, list 引用不变就不 emit, `OdSdkChildRow` 读到旧值, 视觉上 "点不动"。

折叠后再展开的 "自动跳" 现象: 用户点完没反应, 折叠再展开, `AnimatedVisibility` 重新进入, 子行重新读 data class 字段 - 此时 data class 已经是新值, 视觉上 "突然自己跳了一下"。再次点击因为看不到前面那次的结果, 容易连点, 折叠再展开又跳一次, 看起来像自动勾选/取消。

**修复**: 加 `checkedNodeStates: SnapshotStateMap<String, ToggleableState>`, 跟 #392 的 `expandedNodeIds` 同套做法。`onNodeCheckChange` 写 map 即触发子行 + 父徽标 重组, 同步回写 `node.checkedState` 是给 ViewModel (`getInstallTasks` / `triggerPendingChangesCheck`) 用的, 不能省。`OdSdkChildRow` / `OdSdkGroupStateBadge` / `OdSdkGroupCard` 的 `selectedCount` 全部改读 `map[id] ?: checkedState` 兜底, 首次进入 / 跟 SdkManager 同步过来的 "已安装" 状态也能正确显示。

## 2. build-tools 改多选

| 组件 | 之前 | 之后 |
|---|---|---|
| build-tools | 单选 (radio) | **多选 (checkbox)**, 默认 latest 勾上 |
| platform-tools | 单选 (radio) | 单选 (radio) |

代码改动: `isSingleSelect = firstOrNull()?.componentType == "platform-tools"`; 单选互斥清空 set 从 `{"build-tools", "platform-tools"}` 缩成 `{"platform-tools"}`; `OdSdkChildRow` 的 `isSingleSelect` 是参数透传, 自动跟着走。

## 3. 底部 chip 文字自适应不换行

360dp 屏 4 个 chip 均分每 chip ≈77dp, 11sp 字号下 "Install Git" 完整宽度 ≈60-65dp, 加 checkbox (16+6=22) + icon (13+4=17) + padding (8*2=16) ≈115dp, 明显超界。`maxLines=1` 之前直接硬截断, 屏幕上看不到省略号。

改用 `BasicText` + `TextAutoSize.StepBased(minFontSize=8sp, maxFontSize=11sp, stepSize=0.5sp)`, 在 8~11sp 之间逐级收缩到刚好放下, 加 `softWrap=false` / `overflow=TextOverflow.Visible` / `weight(1f)`, 保证:
- ① 不换行
- ② 整词完整显示
- ③ 字号能缩到 8sp, 最差也只缩到能放下为止, 不会出省略号

## 改动
```
1 file changed, 69 insertions(+), 13 deletions(-)
```

## 验证
- 沙箱内 gradle 包装器下载失败, 未跑 `./gradlew :core:app:compileDebugKotlin`
- 静态检查:
  - `expandedNodeIds` / `checkedNodeStates` 在所有需要的位置都接住了
  - 父徽标 / 父状态 / 子行 / ViewModel 读值都来自 `map ?: data class` 兜底, 漏读不会发生
  - `BasicText` + `TextAutoSize` 是 Compose 1.7+ 官方 API, 项目 `compose-bom = "2026.05.00"` 已含

## 关联
- 上游 #392 / #393: 父节点展开 (同根问题, 这次把子行也修了)
- #391: 编译错误收尾
- #389 (redesign): 引入本次要修的交互 bug