### PR TITLE
fix(od-sdk-install): BasicText 的 fontWeight/color 进 TextStyle

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/onboarding/OdSdkToolInstallFragment.kt
@@ -90,6 +90,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -1593,9 +1594,13 @@ class OdSdkToolInstallFragment : Fragment(), SlidePolicy {
                   maxFontSize = 11.sp,
                   stepSize = 0.5.sp,
               ),
-          fontWeight = if (checked) FontWeight.SemiBold else FontWeight.Medium,
-          color =
-              if (checked) colors.onSurface else colors.onSurfaceVariant,
+          // BasicText 不接受 fontWeight / color 作顶层参数 (Compose 1.7 签名),
+          // 全部要进 TextStyle。color 同样走 TextStyle.color。
+          style =
+              TextStyle(
+                  fontWeight = if (checked) FontWeight.SemiBold else FontWeight.Medium,
+                  color = if (checked) colors.onSurface else colors.onSurfaceVariant,
+              ),
           maxLines = 1,
           softWrap = false,
           overflow = TextOverflow.Visible,


### PR DESCRIPTION
## 背景
[PR #394](https://github.com/msmt2018/ZeroStudio/pull/394) 把 chip 文字换成 `BasicText` + `TextAutoSize`, 但 `fontWeight` / `color` 被当成 `BasicText` 的顶层参数传, Compose 1.7 之后 `BasicText` 的签名只接 `style: TextStyle` 和 `color: ColorProducer?`, 编译失败。

## 编译错误
```
e: OdSdkToolInstallFragment.kt:1588:7 None of the following candidates is applicable:
  fun BasicText(text: String, modifier: Modifier = ..., style: TextStyle = ..., onTextLayout: ... = ..., overflow: TextOverflow = ..., softWrap: Boolean = ..., maxLines: Int = ..., minLines: Int = ..., color: ColorProducer? = ..., autoSize: TextAutoSize? = ...): Unit
  fun BasicText(text: AnnotatedString, ...): Unit
```

## 修复
`fontWeight` 和 `color` 都进 `TextStyle(...)`, 同步补 import `androidx.compose.ui.text.TextStyle`。`autoSize` 仍是顶层参数 (1.7 才加的), 不动。

## 改动
```
1 file changed, 8 insertions(+), 3 deletions(-)
```

## 验证
- 沙箱内 gradle 包装器下载失败, 未跑 `./gradlew :core:app:compileDebugKotlin`

## 关联
- 上游 #394 (本 PR 修 PR #394 引入的 BasicText 误用)