### PR TITLE
fix(core:app): resolve CodeEditorView coerceIn type mismatch

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -181,11 +181,12 @@ class CodeEditorView(context: Context, file: File, selection: Range) :
     val rowCenter = (rowTop + rowBottom) / 2f
     val targetY =
         when (position) {
-          EditorPreferences.CURSOR_SCROLL_POSITION_TOP -> rowTop - rowHeight
+          EditorPreferences.CURSOR_SCROLL_POSITION_TOP -> (rowTop - rowHeight).toFloat()
           EditorPreferences.CURSOR_SCROLL_POSITION_CENTER -> rowCenter - visibleHeight / 2f
-          else -> rowBottom - visibleHeight + rowHeight * CURSOR_BOTTOM_VISIBLE_MARGIN_ROWS
-        }
-            .coerceIn(0f, getScrollMaxY().toFloat())
+          else ->
+              (rowBottom - visibleHeight + rowHeight * CURSOR_BOTTOM_VISIBLE_MARGIN_ROWS)
+                  .toFloat()
+        }.coerceIn(0f, getScrollMaxY().toFloat())
     val deltaY = targetY - getOffsetY()
     if (deltaY > -1f && deltaY < 1f) {
       invalidate()


### PR DESCRIPTION
## 修复内容

修复 `core/app` 模块编译错误：

- 文件: `core/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt`
- 函数: `IDEEditor.scrollCursorLineToVisiblePosition`

## 错误原因

`when` 表达式的三个分支混合了 `Int` 与 `Float` 类型：

- TOP 分支: `rowTop - rowHeight` -> `Int`
- CENTER 分支: `rowCenter - visibleHeight / 2f` -> `Float`
- 其它分支: `rowBottom - visibleHeight + ...` -> `Int`

Kotlin 将其推为共同上界 `Number`，而 `coerceIn` 扩展函数并未在 `Number` 上定义，因此编译失败，错误为:

```
None of the following candidates is applicable:
fun <T : Comparable<T>> T.coerceIn(...)
fun Byte.coerceIn(...)
...
```

随后 `if (deltaY > -1f && deltaY < 1f)` 中对 `Number` 调用 `compareTo` 又产生了 `operator modifier is required` 连锁错误。

## 修复方式

将 `Int` 分支显式转换为 `Float`，使 `when` 表达式结果类型为 `Float`，从而能正确解析 `.coerceIn(0f, getScrollMaxY().toFloat())`。

```kotlin
val targetY =
    when (position) {
        EditorPreferences.CURSOR_SCROLL_POSITION_TOP -> (rowTop - rowHeight).toFloat()
        EditorPreferences.CURSOR_SCROLL_POSITION_CENTER -> rowCenter - visibleHeight / 2f
        else ->
            (rowBottom - visibleHeight + rowHeight * CURSOR_BOTTOM_VISIBLE_MARGIN_ROWS)
                .toFloat()
    }.coerceIn(0f, getScrollMaxY().toFloat())
```

## 验证

构建失败信息已确认消失，未改动其他无关代码。