### PR TITLE
Parse minor API levels in api-versions.xml and fix proot version-catalog aliases

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
@@ -34,7 +34,14 @@ import com.itsaky.androidide.preferences.internal.EditorPreferences.AUTO_SAVE_EN
 import com.itsaky.androidide.preferences.internal.EditorPreferences.AUTO_SAVE_ON_FOCUS_LOSS
 import com.itsaky.androidide.preferences.internal.EditorPreferences.COLOR_SCHEME
 import com.itsaky.androidide.preferences.internal.EditorPreferences.COMPLETIONS_MATCH_LOWER
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_IME_SCROLL_POSITION
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_IME_VISIBLE_SCROLL
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_SCROLL_POSITION_BOTTOM
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_SCROLL_POSITION_CENTER
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_SCROLL_POSITION_TOP
 import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_STYLE
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_VISIBLE_AREA_SCROLL
+import com.itsaky.androidide.preferences.internal.EditorPreferences.CURSOR_VISIBLE_AREA_SCROLL_POSITION
 import com.itsaky.androidide.preferences.internal.EditorPreferences.DEFAULT_COLOR_SCHEME
 import com.itsaky.androidide.preferences.internal.EditorPreferences.DELETE_EMPTY_LINES
 import com.itsaky.androidide.preferences.internal.EditorPreferences.DELETE_TABS_ON_BACKSPACE
@@ -173,6 +180,10 @@ private class CursorAndSelectionPreferences(
   init {
     addPreference(SmoothCursorMovement())
     addPreference(CursorStylePreference())
+    addPreference(CursorImeVisibleScrollPreference())
+    addPreference(CursorImeScrollPositionPreference())
+    addPreference(CursorVisibleAreaScrollPreference())
+    addPreference(CursorVisibleAreaScrollPositionPreference())
   }
 }
 
@@ -223,6 +234,137 @@ private class SmoothCursorMovement(
         setValue = EditorPreferences::smoothCursorMovement::set,
         getValue = EditorPreferences::smoothCursorMovement::get,
     )
