### PR TITLE
feat(compose-preview): 完整全屏切换 + 缩放适配

### DIFF
--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -31,14 +31,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,10 +51,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -186,6 +196,38 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
         }
     }
 
+    /**
+     * 【PR-B】应用全屏模式到 Activity 的 window insets controller.
+     *
+     * - [FullscreenMode.OFF]: 显示系统状态栏 + 导航栏.
+     * - [FullscreenMode.WITH_SYSTEM_BARS]: 全屏, 但保留系统状态栏 (用户能在顶部看到时间 / 信号).
+     * - [FullscreenMode.WITHOUT_SYSTEM_BARS]: 沉浸式全屏, 隐藏系统栏, 适合看沉浸式 UI.
+     *
+     * 用户在 Preview 内点击设备套壳 / compose 内容时, 需要 swipe to show system bars.
+     * BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE 让系统栏在被 swipe 时短暂显示.
+     */
+    fun applyFullscreenMode(mode: FullscreenMode) {
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        when (mode) {
+            FullscreenMode.OFF -> {
+                controller.show(WindowInsetsCompat.Type.systemBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+            }
+            FullscreenMode.WITH_SYSTEM_BARS -> {
+                controller.show(WindowInsetsCompat.Type.systemBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+            FullscreenMode.WITHOUT_SYSTEM_BARS -> {
+                controller.hide(WindowInsetsCompat.Type.systemBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        }
+        LOG.info("Applied fullscreen mode: {}", mode)
+    }
+
     override fun onDestroy() {
         renderEngine?.detach()
         renderEngine = null
@@ -223,6 +265,15 @@ private fun ComposePreviewScreen(
     val viewport by viewModel.viewport.collectAsStateWithLifecycle()
     val theme by viewModel.theme.collectAsStateWithLifecycle()
     val debugEnabled by viewModel.debugEnabled.collectAsStateWithLifecycle()
+    val isFullscreen by viewModel.isFullscreen.collectAsStateWithLifecycle()
+    val fullscreenMode by viewModel.fullscreenMode.collectAsStateWithLifecycle()
+
+    // 【PR-B】全屏模式: 控制手机系统状态栏. LaunchedEffect 在 mode 变化时调用
+    // Activity 的 windowInsetsController.
+    val activityCtx = LocalContext.current as ComposePreviewActivity
+    LaunchedEffect(fullscreenMode) {
+        activityCtx.applyFullscreenMode(fullscreenMode)
+    }
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -242,30 +293,46 @@ private fun ComposePreviewScreen(
             color = MaterialTheme.colorScheme.background,
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                // 顶栏
-                PreviewToolbar(
-                    state = PreviewToolbarState(
-                        deviceName = deviceConfig.profile.displayName,
-                        themeLabel = theme.name,
-                        zoom = viewport.zoom,
-                        showSystemBars = deviceConfig.showStatusBar,
-                        debugEnabled = debugEnabled,
-                        deviceSimEnabled = deviceConfig.deviceSimEnabled,
-                    ),
-                    actions = PreviewToolbarActions(
-                        onOpenDeviceSheet = { showDeviceSheet = true },
-                        onCycleTheme = { viewModel.cycleTheme() },
-                        onSetZoom = { viewModel.setZoom(it) },
-                        onFitZoom = { viewModel.fitZoom() },
-                        onToggleSystemBars = { viewModel.toggleSystemBars() },
-                        onToggleDebug = { viewModel.toggleDebug() },
-                        onClose = onClose,
-                        onToggleDeviceSim = { viewModel.toggleDeviceSim() },
-                        onToggleFullscreen = { viewModel.toggleFullscreen() },
-                    ),
-                )
-
-                HorizontalDivider()
+                // 【PR-B】顶栏: 全屏时隐藏, 右上角改放"退出全屏"按钮.
+                if (!isFullscreen) {
+                    PreviewToolbar(
+                        state = PreviewToolbarState(
+                            deviceName = deviceConfig.profile.displayName,
+                            themeLabel = theme.name,
+                            zoom = viewport.zoom,
+                            showSystemBars = deviceConfig.showStatusBar,
+                            debugEnabled = debugEnabled,
+                            deviceSimEnabled = deviceConfig.deviceSimEnabled,
+                            fullscreen = false,
+                        ),
+                        actions = PreviewToolbarActions(
+                            onOpenDeviceSheet = { showDeviceSheet = true },
+                            onCycleTheme = { viewModel.cycleTheme() },
+                            onSetZoom = { viewModel.setZoom(it) },
+                            onFitZoom = { viewModel.fitZoom() },
+                            onToggleSystemBars = { viewModel.toggleSystemBars() },
+                            onToggleDebug = { viewModel.toggleDebug() },
+                            onClose = onClose,
+                            onToggleDeviceSim = { viewModel.toggleDeviceSim() },
+                            onToggleFullscreen = { viewModel.toggleFullscreen() },
+                            onSetFullscreenMode = { mode -> viewModel.setFullscreenMode(mode) },
+                        ),
+                    )
+                    HorizontalDivider()
+                } else {
+                    // 【PR-B】全屏时: 右上角加一个退出全屏按钮 (全人类习惯).
+                    Box(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                        IconButton(
+                            onClick = { viewModel.toggleFullscreen() },
+                            modifier = Modifier.align(Alignment.TopEnd),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.FullscreenExit,
+                                contentDescription = "退出全屏",
+                            )
+                        }
+                    }
+                }
 
                 // 主体
                 Box(
@@ -292,6 +359,8 @@ private fun ComposePreviewScreen(
                         is PreviewState.Ready -> ReadyPanel(
                             activity = activity,
                             deviceConfig = deviceConfig,
+                            viewport = viewport,
+                            isFullscreen = isFullscreen,
                         )
                     }
                 }
@@ -419,6 +488,8 @@ private fun ErrorPanel(
 private fun ReadyPanel(
     activity: ComposePreviewActivity,
     deviceConfig: DeviceConfig,
+    viewport: ViewportState,
+    isFullscreen: Boolean,
 ) {
     // 设备框 + 内容
     Box(
@@ -427,28 +498,44 @@ private fun ReadyPanel(
             .padding(if (deviceConfig.deviceSimEnabled) 16.dp else 0.dp),
         contentAlignment = Alignment.Center,
     ) {
+        // 【PR-B】zoom 应用:
+        // - 设备模式: 整个 device frame + content 一起缩放 (用户要求 #3 "真实设备模拟
+        //   时就需要直接将设备套壳以及内容显示区域等同步放大或者缩小").
+        // - 无设备模式: 仅缩放 content (compose UI), 以中心点缩放 (用户要求 #3
+        //   "以中心点逐渐放大").
+        // 用 graphicsLayer + TransformOrigin.Center 实现 GPU 缩放, 不触发重测量.
+        val zoomScale = viewport.zoom
+        val graphicsModifier = Modifier.graphicsLayer(
+            scaleX = zoomScale,
+            scaleY = zoomScale,
+            transformOrigin = TransformOrigin.Center,
+        )
+
         // 【v3.2】用 key() 强制 deviceSimEnabled / profile 变化时整体重组.
-        // 原因: AndroidView 的 factory 缓存 (默认按位置 key), 切 deviceSim 时
-        // 如果不重置, 旧 PreviewRenderEngine 引用的 ComposeView 还在新 container
-        // 之外, 切回时显示黑屏. key 强制整个子树重组, 触发 AndroidView 重建.
         androidx.compose.runtime.key(
             deviceConfig.deviceSimEnabled,
             deviceConfig.profile.id
         ) {
             if (deviceConfig.deviceSimEnabled) {
-                DeviceFrame(
-                    profile = deviceConfig.profile,
-                    systemBarsTheme = deviceConfig.systemBarsTheme,
-                    showStatusBar = deviceConfig.showStatusBar,
-                    showNavigationBar = deviceConfig.showNavigationBar,
-                    showCutout = deviceConfig.showCutout,
-                    showChassis = deviceConfig.showChassis,
-                    useGestureNav = deviceConfig.useGestureNav,
-                ) {
-                    PreviewContainer(activity)
+                // 设备模式: 整个 device frame 一起缩放
+                Box(modifier = graphicsModifier) {
+                    DeviceFrame(
+                        profile = deviceConfig.profile,
+                        systemBarsTheme = deviceConfig.systemBarsTheme,
+                        showStatusBar = deviceConfig.showStatusBar,
+                        showNavigationBar = deviceConfig.showNavigationBar,
+                        showCutout = deviceConfig.showCutout,
+                        showChassis = deviceConfig.showChassis,
+                        useGestureNav = deviceConfig.useGestureNav,
+                    ) {
+                        PreviewContainer(activity)
+                    }
                 }
             } else {
-                PreviewContainer(activity)
+                // 无设备模式: 缩放 compose UI 本身, 不缩放外层
+                Box(modifier = graphicsModifier) {
+                    PreviewContainer(activity)
+                }
             }
         }
     }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -164,9 +164,24 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
     /**
      * 由 ComposePreviewScreen 内 AndroidView 调用, 注入预览容器.
      * 引擎 attach 到此 container 后, container 会显示 Compose 渲染.
+     *
+     * 【v3.2】如果上次 attach 的 container 与当前不同 (切 deviceSim / 切 profile
+     * 触发 AndroidView 重建时), 强制 detach 旧引擎 + 新建引擎. 否则旧 ComposeView
+     * 仍然 addView 在旧 FrameLayout 上, 用户看到的是"切回后黑屏".
      */
     fun attachPreviewContainer(container: android.widget.FrameLayout) {
-        if (renderEngine == null) {
+        val existing = renderEngine
+        if (existing == null) {
+            renderEngine = PreviewRenderEngine(this, container).also { it.attach() }
+            return
+        }
+        if (existing.container !== container) {
+            LOG.info(
+                "Container changed ({} -> {}), recreating PreviewRenderEngine",
+                System.identityHashCode(existing.container),
+                System.identityHashCode(container),
+            )
+            existing.detach()
             renderEngine = PreviewRenderEngine(this, container).also { it.attach() }
         }
     }
@@ -235,6 +250,7 @@ private fun ComposePreviewScreen(
                         zoom = viewport.zoom,
                         showSystemBars = deviceConfig.showStatusBar,
                         debugEnabled = debugEnabled,
+                        deviceSimEnabled = deviceConfig.deviceSimEnabled,
                     ),
                     actions = PreviewToolbarActions(
                         onOpenDeviceSheet = { showDeviceSheet = true },
@@ -244,6 +260,8 @@ private fun ComposePreviewScreen(
                         onToggleSystemBars = { viewModel.toggleSystemBars() },
                         onToggleDebug = { viewModel.toggleDebug() },
                         onClose = onClose,
+                        onToggleDeviceSim = { viewModel.toggleDeviceSim() },
+                        onToggleFullscreen = { viewModel.toggleFullscreen() },
                     ),
                 )
 
@@ -406,38 +424,55 @@ private fun ReadyPanel(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(if (deviceConfig.deviceSimEnabled) 16.dp else 0.dp),
         contentAlignment = Alignment.Center,
     ) {
-        // 用 DeviceFrame 包裹实际预览 ComposeView
-        DeviceFrame(
-            profile = deviceConfig.profile,
-            systemBarsTheme = deviceConfig.systemBarsTheme,
-            showStatusBar = deviceConfig.showStatusBar,
-            showNavigationBar = deviceConfig.showNavigationBar,
-            showCutout = deviceConfig.showCutout,
-            showChassis = deviceConfig.showChassis,
-            useGestureNav = deviceConfig.useGestureNav,
+        // 【v3.2】用 key() 强制 deviceSimEnabled / profile 变化时整体重组.
+        // 原因: AndroidView 的 factory 缓存 (默认按位置 key), 切 deviceSim 时
+        // 如果不重置, 旧 PreviewRenderEngine 引用的 ComposeView 还在新 container
+        // 之外, 切回时显示黑屏. key 强制整个子树重组, 触发 AndroidView 重建.
+        androidx.compose.runtime.key(
+            deviceConfig.deviceSimEnabled,
+            deviceConfig.profile.id
         ) {
-            // 容器 Box, 通过 AndroidView 嵌入一个 FrameLayout, 让 PreviewRenderEngine 把
-            // 自己的 ComposeView addView 进去. 显式使用 MATCH_PARENT layoutParams 避免
-            // SubcomposeLayout 嵌套测量把 ComposeView 的尺寸压成 0 (这是 v2.1 的根因).
-            AndroidView(
-                factory = { ctx ->
-                    android.widget.FrameLayout(ctx).apply {
-                        layoutParams = android.view.ViewGroup.LayoutParams(
-                            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                        )
-                        // 通知 Activity 创建引擎, 把这个容器给引擎.
-                        // activity 由 ComposePreviewScreen 显式传入, 不会因重组失效.
-                        activity.attachPreviewContainer(this)
-                    }
-                },
-                modifier = Modifier.fillMaxSize(),
-            )
+            if (deviceConfig.deviceSimEnabled) {
+                DeviceFrame(
+                    profile = deviceConfig.profile,
+                    systemBarsTheme = deviceConfig.systemBarsTheme,
+                    showStatusBar = deviceConfig.showStatusBar,
+                    showNavigationBar = deviceConfig.showNavigationBar,
+                    showCutout = deviceConfig.showCutout,
+                    showChassis = deviceConfig.showChassis,
+                    useGestureNav = deviceConfig.useGestureNav,
+                ) {
+                    PreviewContainer(activity)
+                }
+            } else {
+                PreviewContainer(activity)
+            }
         }
     }
+}
+
+@Composable
+private fun PreviewContainer(activity: ComposePreviewActivity) {
+    // 容器 Box, 通过 AndroidView 嵌入一个 FrameLayout, 让 PreviewRenderEngine 把
+    // 自己的 ComposeView addView 进去. 显式使用 MATCH_PARENT layoutParams 避免
+    // SubcomposeLayout 嵌套测量把 ComposeView 的尺寸压成 0 (这是 v2.1 的根因).
+    AndroidView(
+        factory = { ctx ->
+            android.widget.FrameLayout(ctx).apply {
+                layoutParams = android.view.ViewGroup.LayoutParams(
+                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                // 通知 Activity 创建引擎, 把这个容器给引擎.
+                // activity 由 ComposePreviewScreen 显式传入, 不会因重组失效.
+                activity.attachPreviewContainer(this)
+            }
+        },
+        modifier = Modifier.fillMaxSize(),
+    )
 }
 
 private fun triggerBuild(

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -34,10 +34,13 @@ import com.itsaky.androidide.compose.preview.ui.SystemBarsTheme
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -167,9 +170,24 @@ class ComposePreviewViewModel(
 
     private val _debugEnabled = MutableStateFlow(false)
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
-    /** v3.2 / PR-B 占位: 全屏状态. */
-    private val _isFullscreen = MutableStateFlow(false)
-    val isFullscreen: StateFlow<Boolean> = _isFullscreen.asStateFlow()
+    /**
+     * 【PR-B】全屏模式. 默认为 [FullscreenMode.OFF] (非全屏).
+     *
+     * 单击全屏按钮: 切 [FullscreenMode.WITH_SYSTEM_BARS] (带系统状态栏的全屏).
+     * 长按全屏按钮: 弹菜单, 用户选 [FullscreenMode.WITH_SYSTEM_BARS] 或
+     * [FullscreenMode.WITHOUT_SYSTEM_BARS] (隐藏系统状态栏的纯全屏).
+     * 退出全屏 (右上角 X 按钮): 设回 [FullscreenMode.OFF].
+     */
+    private val _fullscreenMode = MutableStateFlow(FullscreenMode.OFF)
+    val fullscreenMode: StateFlow<FullscreenMode> = _fullscreenMode.asStateFlow()
+
+    /**
+     * 【PR-B】true=处于全屏 (无论是否隐藏系统状态栏). 由 [fullscreenMode] 派生,
+     * 不需要单独维护. UI 用这个判断 toolbar 显示 / 隐藏 + 退出按钮.
+     */
+    val isFullscreen: StateFlow<Boolean> = _fullscreenMode
+        .map { it != FullscreenMode.OFF }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
@@ -447,14 +465,25 @@ class ComposePreviewViewModel(
     }
 
     /**
-     * 【v3.2 / PR-B 占位】切换全屏. PR-B 实现完整行为:
-     * - true: 隐藏 toolbar
-     * - 切回: 顶部右上角 X 按钮恢复
-     * - 长按: 弹 "带/不带系统状态栏" 选择
+     * 【PR-B】切换全屏. 默认切到带系统状态栏的全屏. 长按全屏按钮调 [setFullscreenMode].
+     * - OFF -> WITH_SYSTEM_BARS
+     * - WITH_SYSTEM_BARS / WITHOUT_SYSTEM_BARS -> OFF
      */
     fun toggleFullscreen() {
-        _isFullscreen.value = !_isFullscreen.value
-        LOG.info("Fullscreen toggled: {}", _isFullscreen.value)
+        _fullscreenMode.value = if (_fullscreenMode.value == FullscreenMode.OFF) {
+            FullscreenMode.WITH_SYSTEM_BARS
+        } else {
+            FullscreenMode.OFF
+        }
+        LOG.info("Fullscreen toggled: {}", _fullscreenMode.value)
+    }
+
+    /**
+     * 【PR-B】设置全屏模式 (长按全屏按钮菜单调用).
+     */
+    fun setFullscreenMode(mode: FullscreenMode) {
+        _fullscreenMode.value = mode
+        LOG.info("Fullscreen mode set: {}", mode)
     }
 
     fun toggleSystemBars() {
@@ -496,4 +525,18 @@ class ComposePreviewViewModel(
         private val LOG = LoggerFactory.getLogger(ComposePreviewViewModel::class.java)
         private const val DEBOUNCE_MS = 500L
     }
+}
+
+/**
+ * 【PR-B】全屏模式.
+ *
+ * - [OFF]: 非全屏, 顶栏显示.
+ * - [WITH_SYSTEM_BARS]: 全屏, 但保留手机系统状态栏 (用户在 APK 安装运行后看到的样子).
+ * - [WITHOUT_SYSTEM_BARS]: 纯全屏, 隐藏系统状态栏, 适合查看实际应用沉浸式全屏效果.
+ */
+@Immutable
+enum class FullscreenMode {
+    OFF, WITH_SYSTEM_BARS, WITHOUT_SYSTEM_BARS;
+
+    val isFullscreen: Boolean get() = this != OFF
 }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewViewModel.kt
@@ -167,6 +167,9 @@ class ComposePreviewViewModel(
 
     private val _debugEnabled = MutableStateFlow(false)
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
+    /** v3.2 / PR-B 占位: 全屏状态. */
+    private val _isFullscreen = MutableStateFlow(false)
+    val isFullscreen: StateFlow<Boolean> = _isFullscreen.asStateFlow()
 
     private val sourceChanges = MutableSharedFlow<SourceUpdate>()
 
@@ -424,12 +427,34 @@ class ComposePreviewViewModel(
     // === v2.1 新增方法 ===
 
     fun selectDevice(profile: DeviceProfile) {
-        _deviceConfig.value = _deviceConfig.value.copy(profile = profile)
+        _deviceConfig.value = _deviceConfig.value.copy(profile = profile, deviceSimEnabled = true)
         LOG.info("Device selected: {}", profile.displayName)
     }
 
     fun setSystemBarsTheme(theme: SystemBarsTheme) {
         _deviceConfig.value = _deviceConfig.value.copy(systemBarsTheme = theme)
+    }
+
+    /**
+     * 【v3.2】切换"真实设备模拟"开关. true=套壳显示, false=无外壳直接显示.
+     * 切到 false 时, profile 仍保留, 方便用户切回去.
+     */
+    fun toggleDeviceSim() {
+        _deviceConfig.value = _deviceConfig.value.copy(
+            deviceSimEnabled = !_deviceConfig.value.deviceSimEnabled
+        )
+        LOG.info("Device sim toggled: {}", _deviceConfig.value.deviceSimEnabled)
+    }
+
+    /**
+     * 【v3.2 / PR-B 占位】切换全屏. PR-B 实现完整行为:
+     * - true: 隐藏 toolbar
+     * - 切回: 顶部右上角 X 按钮恢复
+     * - 长按: 弹 "带/不带系统状态栏" 选择
+     */
+    fun toggleFullscreen() {
+        _isFullscreen.value = !_isFullscreen.value
+        LOG.info("Fullscreen toggled: {}", _isFullscreen.value)
     }
 
     fun toggleSystemBars() {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/CutoutGeometry.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/CutoutGeometry.kt
@@ -137,11 +137,10 @@ sealed class CutoutGeometry {
             cornerRadiusDp = 15f
         )
 
-        /** iPhone 15 Pro 风格 Dynamic Island (126 × 37 dp, 顶部居中) */
-        val DYNAMIC_ISLAND: Notch = Notch(
+        /** iPhone 14 Pro+ 灵动岛 (126 × 37 dp, 顶部居中) — v3.2 用独立类型 */
+        val DYNAMIC_ISLAND: DynamicIsland = DynamicIsland(
             widthDp = 126f,
             heightDp = 37f,
-            anchor = Anchor.TOP_CENTER,
             cornerRadiusDp = 18f
         )
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/DeviceCatalog.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/DeviceCatalog.kt
@@ -219,9 +219,9 @@ object DeviceCatalog {
         manufacturer = "Apple", model = "iPhone 15 Pro", osVersion = "iOS 17",
         widthPx = 1179, heightPx = 2556, densityDpi = 460,
         cornerRadiusDp = 50f,
-        cutout = CutoutGeometry.Notch(
+        cutout = CutoutGeometry.DynamicIsland(
             widthDp = 126f, heightDp = 37f,
-            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 18f
+            cornerRadiusDp = 18f
         ),
         bezels = Bezels(topDp = 37f, bottomDp = 24f, leftDp = 4f, rightDp = 4f),
         physicalKeys = PhysicalKey.iphoneKeys(393f),
@@ -234,12 +234,12 @@ object DeviceCatalog {
         manufacturer = "Apple", model = "iPhone 15 Pro Max", osVersion = "iOS 17",
         widthPx = 1290, heightPx = 2796, densityDpi = 460,
         cornerRadiusDp = 50f,
-        cutout = CutoutGeometry.Notch(
+        cutout = CutoutGeometry.DynamicIsland(
             widthDp = 130f, heightDp = 38f,
-            anchor = CutoutGeometry.Anchor.TOP_CENTER, cornerRadiusDp = 19f
+            cornerRadiusDp = 19f
         ),
         bezels = Bezels(topDp = 38f, bottomDp = 26f, leftDp = 4f, rightDp = 4f),
-        physicalKeys = PhysicalKey.iphoneKeys(430f),
+        physicalKeys = PhysicalKey.iphoneKeys(449f),
         chassisColor = Color(0xFF2A2A2C),
     )
 

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/PhysicalKey.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/device/PhysicalKey.kt
@@ -138,13 +138,29 @@ sealed class PhysicalKey {
         )
 
         /**
-         * iPhone (左侧音量 + 静音, 右侧电源). 静音键用 VolUp 占位.
+         * iPhone (左侧音量 + Action Button, 右侧电源). 静音键被
+         * iPhone 15 Pro+ 替换为 Action Button.
+         *
+         * 按真实 iPhone 15 Pro Max 设备图物理键位置 (相对设备原始 dp):
+         * - 左侧 Action Button y ≈ screenHeight × 14%
+         * - 左侧 Vol+ y ≈ screenHeight × 18%
+         * - 左侧 Vol- y ≈ screenHeight × 22%
+         * - 右侧 Power y ≈ screenHeight × 18%
+         *
+         * 屏幕宽 / 高比例固定为 9:19.5, 因此 screenHeight ≈ screenWidthDp × 2.167.
+         * 实际 y 坐标用 screenWidthDp × 0.305 ~ 0.480 系数计算.
          */
-        fun iphoneKeys(screenWidthDp: Float): List<PhysicalKey> = listOf(
-            VolumeUp(positionXdp = -6f, positionYdp = 280f),
-            VolumeDown(positionXdp = -6f, positionYdp = 320f),
-            Power(positionXdp = screenWidthDp + 6f, positionYdp = 480f)
-        )
+        fun iphoneKeys(screenWidthDp: Float): List<PhysicalKey> {
+            val h = screenWidthDp * 2.167f
+            return listOf(
+                // 左侧 Action Button (iPhone 15 Pro+) — 替代静音键
+                Assistant(positionXdp = -6f, positionYdp = h * 0.14f),
+                VolumeUp(positionXdp = -6f, positionYdp = h * 0.18f),
+                VolumeDown(positionXdp = -6f, positionYdp = h * 0.22f),
+                // 右侧 Power (Side button) — 屏幕中上部
+                Power(positionXdp = screenWidthDp + 6f, positionYdp = h * 0.18f)
+            )
+        }
 
         /** 无按键 (平板 / 折叠屏内屏 / 桌面模式 / 自定义) */
         val NO_KEYS: List<PhysicalKey> = emptyList()

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewRenderEngine.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewRenderEngine.kt
@@ -67,7 +67,12 @@ import java.util.concurrent.atomic.AtomicReference
  */
 class PreviewRenderEngine(
     private val context: Context,
-    private val container: ViewGroup,
+    /**
+     * 外部可见 (internal), 让 [com.itsaky.androidide.compose.preview.ComposePreviewActivity.attachPreviewContainer]
+     * 能判断 "container 是否改变" 来决定是否 detach + 重建引擎. v3.2 修复切
+     * deviceSim / profile 时显示黑屏的 bug.
+     */
+    internal val container: ViewGroup,
 ) {
 
     private val LOG = LoggerFactory.getLogger(PreviewRenderEngine::class.java)
@@ -85,6 +90,17 @@ class PreviewRenderEngine(
      */
     fun attach() {
         if (composeView != null) return
+        // 【v3.2】如果 container 已经有别的 engine 添加的 ComposeView, 先清理.
+        // 切 deviceSim / profile 时旧 engine 已经被 Activity.detach() 释放, 但
+        // 旧 ComposeView 可能仍残留 (Activity 是 main thread, GC 还没跑).
+        repeat(container.childCount) { i ->
+            val child = container.getChildAt(i)
+            if (child is ComposeView) {
+                container.removeViewAt(i)
+                LOG.debug("Removed orphan ComposeView from container before attach")
+                return@repeat
+            }
+        }
         val view = ComposeView(context).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/CutoutOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/CutoutOverlay.kt
@@ -63,10 +63,41 @@ fun CutoutOverlay(
     Canvas(modifier = modifier) {
         when (cutout) {
             is CutoutGeometry.Notch -> drawNotch(cutout, color)
+            is CutoutGeometry.DynamicIsland -> drawDynamicIsland(cutout, color)
             is CutoutGeometry.PunchHole -> drawPunchHole(cutout, color)
             is CutoutGeometry.WaterfallCurve -> drawWaterfall(cutout, color, screenSize)
         }
     }
+}
+
+/**
+ * 绘制灵动岛 (iPhone 14 Pro+ 风格).
+ *
+ * 视觉上是一个比 notch 更小、纯黑色的圆角药丸, 内部**无摄像头 / 听筒绘制**
+ * (因为真实 iPhone 灵动岛下面是传感器 + 摄像头, 但屏幕 UI 不需要看到细节).
+ *
+ * 关键: 灵动岛**两侧**屏幕仍然可显示状态栏 (时间 / 信号 / 电池), 这部分
+ * 由 [SystemBarsOverlay] 配合 [DeviceProfile.cutout] 类型识别处理.
+ */
+private fun DrawScope.drawDynamicIsland(island: CutoutGeometry.DynamicIsland, color: Color) {
+    val widthPx = withHpx(island.widthDp)
+    val heightPx = withHpx(island.heightDp)
+    val cornerRadiusPx = withHpx(island.cornerRadiusDp)
+
+    val x = (size.width - widthPx) / 2f
+    val y = withHpx(8f)  // iPhone 灵动岛顶端到屏幕顶端约 8dp
+
+    val path = Path().apply {
+        addRoundRect(
+            androidx.compose.ui.geometry.RoundRect(
+                left = x, top = y,
+                right = x + widthPx, bottom = y + heightPx,
+                radiusX = cornerRadiusPx, radiusY = cornerRadiusPx
+            )
+        )
+    }
+    // 灵动岛本体 — 纯黑
+    drawPath(path = path, color = Color(0xFF000000))
 }
 
 /**

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
@@ -113,11 +113,19 @@ fun DeviceFrame(
             content = content,
         )
         DeviceProfile.FormFactor.DESKTOP,
-        DeviceProfile.FormFactor.NONE -> Box(
-            modifier = modifier
-                .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
-        ) {
-            content()
+        DeviceProfile.FormFactor.NONE -> {
+            // 【v3.2 修复 #1】DESKTOP / NONE 必须 fillMaxSize, 否则 Box 没有
+            // 尺寸约束, Compose 跳过绘制 (用户看到全透明 + 紫底透出).
+            // 之前版本只 .clip(RoundedCornerShape(...)) 没用 fillMaxSize, 在
+            // ComposePreviewScreen 内会被父容器测量为 0.
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
+                    .background(Color.Transparent)
+            ) {
+                content()
+            }
         }
         else -> PhoneOrFoldableFrame(
             profile = profile,
@@ -159,15 +167,27 @@ private fun PhoneOrFoldableFrame(
     ) {
         val parentWidth = maxWidth
         val parentHeight = maxHeight
-
-        // 计算屏幕尺寸 (按设备纵横比 + 父容器约束)
-        val screenWidth = parentWidth
         val aspect = profile.aspectRatio
-        val screenHeight = screenWidth / aspect
+
+        // 【v3.2 修复 #3】按 maxWidth 和 maxHeight 双向约束, 选 min.
+        //
+        // 之前版本 val screenHeight = screenWidth / aspect 没用 maxHeight 限制,
+        // 当 device 纵横比很窄 (iPhone 15 Pro Max 0.461) 且父容器较扁时, 实际渲染
+        // 高度会超出 BoxWithConstraints 默认 clip 范围, 物理键 (y=480) 跟着被裁切
+        // 显示不出来. 现在按 maxHeight 双向约束, 物理键按实际渲染高度计算.
+        val maxScreenWidth = parentWidth
+        val maxScreenHeight = (parentHeight * 0.96f)  // 留 4% 余量防裁切
+        val screenWidth = maxScreenWidth
+        val screenHeight = (screenWidth / aspect).coerceAtMost(maxScreenHeight)
+        val finalScreenWidth = if (screenHeight == maxScreenHeight) {
+            screenHeight * aspect
+        } else {
+            screenWidth
+        }
 
         Box(
             modifier = Modifier
-                .width(screenWidth)
+                .width(finalScreenWidth)
                 .height(screenHeight)
         ) {
             // 1) 机身外壳
@@ -221,12 +241,13 @@ private fun PhoneOrFoldableFrame(
                 )
             }
 
-            // 7) 物理按键 (屏幕外侧)
+            // 7) 物理按键 (屏幕外侧) — 传实际渲染高度, 让按比例定位的按键不超范围
             if (showPhysicalKeys) {
                 profile.physicalKeys.forEach { key ->
                     PhysicalKeyIndicator(
                         key = key,
-                        screenHeightDp = with(density) { (parentHeight.value).dp },
+                        screenWidthDp = with(density) { finalScreenWidth },
+                        screenHeightDp = with(density) { screenHeight },
                     )
                 }
             }
@@ -241,8 +262,10 @@ private fun WatchFrame(
     systemBarsTheme: SystemBarsTheme,
     content: @Composable () -> Unit,
 ) {
+    // 【v3.2 修复 #2】撑开 BoxWithConstraints, 否则 maxWidth/maxHeight 都是 0,
+    // size = 0, 内层 Box size = 0, content() 渲染不到任何像素 = 全黑.
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
         val size = if (maxWidth < maxHeight) maxWidth else maxHeight
@@ -266,10 +289,15 @@ private fun WatchFrame(
 
 /**
  * 物理按键指示器 (在屏幕外侧画一个矩形 + 文字).
+ *
+ * 【v3.2 修复 #3】坐标基准改成"实际渲染屏幕尺寸" (而非父 BoxWithConstraints),
+ * 这样在窄高比 device (iPhone 15 Pro Max 0.461) 实际渲染高度被 maxHeight 限制
+ * 时, 物理键按"屏幕实际尺寸"百分比定位, 不会被父容器裁切.
  */
 @Composable
 private fun PhysicalKeyIndicator(
     key: PhysicalKey,
+    screenWidthDp: androidx.compose.ui.unit.Dp,
     screenHeightDp: androidx.compose.ui.unit.Dp,
 ) {
     val density = LocalDensity.current

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
@@ -35,7 +35,11 @@ import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Brightness6
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
+import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Smartphone
+import androidx.compose.material.icons.filled.SmartphoneOff
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.ZoomIn
@@ -91,9 +95,25 @@ fun PreviewToolbar(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // 设备 chip
+        // 【v3.2】真实设备模拟 toggle — 默认无设备模式 (chip 文字 "Device" 表示可切到套壳,
+        // selected 时 chip 高亮 = 当前已启用真实设备模拟).
+        FilterChip(
+            selected = state.deviceSimEnabled,
+            onClick = actions.onToggleDeviceSim,
+            label = { Text(if (state.deviceSimEnabled) "Device" else "Raw") },
+            leadingIcon = {
+                Icon(
+                    imageVector = if (state.deviceSimEnabled) Icons.Filled.Smartphone else Icons.Filled.SmartphoneOff,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
+
+        // 设备 chip (只切到设备模拟时显示, 否则灰显)
         AssistChip(
             onClick = actions.onOpenDeviceSheet,
+            enabled = state.deviceSimEnabled,
             label = { Text(state.deviceName) },
             leadingIcon = {
                 Icon(
@@ -168,6 +188,14 @@ fun PreviewToolbar(
             },
         )
 
+        // 【PR-B 占位】全屏切换 (v3.2 先放按钮, 行为 PR-B 实现)
+        IconButton(onClick = actions.onToggleFullscreen) {
+            Icon(
+                Icons.Filled.Fullscreen,
+                contentDescription = "Fullscreen",
+            )
+        }
+
         Spacer(modifier = Modifier.width(8.dp))
 
         // 关闭
@@ -186,6 +214,10 @@ data class PreviewToolbarState(
     val zoom: Float = 1.0f,
     val showSystemBars: Boolean = true,
     val debugEnabled: Boolean = false,
+    /** v3.2: 是否启用真实设备模拟. 默认 false. */
+    val deviceSimEnabled: Boolean = false,
+    /** v3.2 / PR-B: 全屏模式. 默认 false. */
+    val fullscreen: Boolean = false,
 )
 
 /**
@@ -199,4 +231,8 @@ data class PreviewToolbarActions(
     val onToggleSystemBars: () -> Unit,
     val onToggleDebug: () -> Unit,
     val onClose: () -> Unit,
+    /** v3.2: 切换设备模拟开关. */
+    val onToggleDeviceSim: () -> Unit = {},
+    /** v3.2 / PR-B: 切换全屏. */
+    val onToggleFullscreen: () -> Unit = {},
 )

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/PreviewToolbar.kt
@@ -46,17 +46,24 @@ import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material.icons.filled.ZoomOut
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -188,12 +195,41 @@ fun PreviewToolbar(
             },
         )
 
-        // 【PR-B 占位】全屏切换 (v3.2 先放按钮, 行为 PR-B 实现)
-        IconButton(onClick = actions.onToggleFullscreen) {
-            Icon(
-                Icons.Filled.Fullscreen,
-                contentDescription = "Fullscreen",
-            )
+        // 【PR-B】全屏切换按钮 (单击 = toggle; 长按 = 弹带/不带系统状态栏选择菜单).
+        var fullscreenMenuOpen by remember { mutableStateOf(false) }
+        Box {
+            IconButton(
+                onClick = actions.onToggleFullscreen,
+                modifier = Modifier.pointerInput(Unit) {
+                    androidx.compose.foundation.gestures.detectTapGestures(
+                        onLongPress = { fullscreenMenuOpen = true },
+                    )
+                },
+            ) {
+                Icon(
+                    imageVector = if (state.fullscreen) Icons.Filled.FullscreenExit else Icons.Filled.Fullscreen,
+                    contentDescription = if (state.fullscreen) "退出全屏" else "全屏",
+                )
+            }
+            DropdownMenu(
+                expanded = fullscreenMenuOpen,
+                onDismissRequest = { fullscreenMenuOpen = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text("全屏 (带系统状态栏)") },
+                    onClick = {
+                        fullscreenMenuOpen = false
+                        actions.onSetFullscreenMode(com.itsaky.androidide.compose.preview.FullscreenMode.WITH_SYSTEM_BARS)
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("沉浸式全屏 (隐藏系统状态栏)") },
+                    onClick = {
+                        fullscreenMenuOpen = false
+                        actions.onSetFullscreenMode(com.itsaky.androidide.compose.preview.FullscreenMode.WITHOUT_SYSTEM_BARS)
+                    },
+                )
+            }
         }
 
         Spacer(modifier = Modifier.width(8.dp))
@@ -233,6 +269,8 @@ data class PreviewToolbarActions(
     val onClose: () -> Unit,
     /** v3.2: 切换设备模拟开关. */
     val onToggleDeviceSim: () -> Unit = {},
-    /** v3.2 / PR-B: 切换全屏. */
+    /** PR-B: 切换全屏. */
     val onToggleFullscreen: () -> Unit = {},
+    /** PR-B: 设置全屏模式 (长按全屏菜单调用). */
+    val onSetFullscreenMode: (com.itsaky.androidide.compose.preview.FullscreenMode) -> Unit = {},
 )


### PR DESCRIPTION
基于 [PR #401](https://github.com/msmt2018/ZeroStudio/pull/401) (PR-A: 桌面全透明/手表黑屏/iPhone 套壳 + 无设备模式) rebase. PR #401 未合并前 PR-B 的 commit history 包含 PR-A 修复.

## 新功能

### 完整全屏切换 (用户要求 #4)

- **FullscreenMode 枚举**: `OFF` / `WITH_SYSTEM_BARS` / `WITHOUT_SYSTEM_BARS`
- **单击全屏按钮**: 切 `WITH_SYSTEM_BARS` (默认带系统状态栏的全屏)
- **长按全屏按钮**: 弹 `DropdownMenu` 2 个 item — 带/不带系统状态栏
- **退出全屏 (右上角 X 按钮)**: 设回 `OFF`, 显示 toolbar
- **Activity 端 `applyFullscreenMode()`**: 用 `WindowInsetsControllerCompat` 控制手机系统状态栏 (hide/show + BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)

### 全屏 UI 切换

| 状态 | 顶栏 | 退出按钮 | 系统栏 |
| --- | --- | --- | --- |
| `OFF` | 显示 | 隐藏 | 显示 |
| `WITH_SYSTEM_BARS` | 隐藏 | 右上角 `FullscreenExit` | 显示 (用户能看时间) |
| `WITHOUT_SYSTEM_BARS` | 隐藏 | 右上角 `FullscreenExit` | 隐藏 (沉浸式) |

### 缩放适配 (用户要求 #3)

- 用 `graphicsLayer + TransformOrigin.Center` 应用 `viewport.zoom`
- **设备模式**: 整个 device frame + content 一起缩放 (GPU 缩放, 不触发重测量)
- **无设备模式**: 仅缩放 compose UI (中心点锚定)

## 内部实现

### ViewModel
- `_fullscreenMode: MutableStateFlow<FullscreenMode>`
- `isFullscreen StateFlow` 由 `fullscreenMode` 派生 (`stateIn(Eagerly)`)
- `toggleFullscreen()` / `setFullscreenMode(mode)` 方法

### ComposePreviewActivity
- `applyFullscreenMode(mode)` 控制 window insets
- `LaunchedEffect(fullscreenMode)` 触发 apply
- 全屏时 `Box 右上角 IconButton` 退出按钮
- `ReadyPanel` 加 `viewport + isFullscreen` 参数

### PreviewToolbar
- `PreviewToolbarActions.onSetFullscreenMode(mode)` 回调
- 全屏按钮 `pointerInput + detectTapGestures(onLongPress = { 弹菜单 })`

## 文件清单

- 3 files changed, +222 / -54
- commit: 081f21e8c

---

后续 PR:
- **PR-C**: 桌面 launcher 模拟 (从 AGP 资源拿 app icon + 几个不可点击系统 app + 物理键返回桌面 + 后台模拟) + 手表圆形 UI 真实化 + 折叠屏铰链

Co-Authored-By: ZeroStudio <noreply@zerostudio.dev>