### PR TITLE
fix: 修复 ProjectManagerPage 添加 tab 崩溃 + compose-preview ToolingServer 未启动崩溃

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/fragments/main/ProjectManagerPage.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/main/ProjectManagerPage.kt
@@ -39,7 +39,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -98,7 +100,15 @@ fun ProjectManagerPage(onOpenProject: (String) -> Unit) {
     }
   }
 
-  val safeSelected = if (tabState.isEmpty()) 0 else selectedTabIndexState.coerceIn(0, tabState.lastIndex)
+  // 把 safeSelected 改成 derivedStateOf, 让它能正确跟踪 tabState.size 和
+  // selectedTabIndexState 的变化, 避免 ScrollableTabRow 内部用旧 size 算
+  // tabPositions 时拿到越界的 selectedTabIndex 触发 IndexOutOfBoundsException。
+  val safeSelected by remember(tabState.size, selectedTabIndexState) {
+    derivedStateOf {
+      if (tabState.isEmpty()) 0
+      else selectedTabIndexState.coerceIn(0, tabState.lastIndex)
+    }
+  }
   if (safeSelected != selectedTabIndexState) selectedTabIndexState = safeSelected
   val selectedTab = tabState.getOrNull(safeSelected)
 
@@ -112,7 +122,10 @@ fun ProjectManagerPage(onOpenProject: (String) -> Unit) {
 
   Column(modifier = Modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
     Box(modifier = Modifier.fillMaxWidth()) {
-      if (tabState.isNotEmpty()) {
+      if (tabState.isNotEmpty() && safeSelected in tabState.indices) {
+        // key(tabState.size) 强制 ScrollableTabRow 在 tab 数量变化时整体重组,
+        // 避免 Material3 内部缓存的 tabIndicators 跟外部传入的 selectedTabIndex 不一致。
+        key(tabState.size) {
         ScrollableTabRow(selectedTabIndex = safeSelected, modifier = Modifier.fillMaxWidth().padding(end = 30.dp)) {
           tabState.forEachIndexed { index, tab ->
             Tab(
@@ -124,6 +137,7 @@ fun ProjectManagerPage(onOpenProject: (String) -> Unit) {
               text = { Text(tab.title, maxLines = 1, overflow = TextOverflow.Ellipsis) }
             )
           }
+        }
         }
       }
       FloatingActionButton(

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -415,6 +415,24 @@ private fun triggerBuild(
         return
     }
 
+    // Tooling server 必须在项目编辑器打开时由 ProjectHandlerActivity 启动
+    // (buildService 不在 compose-preview 模块里自己起 server, 避免与编辑器
+    // 端的 init 流程争抢状态). 未启动时直接告诉用户先去打开项目, 而不是
+    // 让 executeTasks 抛 ToolingServerNotStartedException 炸成未捕获异常。
+    // 这跟 QuickRunWithCancellationAction.onModuleSelected 的兜底一致。
+    if (!buildService.isToolingServerStarted()) {
+        LOG.warn("Tooling server has not been started; ask the user to open the project in the editor first.")
+        viewModel.setBuildFailed()
+        (context as? android.app.Activity)?.runOnUiThread {
+            android.widget.Toast.makeText(
+                context,
+                "请先在编辑器中打开该项目并完成 Gradle 同步, 再使用 Compose 预览。",
+                android.widget.Toast.LENGTH_LONG,
+            ).show()
+        }
+        return
+    }
+
     viewModel.setBuildingState()
 
     val capitalizedVariant = variantName.replaceFirstChar { it.uppercaseChar() }
@@ -424,9 +442,12 @@ private fun triggerBuild(
         "assemble$capitalizedVariant"
     }
 
+    // 与 QuickRunWithCancellationAction.quickRun 一样, 直接向 buildService
+    // 发送 gradle assemble 任务. 构建完成后 dex 被刷新, Compose Preview 通过
+    // classloading + 反射加载最新的 Composable 即可。
     buildService.executeTasks(task).whenComplete { result, error ->
         (context as? android.app.Activity)?.runOnUiThread {
-            if (error != null || !result.isSuccessful) {
+            if (error != null || result?.isSuccessful != true) {
                 viewModel.setBuildFailed()
             } else {
                 viewModel.refreshAfterBuild(context)


### PR DESCRIPTION
## 背景

两份 stack trace 都来自 main 分支当前版本 (becb93e0):

1. **ProjectManagerPage.kt**
   ```
   java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
       at androidx.compose.material3.TabRowKt.ScrollableTabRow_sKfQg0A$lambda$0(TabRow.kt:1411)
   ```
   触发场景: 用户点击 + 添加目标目录到 tab。

2. **ComposePreviewActivity.kt**
   ```
   com.itsaky.androidide.services.ToolingServerNotStartedException: Tooling API server has not been started
       at GradleBuildService.checkServerStarted(GradleBuildService.kt:898)
       at GradleBuildService.executeTasks(GradleBuildService.kt:612)
       at ComposePreviewActivityKt.triggerBuild(ComposePreviewActivity.kt:427)
   ```
   触发场景: 首次进入 Compose Preview 直接点构建, Gradle BuildService 已在 Lookup 中但 Tooling Server 尚未启动。

## 修改

### Commit 1 (`4820b766`): fix(project-manager): 修复添加 tab 时 ScrollableTabRow 越界崩溃

[core/app/.../ProjectManagerPage.kt](core/app/src/main/java/com/itsaky/androidide/fragments/main/ProjectManagerPage.kt)

根因: tabState.add(tab) 同步修改列表后, 下一帧重组里 Material3 内部按 tabState 算出的 tabIndicators 缓存可能尚未刷新 (size 仍是旧值), 但外部传入的 selectedTabIndex 已是新值, 触发 tabPositions[1] 在 length=1 的列表上越界。

修复:
1. safeSelected 改用 `derivedStateOf`, 显式跟踪 `tabState.size` 和 `selectedTabIndexState` 变化, 避免上一帧脏值;
2. 渲染守卫 `safeSelected in tabState.indices`, 即使极短不一致窗口也不渲染越界;
3. `key(tabState.size)` 包裹, tab 数量变化时整棵 ScrollableTabRow 重新挂载, Material3 内部 tabIndicators 缓存干净重建。

### Commit 2 (`ab48c7e3`): fix(compose-preview): 修复 Tooling Server 未启动时点击构建的崩溃

[modules/compose-preview/.../ComposePreviewActivity.kt](modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt) (只这一个文件)

**前一版 (`08e2be35`) 的错误做法**: 试图把 `GradleBuildService.internal fun startToolingServer` 提升为 `BuildService` 接口方法, 让 `compose-preview` 自己启动 server。这个改动是错的 —— `BuildService` 是 core/projects 模块的契约, `GradleBuildService` 是 core/app 模块的具体实现, 改动会强制 `compose-preview` 模块承担本不该承担的 server 启动责任, 而且跟 `ProjectHandlerActivity.onGradleBuildServiceConnected` 端的 init 流程争抢内部 `toolingServerRunner` 状态, 反而把整个构建服务搞挂, assemble 任务无法真正执行, dex 也不会被刷新。所以这一版 (`ab48c7e3`) 撤回了 `BuildService.kt` 和 `GradleBuildService.kt` 的所有修改, 跟 `becb93e0` 完全一致。

**正确做法** (跟 `QuickRunWithCancellationAction.onModuleSelected` 保持一致):

- Tooling server 启动责任仍归 `ProjectHandlerActivity`, 这是项目编辑器打开时 `onGradleBuildServiceConnected` 的固定流程, 不在 `compose-preview` 这边越界动手。
- `compose-preview` 在 `triggerBuild` 里 `executeTasks` 前先检查 `isToolingServerStarted()`, 未启动时直接 toast 提示用户「请先在编辑器中打开该项目并完成 Gradle 同步」, 并把 viewModel 切到 failed 态, 不再冒泡异常。
- 已启动时照常 `executeTasks(task)` (形如 `:app:assembleDebug`), assemble 完成后 dex 刷新, Compose Preview 通过 classloading + 反射加载最新 Composable 即可。

## 文件清单 (本 PR 最终状态)

- `core/app/src/main/java/com/itsaky/androidide/fragments/main/ProjectManagerPage.kt`
- `modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt`

未触碰 `BuildService` 或 `GradleBuildService`, 不动 `BuildService` 契约。

## 验证

- 不需要新增测试, 改动是行为修正而非新功能。
- ProjectManagerPage: safeSelected 数值与原行为完全一致, 仅添加越界守卫。
- ComposePreview: 未启动 server 时不再抛异常, 而是 toast 提示; 已启动时 assemble 任务正常下发, dex 刷新, 跟 QuickRunWithCancellationAction 同语义。

Co-authored-by: traeagent <traeagent@users.noreply.github.com>