### PR TITLE
fix(editor): IME 软键盘弹起时自动折叠 BottomSheet, 让符号栏顶部同步到 IME 顶部

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -85,6 +85,12 @@ class EditorBottomSheet @JvmOverloads constructor(
   @JvmField var binding: LayoutEditorBottomSheetBinding
   val pagerAdapter: EditorBottomSheetTabAdapter
 
+  // ==== IME 软键盘顶部同步相关字段 ====
+  // 记录上一次 IME 可见性, 用于在 IME 状态切换时做 BottomSheet 状态联动.
+  // 不使用更复杂的 diff 监听, 因为 WindowInsets API 在动画过程中会一帧一帧回调,
+  // 单纯比较 boolean 即可精确捕获"打开/关闭"两个边界.
+  private var wasImeVisible = false
+
   private val behavior: BottomSheetBehavior<EditorBottomSheet> by lazy {
     BottomSheetBehavior.from(this).apply {
       isFitToContents = false
@@ -247,6 +253,31 @@ class EditorBottomSheet @JvmOverloads constructor(
     val navInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
     val isImeVisibleNow = insets.isVisible(WindowInsetsCompat.Type.ime())
     val targetBottomInset = if (isImeVisibleNow) imeInsets.bottom else navInsets.bottom
+
+    // ==== IME 软键盘打开/关闭 与 BottomSheet 状态联动 ====
+    // 设计目标: IME 弹起时, 底部符号输入控件 (AdvancedSymbolInputView) 的顶部
+    // 自动同步到 IME 顶部, 同时四个层级 (bubble / build_status / header / symbol_input)
+    // 一起跟着 IME 上下移动, 视觉绑定关系不破坏.
+    //
+    // 实现: IME 弹起时, 如果 BottomSheet 处于展开/半展开/拖拽中的"打开"状态, 先把
+    // 它折叠到 STATE_COLLAPSED. 折叠后, floating_header_area 的底部 (即 symbol_input
+    // 的底部) 就被 peekHeight 钉在屏幕底部, peekHeight 包含 IME 高度, 所以 symbol_input
+    // 的底部正好落在 IME 顶部. IME 关闭时, 不自动恢复 BottomSheet 状态, 让用户自己
+    // 决定要不要再展开抽屉 (避免频繁的自动展开/折叠打扰用户).
+    //
+    // 不在 onStateChanged 里做: 那个回调在 BottomSheet 自己的动画过程中也会触发, 会
+    // 和 IME 状态变化抢着切状态. 在这里做是单点控制, 逻辑最清晰.
+    if (isImeVisibleNow != wasImeVisible) {
+      if (isImeVisibleNow) {
+        if (behavior.state == BottomSheetBehavior.STATE_EXPANDED ||
+            behavior.state == BottomSheetBehavior.STATE_HALF_EXPANDED ||
+            behavior.state == BottomSheetBehavior.STATE_DRAGGING) {
+          behavior.state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+      }
+      wasImeVisible = isImeVisibleNow
+    }
+
     updateBottomInset(targetBottomInset)
   }
 


### PR DESCRIPTION
## 背景

之前 (PR2 之前) 的 IME 同步逻辑: 不管 IME 是否弹起, 都不动 BottomSheet 的 state, 只更新 `spaceBottom.height` + `behavior.peekHeight`. 这在 BottomSheet 处于 `STATE_COLLAPSED` 时没问题, 因为 peekHeight 直接控制 floating_header_area 的位置, symbol_input 的底部正好落在 IME 顶部.

但当 BottomSheet 处于 `STATE_EXPANDED` / `STATE_HALF_EXPANDED` / `STATE_DRAGGING` 时, peekHeight 完全不生效 (Material BottomSheetBehavior 的规则), 结果:
- symbol_input 仍然停留在屏幕顶部
- IME 直接盖在 BottomSheet 内容上面
- 用户看不到符号栏, 只能在屏幕顶部那个看不见的地方盲打

## 修复

在 `applyEditorWindowInsets` 里检测 IME 可见性切换, 一旦 IME 弹起:
- 如果 BottomSheet 当前是展开/半展开/拖拽中的"打开"状态, 强制折叠到 `STATE_COLLAPSED`
- 折叠后 peekHeight 才能真正生效, symbol_input 跟着 floating_header_area 一起上移到 IME 顶部, 四个层级 (bubble / build_status / header / symbol_input) 的视觉绑定关系完全保留, 不会被打散
- IME 关闭时, 不自动恢复 BottomSheet 状态, 让用户自己决定要不要再展开抽屉 (避免频繁的自动展开/折叠打扰用户)

## 设计决策

### 为什么不在 `onStateChanged` 里做

onStateChanged 在 BottomSheet 自己的拖拽/吸附动画过程中也会触发, 会和 IME 状态变化抢着切状态, 出现"开了 IME 又被 BottomSheet 自己切回去"的抖动. 在 `applyEditorWindowInsets` 里做是单点控制, 唯一调用路径.

### 为什么是 `STATE_DRAGGING` 也要兜底

用户正在拖拽 BottomSheet 的时候按软键盘 (例如屏幕外接键盘按回车), 也要把抽屉折叠到 collapsed, 否则 peekHeight 仍然不生效.

### 四层级绑定关系验证 (没有破坏)

- `floating_header_area` 的子节点: `page_switch_gesture_bubble` (bubble) / `header_content_wrapper` (含 build_status) / `header_divider` / `external_symbol_input_view`
- peekHeight 改变时, BottomSheet 的 top 改变, floating_header_area 跟着移动, 四个子节点相对位置保持不变, 视觉绑定完全保留
- 这次只改 applyEditorWindowInsets 一处, 不动 floating_header_area / 四个子节点的布局和 binding 关系

## 改动文件

- `core/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt` (+31 行)

## 不改的文件 (验证过不需要改)

- `core/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt` — `onApplyWindowInsets` 的 IME dispatch 路径已经正确, `contentCard.bottomMargin` 已经设过, `content.bottomSheet.applyEditorWindowInsets(insets)` 也会调到本次修改的函数
- `core/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt` — 无 IME 相关代码
- `modules/zero-Symbol-input-view/.../AdvancedSymbolInputView.kt` — 符号输入控件是 passive view, 不直接处理 IME insets, 它的位置由父级 floating_header_area 决定, 不需要单独改

## 测试

- [ ] BottomSheet 处于 STATE_COLLAPSED 时弹起 IME, 符号栏顶部同步到 IME 顶部, 抽屉保持折叠
- [ ] BottomSheet 处于 STATE_HALF_EXPANDED 时弹起 IME, 抽屉自动折叠到 STATE_COLLAPSED, 符号栏顶部同步到 IME 顶部
- [ ] BottomSheet 处于 STATE_EXPANDED 时弹起 IME, 抽屉自动折叠到 STATE_COLLAPSED, 符号栏顶部同步到 IME 顶部
- [ ] 拖拽 BottomSheet 过程中弹起 IME, 抽屉自动折叠到 STATE_COLLAPSED
- [ ] IME 关闭后, 抽屉保持 STATE_COLLAPSED (不自动恢复, 用户可手动展开)
- [ ] 四个层级 (bubble / build_status / header / symbol_input) 视觉绑定关系不破坏
