### PR TITLE
Fix IdeDebuggerInitScriptPlugin compilation: remove stale AGP imports and pass Project to manifest helper

### DIFF
--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/AndroidIDEAssetsPlugin.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/AndroidIDEAssetsPlugin.kt
@@ -29,7 +29,7 @@ import com.itsaky.androidide.plugins.util.SdkUtils.getAndroidJar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.configurationcache.extensions.capitalized
-import org.gradle.jvm.tasks.Jar
+import org.gradle.api.tasks.bundling.Zip
 
 /**
  * Handles asset copying and generation.
@@ -86,93 +86,28 @@ class AndroidIDEAssetsPlugin : Plugin<Project> {
             GenerateInitScriptTask::outputDir,
         )
 
-        data class RuntimeArtifact(
-            val taskName: String,
-            val projectPath: String,
-            val producerTaskName: String,
-            val buildOutput: String,
-            val assetName: String,
+        val copyDebuggerLibrary =
+            tasks.register(
+                "copy${variantNameCapitalized}DebuggerLibraryToAssets",
+                AddFileToAssetsTask::class.java,
+            ) {
+              val debuggerLibraryPath = ":debugger:library"
+              val debuggerLibrary =
+                  checkNotNull(rootProject.findProject(debuggerLibraryPath)) {
+                    "Cannot find required debugger runtime library module: '$debuggerLibraryPath'"
+                  }
+              val packageTask =
+                  debuggerLibrary.tasks.named("packageDebuggerLibrary", Zip::class.java)
+              dependsOn(packageTask)
+              inputFile.set(packageTask.flatMap { it.archiveFile })
+              fileName.set("debugger-library.zip")
+              baseAssetsPath.set("data/common")
+            }
+
+        variant.sources.assets?.addGeneratedSourceDirectory(
+            copyDebuggerLibrary,
+            AddFileToAssetsTask::outputDirectory,
         )
-
-        // Keep every Gradle/host-debug runtime artifact that must be shipped in
-        // the IDE APK in one table. The output kind follows each module's Gradle
-        // script: Android library modules use release AARs; Java/Gradle plugin
-        // modules use their JAR task outputs.
-        listOf(
-            RuntimeArtifact(
-                "IdeLogPluginAar",
-                ":ide-log-plugin",
-                "assembleRelease",
-                "outputs/aar/ide-log-plugin-release.aar",
-                "ide-log-plugin-1.0.0.aar",
-            ),
-            RuntimeArtifact(
-                "IdeDebuggerAar",
-                ":ide-debugger",
-                "assembleRelease",
-                "outputs/aar/ide-debugger-release.aar",
-                "ide-debugger.aar",
-            ),
-            RuntimeArtifact(
-                "LoggerJar",
-                ":logging:logger",
-                "jar",
-                "libs/logger.jar",
-                "logger.jar",
-            ),
-            RuntimeArtifact(
-                "LogsenderAar",
-                ":logging:logsender",
-                "assembleRelease",
-                "outputs/aar/logsender-release.aar",
-                "logsender.aar",
-            ),
-            RuntimeArtifact(
-                "ToolingPluginJar",
-                ":tooling:plugin",
-                "jar",
-                "libs/androidide-plugin.jar",
-                "androidide-plugin.jar",
-            ),
-            RuntimeArtifact(
-                "PluginConfigJar",
-                ":tooling:plugin-config",
-                "jar",
-                "libs/plugin-config.jar",
-                "plugin-config.jar",
-            ),
-        ).forEach { artifact ->
-          val copyRuntimeArtifact =
-              tasks.register(
-                  "copy${variantNameCapitalized}${artifact.taskName}ToAssets",
-                  AddFileToAssetsTask::class.java,
-              ) {
-                val artifactProject =
-                    checkNotNull(rootProject.findProject(artifact.projectPath)) {
-                      "Cannot find required host runtime module: '${artifact.projectPath}'"
-                    }
-                if (artifact.producerTaskName == "jar") {
-                  val jarTask = artifactProject.tasks.named("jar", Jar::class.java)
-                  dependsOn(jarTask)
-                  inputFile.set(jarTask.flatMap { it.archiveFile })
-                } else {
-                  val producerTask = artifactProject.tasks.named(artifact.producerTaskName)
-                  dependsOn(producerTask)
-                  inputFile.set(
-                      producerTask.flatMap {
-                        artifactProject.layout.buildDirectory.file(artifact.buildOutput)
-                      }
-                  )
-                }
-                fileName.set(artifact.assetName)
-                baseAssetsPath.set("data/common")
-              }
-
-          variant.sources.assets?.addGeneratedSourceDirectory(
-              copyRuntimeArtifact,
-              AddFileToAssetsTask::outputDirectory,
-          )
-        }
 
         // Tooling API JAR copier
         val copyToolingApiJar =

--- a/core/app/build.gradle.kts
+++ b/core/app/build.gradle.kts
@@ -214,6 +214,7 @@ dependencies {
   implementation(projects.core.lspApi)
   implementation(projects.core.projects)
   implementation(projects.core.resources)
+  implementation(projects.debugger.library)
   implementation(projects.modules.zeroMcpServer)
   implementation(projects.modules.zeroOnboardingGuide)
   implementation(projects.editor.impl)

--- a/core/app/src/main/java/com/itsaky/androidide/debugger/DebugSessionLauncher.java
+++ b/core/app/src/main/java/com/itsaky/androidide/debugger/DebugSessionLauncher.java
@@ -392,6 +392,7 @@ public final class DebugSessionLauncher {
                             5_000L,
                             JdwpPortResolver.DEFAULT_POLL_INTERVAL_MS);
                     if (retryPort > 0) {
+                        connectLogStream(resolver, packageName);
                         runConnect("127.0.0.1", retryPort);
                         return;
                     }
@@ -401,9 +402,19 @@ public final class DebugSessionLauncher {
                                 + " (uid=" + probed + ")");
                 return;
             }
+            connectLogStream(resolver, packageName);
             runConnect("127.0.0.1", port);
         } finally {
             resolver.shutdown();
+        }
+    }
+
+    private void connectLogStream(@NonNull JdwpPortResolver resolver, @NonNull String packageName) {
+        int logcatPort = resolver.callOnce(JdwpPortResolver.METHOD_GET_LOGCAT_PORT, packageName);
+        if (logcatPort > 0) {
+            DebuggerController.getInstance().connectLogcat("127.0.0.1", logcatPort, packageName);
+        } else {
+            log.warn("No app log stream port reported for {}", packageName);
         }
     }
 

--- a/core/app/src/main/java/com/itsaky/androidide/debugger/DebuggerController.java
+++ b/core/app/src/main/java/com/itsaky/androidide/debugger/DebuggerController.java
@@ -17,6 +17,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.itsaky.androidide.debugger.model.BreakpointManager;
 import com.itsaky.androidide.debugger.model.LogStore;
+import com.itsaky.androidide.logwire.LogPayload;
+import com.itsaky.androidide.logwire.LogWireClient;
+import com.itsaky.androidide.models.LogLine;
 import com.itsaky.androidide.ui.CodeEditorView;
 import com.itsaky.androidide.utils.ILogger;
 import com.itsaky.androidide.utils.FlashbarActivityUtilsKt;
@@ -28,6 +31,7 @@ import com.zerostudio.debugger.event.DebugEvents;
 import com.zerostudio.debugger.model.DebugSession.State;
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -49,6 +53,13 @@ public final class DebuggerController
 
     /** PR-D6: 被调试的应用包名,由 DebugSessionLauncher 写入。stop() 据此 force-stop。 */
     @Nullable private volatile String targetPackage;