+
+@Parcelize
+private class CursorImeVisibleScrollPreference(
+    override val key: String = CURSOR_IME_VISIBLE_SCROLL,
+    override val title: Int = R.string.pref_cursor_ime_visible_scroll_title,
+    override val summary: Int? = R.string.pref_cursor_ime_visible_scroll_summary,
+    override val icon: Int? = R.drawable.ic_cursor_move,
+) :
+    SwitchPreference(
+        setValue = EditorPreferences::cursorImeVisibleScroll::set,
+        getValue = EditorPreferences::cursorImeVisibleScroll::get,
+    )
+
+@Parcelize
+private class CursorVisibleAreaScrollPreference(
+    override val key: String = CURSOR_VISIBLE_AREA_SCROLL,
+    override val title: Int = R.string.pref_cursor_visible_area_scroll_title,
+    override val summary: Int? = R.string.pref_cursor_visible_area_scroll_summary,
+    override val icon: Int? = R.drawable.ic_cursor_move,
+) :
+    SwitchPreference(
+        setValue = EditorPreferences::cursorVisibleAreaScroll::set,
+        getValue = EditorPreferences::cursorVisibleAreaScroll::get,
+    )
+
+private data class CursorScrollPosition(val labelRes: Int, val value: String)
+
+private val cursorScrollPositions =
+    arrayOf(
+        CursorScrollPosition(R.string.pref_cursor_scroll_position_top, CURSOR_SCROLL_POSITION_TOP),
+        CursorScrollPosition(
+            R.string.pref_cursor_scroll_position_center,
+            CURSOR_SCROLL_POSITION_CENTER,
+        ),
+        CursorScrollPosition(
+            R.string.pref_cursor_scroll_position_bottom,
+            CURSOR_SCROLL_POSITION_BOTTOM,
+        ),
+    )
+
+@Parcelize
+private class CursorImeScrollPositionPreference(
+    override val key: String = CURSOR_IME_SCROLL_POSITION,
+    override val title: Int = R.string.pref_cursor_ime_scroll_position_title,
+    override val summary: Int? = R.string.pref_cursor_ime_scroll_position_summary,
+    override val icon: Int? = R.drawable.ic_cursor_move,
+) : SingleChoicePreference() {
+
+  @IgnoredOnParcel override val dialogCancellable = true
+
+  override fun getEntries(preference: Preference): Array<PreferenceChoices.Entry> {
+    val currentPosition = EditorPreferences.cursorImeScrollPosition
+    return Array(cursorScrollPositions.size) { index ->
+      val position = cursorScrollPositions[index]
+      PreferenceChoices.Entry(
+          preference.context.getString(position.labelRes),
+          currentPosition == position.value,
+          position.value,
+      )
+    }
+  }
+
+  override fun onChoiceConfirmed(
+      preference: Preference,
+      entry: PreferenceChoices.Entry?,
+      position: Int,
+  ) {
+    EditorPreferences.cursorImeScrollPosition =
+        (entry?.data as? String) ?: CURSOR_SCROLL_POSITION_BOTTOM
+    updateSummary(preference)
+  }
+
+  override fun onCreatePreference(context: Context): Preference {
+    return super.onCreatePreference(context).also { updateSummary(it) }
+  }
+
+  private fun updateSummary(preference: Preference) {
+    preference.summary =
+        preference.context.getString(
+            cursorScrollPositions
+                .firstOrNull { it.value == EditorPreferences.cursorImeScrollPosition }
+                ?.labelRes ?: R.string.pref_cursor_scroll_position_bottom
+        )
+  }
+}
+
+@Parcelize
+private class CursorVisibleAreaScrollPositionPreference(
+    override val key: String = CURSOR_VISIBLE_AREA_SCROLL_POSITION,
+    override val title: Int = R.string.pref_cursor_visible_area_scroll_position_title,
+    override val summary: Int? = R.string.pref_cursor_visible_area_scroll_position_summary,
+    override val icon: Int? = R.drawable.ic_cursor_move,
+) : SingleChoicePreference() {
+
+  @IgnoredOnParcel override val dialogCancellable = true
+
+  override fun getEntries(preference: Preference): Array<PreferenceChoices.Entry> {
+    val currentPosition = EditorPreferences.cursorVisibleAreaScrollPosition
+    return Array(cursorScrollPositions.size) { index ->
+      val position = cursorScrollPositions[index]
+      PreferenceChoices.Entry(
+          preference.context.getString(position.labelRes),
+          currentPosition == position.value,
+          position.value,
+      )
+    }
+  }
+
+  override fun onChoiceConfirmed(
+      preference: Preference,
+      entry: PreferenceChoices.Entry?,
+      position: Int,
+  ) {
+    EditorPreferences.cursorVisibleAreaScrollPosition =
+        (entry?.data as? String) ?: CURSOR_SCROLL_POSITION_CENTER
+    updateSummary(preference)
+  }
+
+  override fun onCreatePreference(context: Context): Preference {
+    return super.onCreatePreference(context).also { updateSummary(it) }
+  }
+
+  private fun updateSummary(preference: Preference) {
+    preference.summary =
+        preference.context.getString(
+            cursorScrollPositions
+                .firstOrNull { it.value == EditorPreferences.cursorVisibleAreaScrollPosition }
+                ?.labelRes ?: R.string.pref_cursor_scroll_position_center
+        )
+  }
+}
 
 @Parcelize
 private class AutoSavePreferences(

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -147,11 +147,53 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
     }
 
     if (transitionedToVisible) {
-      editorView.post {
-        val cursor = editorView.cursor ?: return@post
-        editorView.ensurePositionVisible(cursor.rightLine, cursor.rightColumn)
-      }
+      editorView.post { adjustCursorLineForObscuredArea(editorView, forceImeMode = true) }
     }
