### PR TITLE
fix(utilities/logwire): Handshake 修复 — 不依赖 android.os.Process

### DIFF
--- a/utilities/logwire/src/main/java/com/itsaky/androidide/logwire/Handshake.java
+++ b/utilities/logwire/src/main/java/com/itsaky/androidide/logwire/Handshake.java
@@ -31,9 +31,50 @@ public final class Handshake {
     }
 
     public static Handshake defaultFor(@NonNull String packageName) {
-        int pid = (int) android.os.Process.myPid();
+        int pid = currentProcessPid();
         long session = System.nanoTime();
         return new Handshake(WireConstants.PROTOCOL_VERSION, pid, packageName, session);
+    }
+
+    /**
+     * Best-effort: get the current process id without depending on
+     * android.os.Process (this module is a pure java-library and is
+     * not compiled against the Android SDK).
+     *
+     * <p>Order:
+     * <ol>
+     *   <li>{@link ProcessHandle#current()} — JDK 9+ (works on plain JVM
+     *       and on Android with desugaring at API 26+).</li>
+     *   <li>Parse {@code pid@host} from the JVM's runtime name.</li>
+     *   <li>Fall back to 0 (caller can still proceed with pid=0, the
+     *       protocol is tolerant — pid is informational only).</li>
+     * </ol>
+     */
+    private static int currentProcessPid() {
+        try {
+            // Java 9+: ProcessHandle.current().pid() returns long.
+            long pid = ProcessHandle.current().pid();
+            if (pid > 0 && pid <= Integer.MAX_VALUE) {
+                return (int) pid;
+            }
+        } catch (Throwable ignored) {
+            // ProcessHandle not supported on this runtime — fall through
+        }
+        try {
+            // Fallback: "pid@host" format from RuntimeMXBean.getName()
+            String name = java.lang.management.ManagementFactory
+                    .getRuntimeMXBean().getName();
+            int at = name.indexOf('@');
+            if (at > 0) {
+                long pid = Long.parseLong(name.substring(0, at));
+                if (pid > 0 && pid <= Integer.MAX_VALUE) {
+                    return (int) pid;
+                }
+            }
+        } catch (Throwable ignored) {
+            // best-effort
+        }
+        return 0;
     }
 
     @NonNull


### PR DESCRIPTION
## 概述

utilities/logwire 是 java-library (纯 Java,不引用 Android SDK),但 Handshake.defaultFor() 直接调用了 android.os.Process.myPid(),导致 compileJava 任务失败。

## 修复

新增 private static int currentProcessPid() 工具方法,三段降级:

1. ProcessHandle.current().pid() — JDK 9+ (JVM 与 Android API 26+ with desugaring 都支持)
2. 解析 RuntimeMXBean.getName() 的 pid@host 格式
3. 失败时返回 0 (协议容忍 — pid 是信息性字段)

## 影响

- Handshake(int pid, ...) 公开构造器不变,自定义场景不受影响
- LogPayload / ErrorPayload / FrameCodec 未引用 android.*,无连锁修复
- 注释里残留的 android.util.Log 是文档说明,不是代码引用

## 测试

- ./gradlew :utilities:logwire:compileJava 通过
- 现有 FrameCodecTest (round-trip 14 项) 继续覆盖 Handshake 序列化
