### PR TITLE
Fix ide-log-plugin Java compilation

### DIFF
--- a/ide-log-plugin/src/main/java/com/zerostudio/logplugin/api/LogPayload.java
+++ b/ide-log-plugin/src/main/java/com/zerostudio/logplugin/api/LogPayload.java
@@ -11,7 +11,6 @@ package com.zerostudio.logplugin.api;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.itsaky.androidide.logwire.LogPayload;
 
 public final class LogPayload {
     public final byte level;
@@ -37,13 +36,14 @@ public final class LogPayload {
 
     /** Convert to the wire-protocol representation. */
     @NonNull
-    public LogPayload toWire() {
-        return new LogPayload(level, timestampMs, threadId, tag, message, throwable);
+    public com.itsaky.androidide.logwire.LogPayload toWire() {
+        return new com.itsaky.androidide.logwire.LogPayload(
+                level, timestampMs, threadId, tag, message, throwable);
     }
 
     /** Read from the wire format. */
     @NonNull
-    public static LogPayload fromWire(@NonNull LogPayload wire) {
+    public static LogPayload fromWire(@NonNull com.itsaky.androidide.logwire.LogPayload wire) {
         return new LogPayload(
                 wire.level, wire.timestampMs,
                 wire.threadId, wire.tag, wire.message, wire.throwable);

--- a/ide-log-plugin/src/main/java/com/zerostudio/logplugin/jdwp/JdwpServer.java
+++ b/ide-log-plugin/src/main/java/com/zerostudio/logplugin/jdwp/JdwpServer.java
@@ -25,7 +25,6 @@ package com.zerostudio.logplugin.jdwp;
 
 import android.os.Looper;
 import android.util.Log;
-import com.zerostudio.logwire.WireConstants;
 import com.zerostudio.logplugin.capture.LogCaptureService;
 import com.zerostudio.logplugin.transport.LogSocketServer;
 import com.zerostudio.logplugin.util.LogBuffer;


### PR DESCRIPTION
### Motivation
- Resolve Java compilation failures in `ide-log-plugin` caused by an unresolved `WireConstants` import and a `LogPayload` type name collision.

### Description
- Removed the stale `com.zerostudio.logwire.WireConstants` import from `JdwpServer` and updated the plugin API wrapper to use fully-qualified `com.itsaky.androidide.logwire.LogPayload` types in `toWire()` and `fromWire()` to avoid the duplicate-symbol conflict.

### Testing
- Ran `git diff --check`, which reported no whitespace or diff errors; this succeeded.
- Attempted `./gradlew :ide-log-plugin:compileDebugJavaWithJavac --stacktrace`, which could not complete because the build tooling failed to parse the local Java runtime version (`openjdk 25.0.2`), so compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e1e670cf883228ddc2750dfa0ffd2)