+  }
+
+  private fun adjustCursorLineForObscuredArea(
+      editorView: IDEEditor,
+      forceImeMode: Boolean = false,
+  ) {
+    val cursor = editorView.cursor ?: return
+    val useImeMode = forceImeMode || isKeyboardVisible
+    val position =
+        if (useImeMode) {
+          if (!EditorPreferences.cursorImeVisibleScroll) return
+          EditorPreferences.cursorImeScrollPosition
+        } else {
+          if (!EditorPreferences.cursorVisibleAreaScroll) return
+          EditorPreferences.cursorVisibleAreaScrollPosition
+        }
+    val obscuredBottom = if (useImeMode) imeBottomInset else 0
+    editorView.scrollCursorLineToVisiblePosition(cursor.rightLine, position, obscuredBottom)
+  }
+
+  private fun IDEEditor.scrollCursorLineToVisiblePosition(
+      line: Int,
+      position: String,
+      obscuredBottom: Int,
+  ) {
+    val rowHeight = getRowHeight().coerceAtLeast(1)
+    val visibleHeight = (height - obscuredBottom).coerceAtLeast(rowHeight)
+    val rowTop = getRowTop(line)
+    val rowBottom = getRowBottom(line)
+    val rowCenter = (rowTop + rowBottom) / 2f
+    val targetY =
+        when (position) {
+          EditorPreferences.CURSOR_SCROLL_POSITION_TOP -> rowTop - rowHeight
+          EditorPreferences.CURSOR_SCROLL_POSITION_CENTER -> rowCenter - visibleHeight / 2f
+          else -> rowBottom - visibleHeight + rowHeight * CURSOR_BOTTOM_VISIBLE_MARGIN_ROWS
+        }
+            .coerceIn(0f, getScrollMaxY().toFloat())
+    val deltaY = targetY - getOffsetY()
+    if (deltaY > -1f && deltaY < 1f) {
+      invalidate()
+      return
+    }
+    getScroller().forceFinished(true)
+    getScroller().startScroll(getOffsetX(), getOffsetY(), 0, deltaY.toInt(), 0)
+    invalidate()
   }
 
   /** Get the file of this editor. */
@@ -173,6 +215,7 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
   companion object {
 
     private val log = LoggerFactory.getLogger(CodeEditorView::class.java)
+    private const val CURSOR_BOTTOM_VISIBLE_MARGIN_ROWS = 3
 
     @Volatile private var isTreeSitterLoaded = false
 
@@ -216,10 +259,9 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
       }
 
       // Keep action enabled/disabled states in sync with cursor/selection changes.
-      // Do not auto-scroll on every cursor move: Sora already keeps the caret readable, and
-      // forcing ensurePositionVisible() here can push the active line to the IME toolbar area.
       subscribeEvent(SelectionChangeEvent::class.java) { _, _ ->
         (context as? Activity?)?.invalidateOptionsMenu()
+        this.post { adjustCursorLineForObscuredArea(this) }
       }
     }
 

--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -216,12 +216,10 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
       }
 
       // Keep action enabled/disabled states in sync with cursor/selection changes.
+      // Do not auto-scroll on every cursor move: Sora already keeps the caret readable, and
+      // forcing ensurePositionVisible() here can push the active line to the IME toolbar area.
       subscribeEvent(SelectionChangeEvent::class.java) { _, _ ->
         (context as? Activity?)?.invalidateOptionsMenu()
-        if (isKeyboardVisible) {
-          val cursor = this.cursor ?: return@subscribeEvent
-          this.post { ensurePositionVisible(cursor.rightLine, cursor.rightColumn) }
-        }
       }
     }
 

--- a/core/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/core/resources/src/main/res/values-zh-rCN/strings.xml
@@ -138,6 +138,17 @@
      <string name="pref_smooth_cursor_movement_title">启用平滑光标移动</string>
      <string name="pref_smooth_cursor_movement_summary">光标移动时带有平滑动画效果</string>
      <string name="pref_cursor_style_title">光标样式</string>
