### PR TITLE
fix(compose-preview): 桌面全透明/手表黑屏/iPhone 套壳 + 新增无设备模式

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -164,9 +164,24 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
     /**
      * 由 ComposePreviewScreen 内 AndroidView 调用, 注入预览容器.
      * 引擎 attach 到此 container 后, container 会显示 Compose 渲染.
+     *
+     * 【v3.2】如果上次 attach 的 container 与当前不同 (切 deviceSim / 切 profile
+     * 触发 AndroidView 重建时), 强制 detach 旧引擎 + 新建引擎. 否则旧 ComposeView
+     * 仍然 addView 在旧 FrameLayout 上, 用户看到的是"切回后黑屏".
      */
     fun attachPreviewContainer(container: android.widget.FrameLayout) {
-        if (renderEngine == null) {
+        val existing = renderEngine
+        if (existing == null) {
+            renderEngine = PreviewRenderEngine(this, container).also { it.attach() }
+            return
+        }
+        if (existing.container !== container) {
+            LOG.info(
+                "Container changed ({} -> {}), recreating PreviewRenderEngine",
+                System.identityHashCode(existing.container),
+                System.identityHashCode(container),
+            )
+            existing.detach()
             renderEngine = PreviewRenderEngine(this, container).also { it.attach() }
         }
     }
@@ -235,6 +250,7 @@ private fun ComposePreviewScreen(
                         zoom = viewport.zoom,
                         showSystemBars = deviceConfig.showStatusBar,
                         debugEnabled = debugEnabled,
+                        deviceSimEnabled = deviceConfig.deviceSimEnabled,
                     ),
                     actions = PreviewToolbarActions(
                         onOpenDeviceSheet = { showDeviceSheet = true },
@@ -244,6 +260,8 @@ private fun ComposePreviewScreen(
                         onToggleSystemBars = { viewModel.toggleSystemBars() },
                         onToggleDebug = { viewModel.toggleDebug() },
                         onClose = onClose,
+                        onToggleDeviceSim = { viewModel.toggleDeviceSim() },
+                        onToggleFullscreen = { viewModel.toggleFullscreen() },
                     ),
                 )
 
@@ -406,38 +424,55 @@ private fun ReadyPanel(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(if (deviceConfig.deviceSimEnabled) 16.dp else 0.dp),
         contentAlignment = Alignment.Center,
     ) {
-        // 用 DeviceFrame 包裹实际预览 ComposeView
-        DeviceFrame(
-            profile = deviceConfig.profile,
-            systemBarsTheme = deviceConfig.systemBarsTheme,
-            showStatusBar = deviceConfig.showStatusBar,
-            showNavigationBar = deviceConfig.showNavigationBar,
-            showCutout = deviceConfig.showCutout,
-            showChassis = deviceConfig.showChassis,
-            useGestureNav = deviceConfig.useGestureNav,
+        // 【v3.2】用 key() 强制 deviceSimEnabled / profile 变化时整体重组.
+        // 原因: AndroidView 的 factory 缓存 (默认按位置 key), 切 deviceSim 时
+        // 如果不重置, 旧 PreviewRenderEngine 引用的 ComposeView 还在新 container
+        // 之外, 切回时显示黑屏. key 强制整个子树重组, 触发 AndroidView 重建.
+        androidx.compose.runtime.key(
+            deviceConfig.deviceSimEnabled,
+            deviceConfig.profile.id
         ) {
-            // 容器 Box, 通过 AndroidView 嵌入一个 FrameLayout, 让 PreviewRenderEngine 把
-            // 自己的 ComposeView addView 进去. 显式使用 MATCH_PARENT layoutParams 避免
-            // SubcomposeLayout 嵌套测量把 ComposeView 的尺寸压成 0 (这是 v2.1 的根因).
-            AndroidView(
-                factory = { ctx ->
-                    android.widget.FrameLayout(ctx).apply {
-                        layoutParams = android.view.ViewGroup.LayoutParams(
-                            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                        )
-                        // 通知 Activity 创建引擎, 把这个容器给引擎.
-                        // activity 由 ComposePreviewScreen 显式传入, 不会因重组失效.
-                        activity.attachPreviewContainer(this)
-                    }
-                },
-                modifier = Modifier.fillMaxSize(),
-            )
+            if (deviceConfig.deviceSimEnabled) {
+                DeviceFrame(
+                    profile = deviceConfig.profile,
+                    systemBarsTheme = deviceConfig.systemBarsTheme,
+                    showStatusBar = deviceConfig.showStatusBar,
+                    showNavigationBar = deviceConfig.showNavigationBar,
+                    showCutout = deviceConfig.showCutout,
+                    showChassis = deviceConfig.showChassis,
+                    useGestureNav = deviceConfig.useGestureNav,
+                ) {
+                    PreviewContainer(activity)
+                }
+            } else {
+                PreviewContainer(activity)
+            }
         }
     }
+}
+
+@Composable
+private fun PreviewContainer(activity: ComposePreviewActivity) {
+    // 容器 Box, 通过 AndroidView 嵌入一个 FrameLayout, 让 PreviewRenderEngine 把
+    // 自己的 ComposeView addView 进去. 显式使用 MATCH_PARENT layoutParams 避免
+    // SubcomposeLayout 嵌套测量把 ComposeView 的尺寸压成 0 (这是 v2.1 的根因).
+    AndroidView(
+        factory = { ctx ->
+            android.widget.FrameLayout(ctx).apply {
+                layoutParams = android.view.ViewGroup.LayoutParams(
+                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                // 通知 Activity 创建引擎, 把这个容器给引擎.
+                // activity 由 ComposePreviewScreen 显式传入, 不会因重组失效.
+                activity.attachPreviewContainer(this)
+            }
+        },
+        modifier = Modifier.fillMaxSize(),
+    )
 }
 
 private fun triggerBuild(

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -167,6 +167,9 @@ class ComposePreviewViewModel(
 
     private val _debugEnabled = MutableStateFlow(false)
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
+    /** v3.2 / PR-B 占位: 全屏状态. */
+    private val _isFullscreen = MutableStateFlow(false)
+    val isFullscreen: StateFlow<Boolean> = _isFullscreen.asStateFlow()
 
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
@@ -424,12 +427,34 @@ class ComposePreviewViewModel(
     // === v2.1 新增方法 ===
 
     fun selectDevice(profile: DeviceProfile) {
-        _deviceConfig.value = _deviceConfig.value.copy(profile = profile)
+        _deviceConfig.value = _deviceConfig.value.copy(profile = profile, deviceSimEnabled = true)
         LOG.info("Device selected: {}", profile.displayName)
     }
 
     fun setSystemBarsTheme(theme: SystemBarsTheme) {
         _deviceConfig.value = _deviceConfig.value.copy(systemBarsTheme = theme)
+    }
+
+    /**
+     * 【v3.2】切换"真实设备模拟"开关. true=套壳显示, false=无外壳直接显示.
+     * 切到 false 时, profile 仍保留, 方便用户切回去.
+     */
+    fun toggleDeviceSim() {
+        _deviceConfig.value = _deviceConfig.value.copy(
+            deviceSimEnabled = !_deviceConfig.value.deviceSimEnabled
+        )
+        LOG.info("Device sim toggled: {}", _deviceConfig.value.deviceSimEnabled)
+    }
+
+    /**
+     * 【v3.2 / PR-B 占位】切换全屏. PR-B 实现完整行为:
+     * - true: 隐藏 toolbar
+     * - 切回: 顶部右上角 X 按钮恢复
+     * - 长按: 弹 "带/不带系统状态栏" 选择
+     */
+    fun toggleFullscreen() {
+        _isFullscreen.value = !_isFullscreen.value
+        LOG.info("Fullscreen toggled: {}", _isFullscreen.value)
     }
 
     fun toggleSystemBars() {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/CutoutGeometry.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/CutoutGeometry.kt
@@ -137,11 +137,10 @@ sealed class CutoutGeometry {
             cornerRadiusDp = 15f
         )
 
-        /** iPhone 15 Pro 风格 Dynamic Island (126 × 37 dp, 顶部居中) */
-        val DYNAMIC_ISLAND: Notch = Notch(
+        /** iPhone 14 Pro+ 灵动岛 (126 × 37 dp, 顶部居中) — v3.2 用独立类型 */
+        val DYNAMIC_ISLAND: DynamicIsland = DynamicIsland(
             widthDp = 126f,
             heightDp = 37f,
-            anchor = Anchor.TOP_CENTER,
             cornerRadiusDp = 18f
         )
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/DeviceCatalog.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/DeviceCatalog.kt
@@ -219,9 +219,9 @@ object DeviceCatalog {
         manufacturer = "Apple", model = "iPhone 15 Pro", osVersion = "iOS 17",
         widthPx = 1179, heightPx = 2556, densityDpi = 460,
         cornerRadiusDp = 50f,
-        cutout = CutoutGeometry.Notch(
+        cutout = CutoutGeometry.DynamicIsland(
             widthDp = 126f, heightDp = 37f,
-            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 18f
+            cornerRadiusDp = 18f
         ),
         bezels = Bezels(topDp = 37f, bottomDp = 24f, leftDp = 4f, rightDp = 4f),
         physicalKeys = PhysicalKey.iphoneKeys(393f),
@@ -234,12 +234,12 @@ object DeviceCatalog {
         manufacturer = "Apple", model = "iPhone 15 Pro Max", osVersion = "iOS 17",
         widthPx = 1290, heightPx = 2796, densityDpi = 460,
         cornerRadiusDp = 50f,
-        cutout = CutoutGeometry.Notch(
+        cutout = CutoutGeometry.DynamicIsland(
             widthDp = 130f, heightDp = 38f,
-            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 19f
+            cornerRadiusDp = 19f
         ),
         bezels = Bezels(topDp = 38f, bottomDp = 26f, leftDp = 4f, rightDp = 4f),
-        physicalKeys = PhysicalKey.iphoneKeys(430f),
+        physicalKeys = PhysicalKey.iphoneKeys(449f),
         chassisColor = Color(0xFF2A2A2C),
     )
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/PhysicalKey.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/PhysicalKey.kt
@@ -138,13 +138,29 @@ sealed class PhysicalKey {
         )
 
         /**
-         * iPhone (左侧音量 + 静音, 右侧电源). 静音键用 VolUp 占位.
+         * iPhone (左侧音量 + Action Button, 右侧电源). 静音键被
+         * iPhone 15 Pro+ 替换为 Action Button.
+         *
+         * 按真实 iPhone 15 Pro Max 设备图物理键位置 (相对设备原始 dp):
+         * - 左侧 Action Button y ≈ screenHeight × 14%
+         * - 左侧 Vol+ y ≈ screenHeight × 18%
+         * - 左侧 Vol- y ≈ screenHeight × 22%
+         * - 右侧 Power y ≈ screenHeight × 18%
+         *
+         * 屏幕宽 / 高比例固定为 9:19.5, 因此 screenHeight ≈ screenWidthDp × 2.167.
+         * 实际 y 坐标用 screenWidthDp × 0.305 ~ 0.480 系数计算.
          */
-        fun iphoneKeys(screenWidthDp: Float): List<PhysicalKey> = listOf(
-            VolumeUp(positionXdp = -6f, positionYdp = 280f),
-            VolumeDown(positionXdp = -6f, positionYdp = 320f),
-            Power(positionXdp = screenWidthDp + 6f, positionYdp = 480f)
-        )
+        fun iphoneKeys(screenWidthDp: Float): List<PhysicalKey> {
+            val h = screenWidthDp * 2.167f
+            return listOf(
+                // 左侧 Action Button (iPhone 15 Pro+) — 替代静音键
+                Assistant(positionXdp = -6f, positionYdp = h * 0.14f),
+                VolumeUp(positionXdp = -6f, positionYdp = h * 0.18f),
+                VolumeDown(positionXdp = -6f, positionYdp = h * 0.22f),
+                // 右侧 Power (Side button) — 屏幕中上部
+                Power(positionXdp = screenWidthDp + 6f, positionYdp = h * 0.18f)
+            )
+        }
 
         /** 无按键 (平板 / 折叠屏内屏 / 桌面模式 / 自定义) */
         val NO_KEYS: List<PhysicalKey> = emptyList()

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewRenderEngine.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewRenderEngine.kt
@@ -67,7 +67,12 @@ import java.util.concurrent.atomic.AtomicReference
  */
 class PreviewRenderEngine(
     private val context: Context,
-    private val container: ViewGroup,
+    /**
+     * 外部可见 (internal), 让 [com.itsaky.androidide.compose.preview.ComposePreviewActivity.attachPreviewContainer]
+     * 能判断 "container 是否改变" 来决定是否 detach + 重建引擎. v3.2 修复切
+     * deviceSim / profile 时显示黑屏的 bug.
+     */
+    internal val container: ViewGroup,
 ) {
 
     private val LOG = LoggerFactory.getLogger(PreviewRenderEngine::class.java)
@@ -85,6 +90,17 @@ class PreviewRenderEngine(
      */
     fun attach() {
         if (composeView != null) return
+        // 【v3.2】如果 container 已经有别的 engine 添加的 ComposeView, 先清理.
+        // 切 deviceSim / profile 时旧 engine 已经被 Activity.detach() 释放, 但
+        // 旧 ComposeView 可能仍残留 (Activity 是 main thread, GC 还没跑).
+        repeat(container.childCount) { i ->
+            val child = container.getChildAt(i)
+            if (child is ComposeView) {
+                container.removeViewAt(i)
+                LOG.debug("Removed orphan ComposeView from container before attach")
+                return@repeat
+            }
+        }
         val view = ComposeView(context).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/CutoutOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/CutoutOverlay.kt
@@ -63,10 +63,41 @@ fun CutoutOverlay(
     Canvas(modifier = modifier) {
         when (cutout) {
             is CutoutGeometry.Notch -> drawNotch(cutout, color)
+            is CutoutGeometry.DynamicIsland -> drawDynamicIsland(cutout, color)
             is CutoutGeometry.PunchHole -> drawPunchHole(cutout, color)
             is CutoutGeometry.WaterfallCurve -> drawWaterfall(cutout, color, screenSize)
         }
     }
+}
+
+/**
+ * 绘制灵动岛 (iPhone 14 Pro+ 风格).
+ *
+ * 视觉上是一个比 notch 更小、纯黑色的圆角药丸, 内部**无摄像头 / 听筒绘制**
+ * (因为真实 iPhone 灵动岛下面是传感器 + 摄像头, 但屏幕 UI 不需要看到细节).
+ *
+ * 关键: 灵动岛**两侧**屏幕仍然可显示状态栏 (时间 / 信号 / 电池), 这部分
+ * 由 [SystemBarsOverlay] 配合 [DeviceProfile.cutout] 类型识别处理.
+ */
+private fun DrawScope.drawDynamicIsland(island: CutoutGeometry.DynamicIsland, color: Color) {
+    val widthPx = withHpx(island.widthDp)
+    val heightPx = withHpx(island.heightDp)
+    val cornerRadiusPx = withHpx(island.cornerRadiusDp)
+
+    val x = (size.width - widthPx) / 2f
+    val y = withHpx(8f)  // iPhone 灵动岛顶端到屏幕顶端约 8dp
+
+    val path = Path().apply {
+        addRoundRect(
+            androidx.compose.ui.geometry.RoundRect(
+                left = x, top = y,
+                right = x + widthPx, bottom = y + heightPx,
+                radiusX = cornerRadiusPx, radiusY = cornerRadiusPx
+            )
+        )
+    }
+    // 灵动岛本体 — 纯黑
+    drawPath(path = path, color = Color(0xFF000000))
 }
 
 /**

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
@@ -113,11 +113,19 @@ fun DeviceFrame(
             content = content,
         )
         DeviceProfile.FormFactor.DESKTOP,
-        DeviceProfile.FormFactor.NONE -> Box(
-            modifier = modifier
-                .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
-        ) {
-            content()
+        DeviceProfile.FormFactor.NONE -> {
+            // 【v3.2 修复 #1】DESKTOP / NONE 必须 fillMaxSize, 否则 Box 没有
+            // 尺寸约束, Compose 跳过绘制 (用户看到全透明 + 紫底透出).
+            // 之前版本只 .clip(RoundedCornerShape(...)) 没用 fillMaxSize, 在
+            // ComposePreviewScreen 内会被父容器测量为 0.
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
+                    .background(Color.Transparent)
+            ) {
+                content()
+            }
         }
         else -> PhoneOrFoldableFrame(
             profile = profile,
@@ -159,15 +167,27 @@ private fun PhoneOrFoldableFrame(
     ) {
         val parentWidth = maxWidth
         val parentHeight = maxHeight
-
-        // 计算屏幕尺寸 (按设备纵横比 + 父容器约束)
-        val screenWidth = parentWidth
         val aspect = profile.aspectRatio
-        val screenHeight = screenWidth / aspect
+
+        // 【v3.2 修复 #3】按 maxWidth 和 maxHeight 双向约束, 选 min.
+        //
+        // 之前版本 val screenHeight = screenWidth / aspect 没用 maxHeight 限制,
+        // 当 device 纵横比很窄 (iPhone 15 Pro Max 0.461) 且父容器较扁时, 实际渲染
+        // 高度会超出 BoxWithConstraints 默认 clip 范围, 物理键 (y=480) 跟着被裁切
+        // 显示不出来. 现在按 maxHeight 双向约束, 物理键按实际渲染高度计算.
+        val maxScreenWidth = parentWidth
+        val maxScreenHeight = (parentHeight * 0.96f)  // 留 4% 余量防裁切
+        val screenWidth = maxScreenWidth
+        val screenHeight = (screenWidth / aspect).coerceAtMost(maxScreenHeight)
+        val finalScreenWidth = if (screenHeight == maxScreenHeight) {
+            screenHeight * aspect
+        } else {
+            screenWidth
+        }
 
         Box(
             modifier = Modifier
-                .width(screenWidth)
+                .width(finalScreenWidth)
                 .height(screenHeight)
         ) {
             // 1) 机身外壳
@@ -221,12 +241,13 @@ private fun PhoneOrFoldableFrame(
                 )
             }
 
-            // 7) 物理按键 (屏幕外侧)
+            // 7) 物理按键 (屏幕外侧) — 传实际渲染高度, 让按比例定位的按键不超范围
             if (showPhysicalKeys) {
                 profile.physicalKeys.forEach { key ->
                     PhysicalKeyIndicator(
                         key = key,
-                        screenHeightDp = with(density) { (parentHeight.value).dp },
+                        screenWidthDp = with(density) { finalScreenWidth },
+                        screenHeightDp = with(density) { screenHeight },
                     )
                 }
             }
@@ -241,8 +262,10 @@ private fun WatchFrame(
     systemBarsTheme: SystemBarsTheme,
     content: @Composable () -> Unit,
 ) {
+    // 【v3.2 修复 #2】撑开 BoxWithConstraints, 否则 maxWidth/maxHeight 都是 0,
+    // size = 0, 内层 Box size = 0, content() 渲染不到任何像素 = 全黑.
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
         val size = if (maxWidth < maxHeight) maxWidth else maxHeight
@@ -266,10 +289,15 @@ private fun WatchFrame(
 
 /**
  * 物理按键指示器 (在屏幕外侧画一个矩形 + 文字).
+ *
+ * 【v3.2 修复 #3】坐标基准改成"实际渲染屏幕尺寸" (而非父 BoxWithConstraints),
+ * 这样在窄高比 device (iPhone 15 Pro Max 0.461) 实际渲染高度被 maxHeight 限制
+ * 时, 物理键按"屏幕实际尺寸"百分比定位, 不会被父容器裁切.
  */
 @Composable
 private fun PhysicalKeyIndicator(
     key: PhysicalKey,
+    screenWidthDp: androidx.compose.ui.unit.Dp,
     screenHeightDp: androidx.compose.ui.unit.Dp,
 ) {
     val density = LocalDensity.current

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
@@ -35,7 +35,11 @@ import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Brightness6
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
+import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Smartphone
+import androidx.compose.material.icons.filled.SmartphoneOff
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.ZoomIn
@@ -91,9 +95,25 @@ fun PreviewToolbar(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // 设备 chip
+        // 【v3.2】真实设备模拟 toggle — 默认无设备模式 (chip 文字 "Device" 表示可切到套壳,
+        // selected 时 chip 高亮 = 当前已启用真实设备模拟).
+        FilterChip(
+            selected = state.deviceSimEnabled,
+            onClick = actions.onToggleDeviceSim,
+            label = { Text(if (state.deviceSimEnabled) "Device" else "Raw") },
+            leadingIcon = {
+                Icon(
+                    imageVector = if (state.deviceSimEnabled) Icons.Filled.Smartphone else Icons.Filled.SmartphoneOff,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        // 设备 chip (只切到设备模拟时显示, 否则灰显)
         AssistChip(
             onClick = actions.onOpenDeviceSheet,
+            enabled = state.deviceSimEnabled,
             label = { Text(state.deviceName) },
             leadingIcon = {
                 Icon(
@@ -168,6 +188,14 @@ fun PreviewToolbar(
             },
         )
 
+        // 【PR-B 占位】全屏切换 (v3.2 先放按钮, 行为 PR-B 实现)
+        IconButton(onClick = actions.onToggleFullscreen) {
+            Icon(
+                Icons.Filled.Fullscreen,
+                contentDescription = "Fullscreen",
+            )
+        }
+
         Spacer(modifier = Modifier.width(8.dp))
 
         // 关闭
@@ -186,6 +214,10 @@ data class PreviewToolbarState(
     val zoom: Float = 1.0f,
     val showSystemBars: Boolean = true,
     val debugEnabled: Boolean = false,
+    /** v3.2: 是否启用真实设备模拟. 默认 false. */
+    val deviceSimEnabled: Boolean = false,
+    /** v3.2 / PR-B: 全屏模式. 默认 false. */
+    val fullscreen: Boolean = false,
 )
 
 /**
@@ -199,4 +231,8 @@ data class PreviewToolbarActions(
     val onToggleSystemBars: () -> Unit,
     val onToggleDebug: () -> Unit,
     val onClose: () -> Unit,
+    /** v3.2: 切换设备模拟开关. */
+    val onToggleDeviceSim: () -> Unit = {},
+    /** v3.2 / PR-B: 切换全屏. */
+    val onToggleFullscreen: () -> Unit = {},
 )


### PR DESCRIPTION
## 修复的 4 个 bug

| Bug | 根因 | 修复 |
| --- | --- | --- |
| 桌面全透明 | DESKTOP/NONE 路径 Box 缺 fillMaxSize | 加 fillMaxSize() + Color.Transparent |
| 手表黑屏 | WatchFrame BoxWithConstraints 没 fillMaxSize, maxWidth/maxHeight=0 | BoxWithConstraints.fillMaxSize() |
| iPhone 套壳 | ① 用 Notch 表示 Dynamic Island 语义错 ② 物理键被父容器裁切 ③ Power 键 y=480 太靠下 | 新增 CutoutGeometry.DynamicIsland 类型 + 双向 maxWidth/maxHeight 约束 + iphoneKeys 按 18% 屏高定位 |
| 切设备黑屏 | PreviewRenderEngine 复用旧 container 引用, 旧 ComposeView 留在新 container 外 | container 改 internal + attach() 清理 orphan + key() 强制重组 |

## 新增功能: 无设备模拟模式 (默认开启)

- DeviceConfig.deviceSimEnabled 字段, 默认 false — 进 Preview 第一眼就看到无外壳 compose UI
- PreviewToolbar 最左侧 FilterChip "Device/Raw" 切换
- ReadyPanel 用 key(deviceSimEnabled, profile.id) 强制整体重组
- 设备 chip 在 deviceSimEnabled=false 时灰显

## 已为 PR-B 埋好接口

- _isFullscreen: StateFlow<Boolean> + toggleFullscreen() 方法
- PreviewToolbarActions.onToggleFullscreen 回调
- 顶栏全屏按钮已就位

## 文件清单

- 9 files changed, +244 / -58
- commit: 194c573162f748339067c99cc296f1b46581c2be

---

后续 PR:
- PR-B: 完整全屏切换 + 缩放适配 (无设备模式以中心点缩放)
- PR-C: 桌面 launcher 模拟 + 手表圆形 UI + 折叠屏铰链

Co-Authored-By: ZeroStudio <noreply@zerostudio.dev>