### PR TITLE
Fix ide-debugger Java compile errors

### DIFF
--- a/ide-debugger/src/main/java/com/zerostudio/debugger/model/AstIndex.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/model/AstIndex.java
@@ -28,6 +28,9 @@ package com.zerostudio.debugger.model;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.zerostudio.debugger.model.JavaSourceParser.ParsedSource;
+import com.zerostudio.debugger.model.JavaSourceParser.SourceClass;
+import com.zerostudio.debugger.model.JavaSourceParser.SourceMethod;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/ide-debugger/src/main/java/com/zerostudio/debugger/model/BatchGetValues.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/model/BatchGetValues.java
@@ -82,7 +82,7 @@ public final class BatchGetValues {
         int count = in.readInt();
         List<String> out = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
-            byte tag = in.readByte();
+            byte tag = (byte) in.readByte();
             out.add(readTagValue(in, tag));
         }
         return out;
@@ -108,7 +108,7 @@ public final class BatchGetValues {
         for (int i = 0; i < frameLocalCount; i++) {
             slots[i] = slotIndex.get(i);
             String sig = slotSig.get(i);
-            tags[i] = sig == null || sig.isEmpty() ? 'L' : (byte) sig.charAt(0);
+            tags[i] = sig == null || sig.isEmpty() ? (byte) 'L' : (byte) sig.charAt(0);
             if (tags[i] == '[' || tags[i] == 'L') tags[i] = 'L';
         }
         List<String> values = readValues(threadId, frameId, slots, tags);

--- a/ide-debugger/src/main/java/com/zerostudio/debugger/model/ReferenceFinder.java
+++ b/ide-debugger/src/main/java/com/zerostudio/debugger/model/ReferenceFinder.java
@@ -39,6 +39,7 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.zerostudio.debugger.model.JavaSourceParser.ParsedSource;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
### Motivation
- Repair Java compilation failures in the `ide-debugger` module caused by implicit int→byte conversions and missing references to nested parser model types so the codebase compiles under expected Java versions.

### Description
- Cast the result of `ByteBuf.readByte()` to `byte` in `BatchGetValues` to avoid a possible lossy conversion. (`ide-debugger/src/main/java/com/zerostudio/debugger/model/BatchGetValues.java`)
- Ensure the default `'L'` tag is stored as a `byte` by explicitly casting the char literal to `byte` in `BatchGetValues`. (`ide-debugger/src/main/java/com/zerostudio/debugger/model/BatchGetValues.java`)
- Import nested parser types `JavaSourceParser.ParsedSource`, `JavaSourceParser.SourceClass`, and `JavaSourceParser.SourceMethod` into `AstIndex` so the parser model symbols resolve. (`ide-debugger/src/main/java/com/zerostudio/debugger/model/AstIndex.java`)
- Import `JavaSourceParser.ParsedSource` into `ReferenceFinder` so parsed sources compile correctly. (`ide-debugger/src/main/java/com/zerostudio/debugger/model/ReferenceFinder.java`)

### Testing
- Ran `./gradlew :ide-debugger:compileDebugJavaWithJavac --stacktrace`, which failed due to the default JDK being `25.0.2` and the bundled Kotlin/Gradle scripting stack rejecting that Java version. (failed)
- Ran `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 PATH=/root/.local/share/mise/installs/java/17.0.2/bin:$PATH ./gradlew :ide-debugger:compileDebugJavaWithJavac`, which progressed further but failed to resolve a buildscript dependency (`com.mooltiverse.oss.nyx:gradle:2.5.2`) from Maven Central returning HTTP 403. (failed)
- Note: the original Java compile errors reported prior to these edits were addressed in code, but a full successful module compilation could not be completed here due to environment/dependency issues described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb03f35e8832fb7508b56dbafda33)