### PR TITLE
Copy logger runtime JAR into assets and resolve LogPayload wire type collision

### DIFF
--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/AndroidIDEAssetsPlugin.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/AndroidIDEAssetsPlugin.kt
@@ -28,6 +28,7 @@ import com.itsaky.androidide.plugins.tasks.SetupAapt2Task
 import com.itsaky.androidide.plugins.util.SdkUtils.getAndroidJar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.jvm.tasks.Jar
 import org.gradle.configurationcache.extensions.capitalized
 
 /**
@@ -106,6 +107,29 @@ class AndroidIDEAssetsPlugin : Plugin<Project> {
 
         variant.sources.assets?.addGeneratedSourceDirectory(
             copyToolingApiJar,
+            AddFileToAssetsTask::outputDirectory,
+        )
+
+        // Logger runtime JAR copier
+        val copyLoggerJar =
+            tasks.register(
+                "copy${variantNameCapitalized}LoggerJarToAssets",
+                AddFileToAssetsTask::class.java,
+            ) {
+              val loggerPath = ":logging:logger"
+              val loggerProject =
+                  checkNotNull(rootProject.findProject(loggerPath)) {
+                    "Cannot find the Logger module with project path: '$loggerPath'"
+                  }
+              val loggerJar = loggerProject.tasks.named("jar", Jar::class.java)
+              dependsOn(loggerJar)
+
+              inputFile.set(loggerJar.flatMap { it.archiveFile })
+              baseAssetsPath.set("data/common")
+            }
+
+        variant.sources.assets?.addGeneratedSourceDirectory(
+            copyLoggerJar,
             AddFileToAssetsTask::outputDirectory,
         )
       }

--- a/ide-log-plugin/src/main/java/com/zerostudio/logplugin/api/LogPayload.java
+++ b/ide-log-plugin/src/main/java/com/zerostudio/logplugin/api/LogPayload.java
@@ -11,7 +11,6 @@ package com.zerostudio.logplugin.api;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.itsaky.androidide.logwire.LogPayload;
 
 public final class LogPayload {
     public final byte level;
@@ -37,13 +36,14 @@ public final class LogPayload {
 
     /** Convert to the wire-protocol representation. */
     @NonNull
-    public LogPayload toWire() {
-        return new LogPayload(level, timestampMs, threadId, tag, message, throwable);
+    public com.itsaky.androidide.logwire.LogPayload toWire() {
+        return new com.itsaky.androidide.logwire.LogPayload(
+                level, timestampMs, threadId, tag, message, throwable);
     }
 
     /** Read from the wire format. */
     @NonNull
-    public static LogPayload fromWire(@NonNull LogPayload wire) {
+    public static LogPayload fromWire(@NonNull com.itsaky.androidide.logwire.LogPayload wire) {
         return new LogPayload(
                 wire.level, wire.timestampMs,
                 wire.threadId, wire.tag, wire.message, wire.throwable);

--- a/ide-log-plugin/src/main/java/com/zerostudio/logplugin/jdwp/JdwpServer.java
+++ b/ide-log-plugin/src/main/java/com/zerostudio/logplugin/jdwp/JdwpServer.java
@@ -25,7 +25,6 @@ package com.zerostudio.logplugin.jdwp;
 
 import android.os.Looper;
 import android.util.Log;
-import com.zerostudio.logwire.WireConstants;
 import com.zerostudio.logplugin.capture.LogCaptureService;
 import com.zerostudio.logplugin.transport.LogSocketServer;
 import com.zerostudio.logplugin.util.LogBuffer;


### PR DESCRIPTION
### Motivation
- Ensure the logger runtime JAR from the `:logging:logger` module is packaged into the app assets so the host can use the shared logging implementation at runtime.
- Avoid type-name collisions between the host plugin API and the wire-format `LogPayload` by using fully-qualified references for the wire type in conversions.

### Description
- Add an import for `org.gradle.jvm.tasks.Jar` and register a `copy${variantNameCapitalized}LoggerJarToAssets` task that depends on the `:logging:logger` `jar` task and copies its `archiveFile` into `data/common` in assets.
- Wire the new task into variant asset generation via `variant.sources.assets?.addGeneratedSourceDirectory(...)` using `AddFileToAssetsTask::outputDirectory`.
- Update `ide-log-plugin` `LogPayload` to remove the ambiguous import and make `toWire()` return a `com.itsaky.androidide.logwire.LogPayload` and make `fromWire(...)` accept a `com.itsaky.androidide.logwire.LogPayload` to remove naming conflicts.
- Remove an unused `WireConstants` import in `JdwpServer` (cleanup related to the payload type changes).

### Testing
- Ran a full project build with `./gradlew build` and the build and plugin checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e1e670cf883228ddc2750dfa0ffd2)