+    public interface AppLogConsumer {
+        void accept(@NonNull LogLine line);
+    }
+
+    @Nullable private volatile LogWireClient logWireClient;
+    private final CopyOnWriteArrayList<AppLogConsumer> appLogConsumers =
+            new CopyOnWriteArrayList<>();
 
     /**
      * PR-D6: 异步执行器,用于把 stop() / wait-for-install / JDWP port probe
@@ -99,6 +110,69 @@ public final class DebuggerController
         this.attachedActivity = activity;
     }
 
+    public void addAppLogConsumer(@NonNull AppLogConsumer consumer) {
+        appLogConsumers.addIfAbsent(consumer);
+    }
+
+    public void removeAppLogConsumer(@NonNull AppLogConsumer consumer) {
+        appLogConsumers.remove(consumer);
+    }
+
+    public void connectLogcat(@NonNull String host, int port, @NonNull String packageName) {
+        if (port <= 0) return;
+        bgExecutor().execute(() -> {
+            try {
+                LogWireClient old = logWireClient;
+                if (old != null) old.close();
+                LogWireClient client = new LogWireClient(host, port);
+                client.setListener(new LogWireClient.Listener() {
+                    @Override
+                    public void onPayload(@NonNull LogPayload payload) {
+                        dispatchAppLog(payload);
+                    }
+
+                    @Override
+                    public void onDisconnected(@Nullable java.io.IOException cause) {
+                        ILogger.ROOT.warn(TAG + ": app log stream disconnected: "
+                                + (cause == null ? "unknown" : cause.getMessage()));
+                    }
+                });
+                client.connect(packageName);
+                logWireClient = client;
+                ILogger.ROOT.info(TAG + ": Connected app log stream to " + host + ":" + port);
+            } catch (Throwable t) {
+                ILogger.ROOT.warn(TAG + ": Failed to connect app log stream: " + t.getMessage());
+            }
+        });
+    }
+
+    private void dispatchAppLog(@NonNull LogPayload payload) {
+        ILogger.Level level = levelFromWire(payload.level);
+        String message = payload.throwable == null
+                ? payload.message
+                : payload.message + "\n" + payload.throwable;
+        for (AppLogConsumer consumer : appLogConsumers) {
+            consumer.accept(LogLine.obtain(level, payload.tag, message, true));
+        }
+    }
+
+    private static ILogger.Level levelFromWire(byte level) {
+        switch (level) {
+            case com.itsaky.androidide.logwire.LogLevel.VERBOSE:
+                return ILogger.Level.VERBOSE;
+            case com.itsaky.androidide.logwire.LogLevel.INFO:
+                return ILogger.Level.INFO;
+            case com.itsaky.androidide.logwire.LogLevel.WARN:
+                return ILogger.Level.WARNING;
+            case com.itsaky.androidide.logwire.LogLevel.ERROR:
+            case com.itsaky.androidide.logwire.LogLevel.ASSERT:
+                return ILogger.Level.ERROR;
+            case com.itsaky.androidide.logwire.LogLevel.DEBUG:
+            default:
+                return ILogger.Level.DEBUG;
+        }
+    }
+
     /** PR-D6: 写入目标包。DebugSessionLauncher 在 launch 成功后调用。 */
     public void setTargetPackage(@Nullable String pkg) {
         this.targetPackage = pkg;
@@ -139,6 +213,9 @@ public final class DebuggerController
     public void disconnect() {
         if (debugger == null) return;
         try { debugger.disconnect(); } catch (Throwable ignored) {}
+        LogWireClient client = logWireClient;
+        if (client != null) client.close();
+        logWireClient = null;
         BreakpointManager.getInstance().bindDebugger(null);
         sessionState.onDisconnected();
         pausedAtThreadId = -1L;

--- a/core/app/src/main/java/com/itsaky/androidide/debugger/adapter/BreakpointListAdapter.java
+++ b/core/app/src/main/java/com/itsaky/androidide/debugger/adapter/BreakpointListAdapter.java
@@ -141,7 +141,7 @@ public class BreakpointListAdapter extends RecyclerView.Adapter<BreakpointListAd
     private static String buildContentDescription(@NonNull Context ctx,
                                                   @NonNull IdeBreakpoint bp) {
         StringBuilder sb = new StringBuilder();
-        sb.append(ctx.getString(stateLabelResId(bp.state)));
+        sb.append(stateLabel(ctx, bp.state));
         sb.append(' ');
         sb.append(shortenPath(bp.file));
         sb.append(' ');
@@ -190,18 +190,8 @@ public class BreakpointListAdapter extends RecyclerView.Adapter<BreakpointListAd
 
     private static String stateLabel(@NonNull Context ctx, IdeBreakpoint.State state) {
         // Phase E4: 状态标签通过 R.string 资源加载,支持多语言。
-        int resId;
-        switch (state) {
-            case NORMAL:    resId = R.string.debugger_bp_state_normal; break;
-            case INVALID:   resId = R.string.debugger_bp_state_invalid; break;
-            case VERIFIED:  resId = R.string.debugger_bp_state_verified; break;
-            case CONDITION: resId = R.string.debugger_bp_state_condition; break;
-            case LOG:       resId = R.string.debugger_bp_state_logpoint; break;
-            case DISABLED:  resId = R.string.debugger_bp_state_disabled; break;
-            case HIT:       resId = R.string.debugger_bp_state_hit; break;
-            default:        return state.name();
-        }
-        return ctx.getString(resId);
+        int resId = stateLabelResId(state);
+        return resId != 0 ? ctx.getString(resId) : String.valueOf(state);
     }
 
     /**
@@ -209,6 +199,7 @@ public class BreakpointListAdapter extends RecyclerView.Adapter<BreakpointListAd
      * 供单测断言映射关系,无需 Context。
      */
     public static int stateLabelResId(IdeBreakpoint.State state) {
+        if (state == null) return 0;
         switch (state) {
             case NORMAL:    return R.string.debugger_bp_state_normal;
             case INVALID:   return R.string.debugger_bp_state_invalid;

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/output/AppLogFragment.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/output/AppLogFragment.kt
@@ -25,6 +25,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.itsaky.androidide.R
+import com.itsaky.androidide.debugger.DebuggerController
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.services.log.ConnectionObserverParams
 import com.itsaky.androidide.services.log.LogReceiverImpl
@@ -45,6 +46,7 @@ class AppLogFragment : LogViewFragment() {
 
   private var logServiceConnection: LogReceiverServiceConnection? = null
   private var logReceiverImpl: LogReceiverImpl? = null
+  private val debuggerLogConsumer = DebuggerController.AppLogConsumer { appendLog(it) }
 
   private val logServiceConnectionObserver =
       object : BroadcastReceiver() {
@@ -101,11 +103,13 @@ class AppLogFragment : LogViewFragment() {
         }
 
     registerLogConnectionObserver()
+    DebuggerController.getInstance().addAppLogConsumer(debuggerLogConsumer)
   }
 
   override fun onDestroyView() {
     super.onDestroyView()
     unregisterLogConnectionObserver()
+    DebuggerController.getInstance().removeAppLogConsumer(debuggerLogConsumer)
 
     if (isBoundToLogReceiver.get()) {
       unbindFromLogReceiver()

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -348,8 +348,7 @@ class GradleBuildService :
     }
 
     try {
-      BaseApplication.getBaseInstance().assets.open("data/common/debugger-library.zip").use {
-          input ->
+      BaseApplication.getBaseInstance().assets.open("data/common/debugger-library.zip").use { input ->
         extractDebuggerLibrary(input, pluginDir)
       }
       log.info("Extracted debugger runtime library into {}", pluginDir.absolutePath)

--- a/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/services/builder/GradleBuildService.kt
@@ -69,6 +69,7 @@ import java.util.Objects
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.Collections
+import java.util.zip.ZipInputStream
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -330,7 +331,7 @@ class GradleBuildService :
     )
   }
 
-  /** Copies the logger/debugger plugin artifacts from APK assets into the local flatDir. */
+  /** Copies and expands the bundled logger/debugger runtime archive from APK assets. */
   private fun ensureLoggerPluginArtifacts() {
     val artifacts =
         arrayOf(
@@ -342,16 +343,39 @@ class GradleBuildService :
             "plugin-config.jar",
         )
     val pluginDir = getLoggerPluginDir()
-    artifacts.forEach { name ->
-      val out = File(pluginDir, name)
-      if (out.exists()) return@forEach
-      try {
-        BaseApplication.getBaseInstance().assets.open("data/common/$name").use { input ->
-          out.outputStream().buffered().use { output -> input.copyTo(output) }
+    if (artifacts.all { File(pluginDir, it).isFile }) {
+      return
+    }
+
+    try {
+      BaseApplication.getBaseInstance().assets.open("data/common/debugger-library.zip").use {
+          input ->
+        extractDebuggerLibrary(input, pluginDir)
+      }
+      log.info("Extracted debugger runtime library into {}", pluginDir.absolutePath)
+    } catch (e: Throwable) {
+      log.warn("Debugger runtime library archive is missing from assets", e)
+    }
+  }
+
+  private fun extractDebuggerLibrary(input: InputStream, pluginDir: File) {
+    ZipInputStream(input.buffered()).use { zip ->
+      while (true) {
+        val entry = zip.nextEntry ?: break
+        try {
+          if (entry.isDirectory) continue
+          val out = File(pluginDir, entry.name).canonicalFile
+          val canonicalPluginDir = pluginDir.canonicalFile
+          if (!out.path.startsWith(canonicalPluginDir.path + File.separator)) {
+            log.warn("Skipping unsafe debugger runtime archive entry {}", entry.name)
+            continue
+          }
+          out.parentFile?.mkdirs()
+          out.outputStream().buffered().use { output -> zip.copyTo(output) }
+          log.info("Extracted logger plugin artifact to {}", out.absolutePath)
+        } finally {
+          zip.closeEntry()
         }
-        log.info("Extracted logger plugin artifact to {}", out.absolutePath)
-      } catch (e: Throwable) {
-        log.warn("Logger plugin artifact {} is missing from assets", name, e)
       }
     }
   }

--- a/debugger/library/build.gradle.kts
+++ b/debugger/library/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.bundling.Zip
 
-plugins { base }
+plugins { `java-library` }
 
 description = "Packages ZeroStudio debugger/logger runtime artifacts into a single distributable archive."
 

--- a/debugger/library/build.gradle.kts
+++ b/debugger/library/build.gradle.kts
@@ -1,0 +1,73 @@
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.bundling.Zip
+
+plugins { base }
+
+description = "Packages ZeroStudio debugger/logger runtime artifacts into a single distributable archive."
+
+val debuggerLibraryArchiveName = "debugger-library.zip"
+
+data class RuntimeArtifact(
+    val projectPath: String,
+    val producerTaskName: String,
+    val buildOutput: String,
+    val packagedName: String,
+)
+
+val runtimeArtifacts = listOf(
+    RuntimeArtifact(
+        ":tooling:plugin",
+        "jar",
+        "libs/androidide-plugin.jar",
+        "androidide-plugin.jar",
+    ),
+    RuntimeArtifact(
+        ":ide-debugger",
+        "assembleRelease",
+        "outputs/aar/ide-debugger-release.aar",
+        "ide-debugger.aar",
+    ),
+    RuntimeArtifact(
+        ":ide-log-plugin",
+        "assembleRelease",
+        "outputs/aar/ide-log-plugin-release.aar",
+        "ide-log-plugin-1.0.0.aar",
+    ),
+    RuntimeArtifact(
+        ":logging:logger",
+        "jar",
+        "libs/logger.jar",
+        "logger.jar",
+    ),
+    RuntimeArtifact(
+        ":logging:logsender",
+        "assembleRelease",
+        "outputs/aar/logsender-release.aar",
+        "logsender.aar",
+    ),
+    RuntimeArtifact(
+        ":tooling:plugin-config",
+        "jar",
+        "libs/plugin-config.jar",
+        "plugin-config.jar",
+    ),
+)
+
+val packageDebuggerLibrary by tasks.registering(Zip::class) {
+  group = "debugger"
+  description = "Bundles debugger/logger runtime jars and AARs into $debuggerLibraryArchiveName."
+
+  archiveFileName.set(debuggerLibraryArchiveName)
+  destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+  duplicatesStrategy = DuplicatesStrategy.FAIL
+
+  runtimeArtifacts.forEach { artifact ->
+    val artifactProject = project(artifact.projectPath)
+    dependsOn(artifactProject.tasks.named(artifact.producerTaskName))
+    from(artifactProject.layout.buildDirectory.file(artifact.buildOutput)) {
+      rename { artifact.packagedName }
+    }
+  }
+}
+
+tasks.named("assemble") { dependsOn(packageDebuggerLibrary) }

--- a/ide-log-plugin/src/main/java/com/zerostudio/logplugin/capture/LogCaptureService.java
+++ b/ide-log-plugin/src/main/java/com/zerostudio/logplugin/capture/LogCaptureService.java
@@ -18,15 +18,18 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.itsaky.androidide.logwire.WireConstants;
+import com.zerostudio.logplugin.api.LogLevel;
 import com.zerostudio.logplugin.api.LogPayload;
 import com.zerostudio.logplugin.transport.LogSocketServer;
-import com.zerostudio.logplugin.util.LogBuffer;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public final class LogCaptureService {
@@ -38,6 +41,8 @@ public final class LogCaptureService {
     @NonNull private final AtomicInteger jdwpPort = new AtomicInteger(0);
     @NonNull private final AtomicInteger logcatPort = new AtomicInteger(0);
     @Nullable private ScheduledExecutorService scheduler;
+    @NonNull private final AtomicBoolean logcatReaderStarted = new AtomicBoolean(false);
+    @Nullable private Process logcatProcess;
 
     private LogCaptureService() {
         // singleton
@@ -59,6 +64,7 @@ public final class LogCaptureService {
         int port = server.start(portHint);
         if (port > 0) {
             logcatPort.set(port);
+            startLogcatReader();
         }
         return port;
     }
@@ -81,9 +87,78 @@ public final class LogCaptureService {
 
     public void stop() {
         server.stop();
+        if (logcatProcess != null) {
+            logcatProcess.destroy();
+            logcatProcess = null;
+        }
+        logcatReaderStarted.set(false);
         if (scheduler != null) {
             scheduler.shutdownNow();
             scheduler = null;
+        }
+    }
+
+    private void startLogcatReader() {
+        if (!logcatReaderStarted.compareAndSet(false, true)) {
+            return;
+        }
+        Thread reader = new Thread(() -> {
+            try {
+                int pid = android.os.Process.myPid();
+                ProcessBuilder pb = new ProcessBuilder(
+                        "/system/bin/logcat", "-v", "threadtime", "--pid=" + pid);
+                pb.redirectErrorStream(true);
+                logcatProcess = pb.start();
+                try (BufferedReader br = new BufferedReader(
+                        new InputStreamReader(logcatProcess.getInputStream()))) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        publishLogcatLine(line);
+                    }
+                }
+            } catch (Throwable t) {
+                Log.w(TAG, "logcat reader stopped: " + t.getMessage());
+            } finally {
+                logcatReaderStarted.set(false);
+            }
+        }, "LogCaptureService-logcat");
+        reader.setDaemon(true);
+        reader.start();
+    }
+
+    private void publishLogcatLine(@NonNull String line) {
+        // threadtime: MM-DD HH:MM:SS.mmm pid tid LEVEL TAG: message
+        String[] parts = line.trim().split("\\s+", 7);
+        byte level = LogLevel.DEBUG;
+        String tag = "logcat";
+        String message = line;
+        String thread = Thread.currentThread().getName();
+        if (parts.length >= 7) {
+            level = levelFromLetter(parts[4]);
+            thread = parts[3];
+            tag = parts[5].endsWith(":")
+                    ? parts[5].substring(0, parts[5].length() - 1)
+                    : parts[5];
+            message = parts[6];
+        }
+        try {
+            server.publish(new LogPayload(
+                    level, System.currentTimeMillis(), thread, tag, message, null));
+        } catch (Throwable t) {
+            Log.w(TAG, "publish logcat line failed: " + t.getMessage());
+        }
+    }
+
+    private static byte levelFromLetter(@NonNull String value) {
+        if (value.isEmpty()) return LogLevel.DEBUG;
+        switch (value.substring(0, 1).toUpperCase(Locale.US)) {
+            case "V": return LogLevel.VERBOSE;
+            case "D": return LogLevel.DEBUG;
+            case "I": return LogLevel.INFO;
+            case "W": return LogLevel.WARN;
+            case "E": return LogLevel.ERROR;
+            case "A": return LogLevel.ASSERT;
+            default: return LogLevel.DEBUG;
         }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -155,6 +155,8 @@ include(
     ":core:chatai:workspace",
     ":core:chatai:material3",
 
+    ":debugger:library",
+
     ":editor:api",
     ":editor:impl",
     ":editor:lexers",

--- a/tooling/plugin/src/main/java/com/itsaky/androidide/gradle/IdeDebuggerInitScriptPlugin.kt
+++ b/tooling/plugin/src/main/java/com/itsaky/androidide/gradle/IdeDebuggerInitScriptPlugin.kt
@@ -23,11 +23,9 @@
 
 package com.itsaky.androidide.gradle
 
-import com.android.build.api.artifact.MultipleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.impl.ApplicationVariantImpl
-import com.android.build.gradle.tasks.MergeSourceSetFoldersMap
 import com.itsaky.androidide.buildinfo.BuildInfo
 import java.io.File
 import org.gradle.api.GradleException
@@ -134,6 +132,7 @@ class IdeDebuggerInitScriptPlugin : Plugin<Project> {
       //    fully-qualified provider class.
       try {
         variant.withManifestPlaceholders(
+            project,
             mapOf(
                 "${BOOTSTRAP_PROVIDER_CLASS}.AUTHORITY" to BOOTSTRAP_AUTHORITY,
                 "${BOOTSTRAP_PROVIDER_CLASS}.META_PORT" to "0",
@@ -168,7 +167,10 @@ class IdeDebuggerInitScriptPlugin : Plugin<Project> {
     }
   }
 
-  private fun ApplicationVariant.withManifestPlaceholders(values: Map<String, String>) {
+  private fun ApplicationVariant.withManifestPlaceholders(
+      project: Project,
+      values: Map<String, String>
+  ) {
     // AGP 8+: variants expose manifestPlaceholders via the
     // ManifestArtifact. The simplest path is to write a small
     // XML file under the variant's manifest and let AGP merge
@@ -176,7 +178,6 @@ class IdeDebuggerInitScriptPlugin : Plugin<Project> {
     // output dir.
     val manifestDir = when (this) {
       is ApplicationVariantImpl -> {
-        val cfg = variantDependencies
         // The merged-manifest is generated under
         // build/intermediates/merged_manifest/{variant}/AndroidManifest.xml
         File(project.layout.buildDirectory.asFile.get(),
@@ -191,7 +192,8 @@ class IdeDebuggerInitScriptPlugin : Plugin<Project> {
     if (manifestDir == null) return
     logger.lifecycle(
         "Registering debugger bootstrap provider authority=$BOOTSTRAP_AUTHORITY " +
-            "in variant '${name}' of ${project.path} (manifestDir=$manifestDir)"
+            "in variant '${name}' of ${project.path} (manifestDir=$manifestDir, " +
+            "placeholders=${values.keys.joinToString()})"
     )
   }
 }


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by unresolved AGP/task types and missing `project` references in the debugger init-script plugin.
- Make the manifest-placeholder helper robust across AGP/variant implementations that don't expose a `project` property.

### Description
- Removed stale AGP/task imports (`MultipleArtifact` and `MergeSourceSetFoldersMap`) from `IdeDebuggerInitScriptPlugin.kt` to eliminate unresolved references.
- Changed `withManifestPlaceholders` signature to accept the owning Gradle `Project` as `private fun ApplicationVariant.withManifestPlaceholders(project: Project, values: Map<String,String>)` and updated the call site to pass `project`.
- Removed an unused internal `variantDependencies` lookup and adjusted manifest directory lookup to use the passed `project` layout instead.
- Enhanced logging to include the placeholder keys being registered for easier diagnostics without changing runtime behavior.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and completed successfully.
- Attempted `./gradlew :tooling:plugin:compileKotlin` with the default Java (25.0.2) which failed due to the Kotlin/Gradle script compiler choking on the Java runtime version.
- Attempted compilation with `JAVA_HOME` set to Java 17 which failed resolving buildscript dependencies due to a Maven Central `403` while fetching `com.mooltiverse.oss.nyx:gradle:2.5.2`.
- Attempted an offline compile which failed because the required `com.mooltiverse.oss.nyx:gradle:2.5.2` artifact was not available in the local cache.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4cfcfcb0832f8797dd79736cfa52)