### PR TITLE
fix(ide-debugger): 修复 11 个编译错误 (StepDepth/StepSize + 公开内部 hooks)

### DIFF
--- a/ide-debugger/src/main/java/com/zerostudio/debugger/api/Debugger.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/api/Debugger.java
@@ -576,7 +576,7 @@ public final class Debugger
 
     // -- internal hooks for the event bus --
 
-    void onVmStart() {
+    public void onVmStart() {
         synchronized (vmStartReceived) {
             vmStartReceived.set(true);
             vmStartReceived.notifyAll();
@@ -585,7 +585,7 @@ public final class Debugger
         eventBus.publish(DebugEvents.vmStart());
     }
 
-    void onSuspend(@NonNull SuspendInfo info) {
+    public void onSuspend(@NonNull SuspendInfo info) {
         // PR-6: handle conditional breakpoints and logpoints BEFORE
         // notifying the UI. A logpoint never pauses the program; a
         // conditional breakpoint only pauses if the condition evaluates
@@ -688,7 +688,7 @@ public final class Debugger
         }
     }
 
-    void onResume() {
+    public void onResume() {
         session.setState(DebugSession.State.RUNNING);
         lastSuspend = null;
         eventBus.publish(DebugEvents.resume());
@@ -697,7 +697,7 @@ public final class Debugger
         }
     }
 
-    void notifyBreakpointChanged(@NonNull Breakpoint bp) {
+    public void notifyBreakpointChanged(@NonNull Breakpoint bp) {
         for (Listener l : listeners) {
             try { l.onBreakpointChanged(bp); } catch (Throwable ignored) { }
         }

--- a/ide-debugger/src/main/java/com/zerostudio/debugger/jdwp/StepDepth.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/jdwp/StepDepth.java
@@ -1,0 +1,24 @@
+/*
+ *  ZeroStudio IDE - ide-debugger
+ *
+ *  JDWP Step depth constants (used in SINGLE_STEP EventRequest modifier).
+ *
+ *  Per the JDWP spec:
+ *    INTO  = 0 — step into method calls
+ *    OVER  = 1 — step over method calls
+ *    OUT   = 2 — step out of the current frame
+ *
+ *  See: VirtualMachine/ThreadReference docs and the SINGLE_STEP
+ *  EventRequest modifier.
+ */
+package com.zerostudio.debugger.jdwp;
+
+public enum StepDepth {
+    INTO((byte) 0),
+    OVER((byte) 1),
+    OUT((byte) 2);
+
+    public final byte value;
+
+    StepDepth(byte v) { this.value = v; }
+}

--- a/ide-debugger/src/main/java/com/zerostudio/debugger/jdwp/StepSize.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/jdwp/StepSize.java
@@ -1,0 +1,22 @@
+/*
+ *  ZeroStudio IDE - ide-debugger
+ *
+ *  JDWP Step size constants (used in SINGLE_STEP EventRequest modifier).
+ *
+ *  Per the JDWP spec:
+ *    MIN  = 0 — step by the minimum code unit (Java bytecode)
+ *    LINE = 1 — step by source line
+ *
+ *  LINE is the common choice for IDE-driven stepping; it stops at
+ *  every source line even if a single line covers multiple bytecodes.
+ */
+package com.zerostudio.debugger.jdwp;
+
+public enum StepSize {
+    MIN((byte) 0),
+    LINE((byte) 1);
+
+    public final byte value;
+
+    StepSize(byte v) { this.value = v; }
+}

--- a/ide-debugger/src/main/java/com/zerostudio/debugger/model/SourceLocator.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/model/SourceLocator.java
@@ -362,6 +362,18 @@ public final class SourceLocator {
                 CommandSet.EventRequest, CommandCodes.EventRequestCmd.Set, buf.toByteArray());
     }
 
+    /**
+     * Type-safe enum-based step API. Preferred over the raw byte
+     * overload. Sets a SINGLE_STEP EventRequest modifier with the
+     * given depth/size and suspends the thread.
+     */
+    public void step(long threadId,
+                     @NonNull com.zerostudio.debugger.jdwp.StepDepth depth,
+                     @NonNull com.zerostudio.debugger.jdwp.StepSize size)
+            throws IOException {
+        step(threadId, depth.value, size.value);
+    }
+
     @NonNull
     public List<StackFrameInfo> getStackFrames(long threadId, int start, int length)
             throws IOException {


### PR DESCRIPTION
之前 trae/solo-agent-gWKO4e 分支已修复,本 commit 同步到 pr-419 分支。

问题:
  Debugger.java 引用了不存在的 com.zerostudio.debugger.jdwp.StepDepth /
  StepSize;另外 onVmStart / onSuspend / onResume / notifyBreakpointChanged
  原本是 package-private,event/ 和 model/ 跨包无法访问。

修复:
  1. 新建 jdwp/StepDepth.java (INTO=0, OVER=1, OUT=2)
  2. 新建 jdwp/StepSize.java (MIN=0, LINE=1)
  3. SourceLocator.step() 新增类型安全重载: public void step(long, StepDepth, StepSize) 内部委托给原有的 byte 重载
  4. Debugger.onVmStart / onSuspend / onResume / notifyBreakpointChanged 改为 public,允许 com.zerostudio.debugger.event.DebugEventBus 和 com.zerostudio.debugger.model.SourceLocator 跨包访问

未影响:任何 public API 的语义,只放宽可见性。