+     <string name="pref_cursor_ime_visible_scroll_title">防止 IME 遮挡光标行</string>
+     <string name="pref_cursor_ime_visible_scroll_summary">软键盘或输入工具栏遮挡编辑器时，自动滚动光标所在行到可见区域。默认开启。</string>
+     <string name="pref_cursor_visible_area_scroll_title">无 IME 时自动滚动光标行</string>
+     <string name="pref_cursor_visible_area_scroll_summary">软键盘隐藏时，自动将光标所在行对齐到编辑器可见区域。默认关闭。</string>
+     <string name="pref_cursor_ime_scroll_position_title">IME 弹出时光标行位置</string>
+     <string name="pref_cursor_ime_scroll_position_summary">选择防 IME 遮挡滚动时光标所在行显示的位置。</string>
+     <string name="pref_cursor_visible_area_scroll_position_title">可见区域光标行位置</string>
+     <string name="pref_cursor_visible_area_scroll_position_summary">选择无 IME 自动滚动开启时光标所在行显示的位置。</string>
+     <string name="pref_cursor_scroll_position_top">上</string>
+     <string name="pref_cursor_scroll_position_center">中</string>
+     <string name="pref_cursor_scroll_position_bottom">下</string>
      <string name="pref_group_code_intelligence">代码智能</string>
      <string name="pref_auto_complete_on_type_title">自动弹出代码补全</string>
      <string name="pref_auto_complete_on_type_summary">在输入时自动显示代码补全建议</string>

--- a/core/resources/src/main/res/values/strings_b.xml
+++ b/core/resources/src/main/res/values/strings_b.xml
@@ -139,6 +139,17 @@
      <string name="pref_smooth_cursor_movement_title">Enable smooth cursor movement</string>
      <string name="pref_smooth_cursor_movement_summary">The cursor moves with a smooth animation effect</string>
      <string name="pref_cursor_style_title">Cursor Style</string>
+     <string name="pref_cursor_ime_visible_scroll_title">Keep cursor line above IME</string>
+     <string name="pref_cursor_ime_visible_scroll_summary">When the soft keyboard or an input toolbar covers the editor, automatically scroll the cursor line into the visible area. Enabled by default.</string>
+     <string name="pref_cursor_visible_area_scroll_title">Auto-scroll cursor line without IME</string>
+     <string name="pref_cursor_visible_area_scroll_summary">When the soft keyboard is hidden, automatically align the cursor line in the visible editor area. Disabled by default.</string>
+     <string name="pref_cursor_ime_scroll_position_title">IME cursor line position</string>
+     <string name="pref_cursor_ime_scroll_position_summary">Choose where to place the cursor line when IME protection scrolls.</string>
+     <string name="pref_cursor_visible_area_scroll_position_title">Cursor line visible-area position</string>
+     <string name="pref_cursor_visible_area_scroll_position_summary">Choose where to place the cursor line when non-IME auto-scroll is enabled.</string>
+     <string name="pref_cursor_scroll_position_top">Top</string>
+     <string name="pref_cursor_scroll_position_center">Center</string>
+     <string name="pref_cursor_scroll_position_bottom">Bottom</string>
      <string name="pref_group_code_intelligence">Code Intelligence</string>
      <string name="pref_auto_complete_on_type_title">Automatic code completion popup</string>
      <string name="pref_auto_complete_on_type_summary">Automatically show code completion suggestions while typing</string>

--- a/termux/proot/build.gradle.kts
+++ b/termux/proot/build.gradle.kts
@@ -45,9 +45,9 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx-appcompat)
+    implementation(libs.androidx.appcompat)
     implementation(libs.google.material)
     testImplementation(libs.tests.junit)
-    androidTestImplementation(libs.tests.androidx.test.junit)
-    androidTestImplementation(libs.tests.androidx.test.espresso)
+    androidTestImplementation(libs.tests.androidx.junit)
+    androidTestImplementation(libs.tests.androidx.espresso.core)
 }

--- a/utilities/preferences/src/main/java/com/itsaky/androidide/preferences/internal/EditorPreferences.kt
+++ b/utilities/preferences/src/main/java/com/itsaky/androidide/preferences/internal/EditorPreferences.kt
@@ -54,6 +54,13 @@ object EditorPreferences {
 
   // 光标与选择
   const val SMOOTH_CURSOR_MOVEMENT = "idepref_editor_smoothCursorMovement"
+  const val CURSOR_IME_VISIBLE_SCROLL = "idepref_editor_cursorImeVisibleScroll"
+  const val CURSOR_VISIBLE_AREA_SCROLL = "idepref_editor_cursorVisibleAreaScroll"
+  const val CURSOR_IME_SCROLL_POSITION = "idepref_editor_cursorImeScrollPosition"
+  const val CURSOR_VISIBLE_AREA_SCROLL_POSITION = "idepref_editor_cursorVisibleAreaScrollPosition"
+  const val CURSOR_SCROLL_POSITION_TOP = "top"
+  const val CURSOR_SCROLL_POSITION_CENTER = "center"
+  const val CURSOR_SCROLL_POSITION_BOTTOM = "bottom"
 
   const val CURSOR_STYLE = "idepref_editor_cursorStyle"
   const val CLEAR_LOGCAT_BEFORE_RUN = "idepref_run_clearLogcatBeforeRun"
@@ -188,6 +195,31 @@ object EditorPreferences {
     get() = prefManager.getBoolean(SMOOTH_CURSOR_MOVEMENT, false)
     set(value) {
       prefManager.putBoolean(SMOOTH_CURSOR_MOVEMENT, value)
+    }
+
+  var cursorImeVisibleScroll: Boolean
+    get() = prefManager.getBoolean(CURSOR_IME_VISIBLE_SCROLL, true)
+    set(value) {
+      prefManager.putBoolean(CURSOR_IME_VISIBLE_SCROLL, value)
+    }
+
+  var cursorVisibleAreaScroll: Boolean
+    get() = prefManager.getBoolean(CURSOR_VISIBLE_AREA_SCROLL, false)
+    set(value) {
+      prefManager.putBoolean(CURSOR_VISIBLE_AREA_SCROLL, value)
+    }
+
+  var cursorImeScrollPosition: String
+    get() = prefManager.getString(CURSOR_IME_SCROLL_POSITION, CURSOR_SCROLL_POSITION_BOTTOM)
+    set(value) {
+      prefManager.putString(CURSOR_IME_SCROLL_POSITION, value)
+    }
+
+  var cursorVisibleAreaScrollPosition: String
+    get() =
+        prefManager.getString(CURSOR_VISIBLE_AREA_SCROLL_POSITION, CURSOR_SCROLL_POSITION_CENTER)
+    set(value) {
+      prefManager.putString(CURSOR_VISIBLE_AREA_SCROLL_POSITION, value)
     }
 
   // Properties for Auto-Save feature

--- a/xml/utils/src/main/java/com/itsaky/androidide/xml/internal/versions/ApiVersionsParser.kt
+++ b/xml/utils/src/main/java/com/itsaky/androidide/xml/internal/versions/ApiVersionsParser.kt
@@ -89,7 +89,7 @@ open class ApiVersionsParser {
 
   private fun consumeStartElement(event: StartElement) {
     when (event.name.localPart) {
-      TAG_API -> apiVersion = event.getAttributeByName(QName("version")).value.toInt()
+      TAG_API -> apiVersion = parseApiLevel(event.getAttributeByName(QName("version")).value)
       TAG_CLASS -> consumeClass(event)
       TAG_FIELD -> consumeMember(event, TAG_FIELD)
       TAG_METHOD -> consumeMember(event, TAG_METHOD)
@@ -172,9 +172,9 @@ open class ApiVersionsParser {
 
       when (attribute.name.localPart) {
         ATTR_NAME -> name = attribute.value
-        ATTR_SIN -> since = attribute.value.toInt()
-        ATTR_DEPR -> deprecated = attribute.value.toInt()
-        ATTR_REM -> removed = attribute.value.toInt()
+        ATTR_SIN -> since = parseApiLevel(attribute.value)
+        ATTR_DEPR -> deprecated = parseApiLevel(attribute.value)
+        ATTR_REM -> removed = parseApiLevel(attribute.value)
       }
     }
 
@@ -187,6 +187,10 @@ open class ApiVersionsParser {
 
     val version = (since shl 16) or (deprecated shl 8) or removed
     return name!! to version
+  }
+
+  private fun parseApiLevel(value: String): Int {
+    return value.substringBefore('.').toInt()
   }
 
   private fun createApiInfo(versions: Int): ApiVersion {

--- a/xml/utils/src/test/java/com/itsaky/androidide/xml/versions/ApiVersionParserTest.kt
+++ b/xml/utils/src/test/java/com/itsaky/androidide/xml/versions/ApiVersionParserTest.kt
@@ -117,6 +117,30 @@ class ApiVersionParserTest {
   }
 
   @Test
+  fun testMinorApiLevelParsing() {
+    val xml =
+        """
+        <api version="36.1">
+            <class name="com.example.ClassA" since="36.1" deprecated="0" removed="0">
+                <method name="methodA" since="36.1" deprecated="0" removed="0"/>
+            </class>
+        </api>
+        """
+            .trimIndent()
+    val inputStream = ByteArrayInputStream(xml.toByteArray())
+
+    parser.parse(inputStream)
+
+    val classInfo = parser.getClassInfo("com.example.ClassA")
+    assertThat(classInfo).isNotNull()
+    assertThat(classInfo!!.since).isEqualTo(36)
+
+    val methodInfo = parser.getMemberInfo("com.example.ClassA", "methodA")
+    assertThat(methodInfo).isNotNull()
+    assertThat(methodInfo!!.since).isEqualTo(36)
+  }
+
+  @Test
   fun testMultipleClassesParsing() {
     val xml =
         """


### PR DESCRIPTION
### Motivation
- Fix a crash caused by `NumberFormatException` when `api-versions.xml` contains minor API levels like `36.1` which were parsed with `.toInt()` and caused failures. 
- Ensure the SDK `api-versions.xml` parser normalizes minor API levels to integer API level for compatibility with the existing bit-packed `ApiVersion` model. 
- Resolve Kotlin DSL unresolved-reference build errors in `:termux:proot` caused by incorrect version-catalog accessors in the Gradle build script. 

### Description
- Replace direct `.toInt()` calls for API version parsing with a new helper `parseApiLevel(value: String)` that strips minor suffixes via `value.substringBefore('.')` and converts to `Int`, and use it for the root `version` and `since/deprecated/removed` attributes in `ApiVersionsParser.kt`. 
- Add a regression unit test `testMinorApiLevelParsing()` in `ApiVersionParserTest.kt` to cover `<api version="36.1">` and member attributes like `since="36.1"` and assert the integer `36` is produced. 
- Fix Gradle version-catalog accessor names in `termux/proot/build.gradle.kts` replacing `libs.androidx-appcompat` and `libs.tests.androidx.test.*` with the correct generated accessors `libs.androidx.appcompat`, `libs.tests.androidx.junit`, and `libs.tests.androidx.espresso.core`. 
- Changes applied in files: `xml/utils/src/main/java/com/itsaky/androidide/xml/internal/versions/ApiVersionsParser.kt`, `xml/utils/src/test/java/com/itsaky/androidide/xml/versions/ApiVersionParserTest.kt`, and `termux/proot/build.gradle.kts`.

### Testing
- Ran `git diff --check` which passed with no whitespace errors. 
- Attempted `./gradlew :xml:utils:testDebugUnitTest :termux:proot:compileDebugKotlin` to execute the added unit test and build the `proot` module, but the Gradle/Kotlin script parsing failed in this environment due to JDK version parsing (`OpenJDK 25.0.2`), so the Gradle tasks did not complete. 
- Ran `./gradlew :termux:proot:compileDebugKotlin --stacktrace` which reproduced the same JVM/JDK environment failure, confirming the failures are environmental rather than code regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a434bf22410832ca2bef010d7b6229d)