### PR TITLE
refactor(compose-preview): v4 render engine + dex hash cache + image …

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/handlers/FileTreeActionHandler.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/handlers/FileTreeActionHandler.kt
@@ -32,6 +32,8 @@ import com.itsaky.androidide.eventbus.events.filetree.FileLongClickEvent
 import com.itsaky.androidide.events.ExpandTreeNodeRequestEvent
 import com.itsaky.androidide.events.FileContextMenuItemClickEvent
 import com.itsaky.androidide.events.ListProjectFilesRequestEvent
+import com.itsaky.androidide.file.FileValidator
+import com.itsaky.androidide.fragments.editor.image.ImagePreviewFragment
 import com.itsaky.androidide.fragments.sheets.OptionsListFragment
 import com.itsaky.androidide.models.SheetOption
 import com.itsaky.androidide.utils.ApkInstaller
@@ -89,7 +91,39 @@ class FileTreeActionHandler : BaseEventHandler() {
       return
     }
 
+    // === 图片预览路由 ===
+    // 文件后缀命中 ImagePreviewFragment.SUPPORTED_FORMATS 时, 直接在 IDE
+    // 内的 Image Preview tab 里打开, 不再走系统 Intent.ACTION_VIEW 调外部
+    // viewer (老逻辑会把用户切出 IDE). `.xml` 文件需要做 content sniff:
+    // layout / manifest / values 等 .xml 都不是 vector, 走 content 头 1KB
+    // 包含 "<vector" 才算 Android vector drawable, 避免误判.
+    if (isSupportedImageFile(event.file)) {
+      val ext = event.file.extension.lowercase()
+      val tabId = context.fragmentTabManager?.openFileTab(
+        filePath = event.file.absolutePath,
+        fileExtension = ext,
+      )
+      if (tabId != null) {
+        log.info("Opened image preview tab {} for {}", tabId, event.file)
+        return
+      }
+      // tab 没注册 (理论不会, 走不到这里) → fall through 到普通 openFile
+    }
+
     context.openFile(event.file)
+  }
+
+  /**
+   * 判断给定文件是否应该走 [ImagePreviewFragment]. 规则:
+   *  - 扩展名在 [ImagePreviewFragment.SUPPORTED_FORMATS] 中
+   *  - 对 `.xml` 还要做 [FileValidator.isLikelyAndroidVector] content sniff,
+   *    排除 layout / manifest / values 等非 vector xml.
+   */
+  private fun isSupportedImageFile(file: File): Boolean {
+    val ext = file.extension.lowercase()
+    if (ext.isEmpty() || ext !in ImagePreviewFragment.SUPPORTED_FORMATS) return false
+    if (ext == "xml") return FileValidator.isLikelyAndroidVector(file)
+    return true
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ComposePreviewActivity.kt
@@ -72,6 +72,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.itsaky.androidide.compose.preview.runtime.PreviewRenderEngine
+import com.itsaky.androidide.compose.preview.runtime.RenderRequest
 import com.itsaky.androidide.compose.preview.ui.AttributeEditPanel
 import com.itsaky.androidide.compose.preview.ui.ComposableFunctionPicker
 import com.itsaky.androidide.compose.preview.ui.DebugToolbar
@@ -182,15 +183,19 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
                             // v3.4: 传入对应 @Composable 的 PreviewConfig, 让 uiMode /
                             // showBackground / backgroundColor 真正生效.
                             // v3.5: 传 deviceConfig.orientation, 让 LocalConfiguration 注入横竖屏.
+                            // v4: 统一用 RenderRequest 数据类, 杜绝 v3 那种 "render 一调用
+                            //     就触发 4~5 步副作用" 的隐式耦合.
                             val previewConfig = state.previewConfigs
                                 .firstOrNull { it.functionName == functionName }
                             engine.render(
-                                previewDex = state.dexFile,
-                                projectDex = state.projectDexFiles,
-                                className = state.className,
-                                functionName = functionName,
-                                previewConfig = previewConfig,
-                                orientation = state.deviceConfig.orientation,
+                                RenderRequest(
+                                    previewDex = state.dexFile,
+                                    projectDex = state.projectDexFiles,
+                                    className = state.className,
+                                    functionName = functionName,
+                                    previewConfig = previewConfig,
+                                    orientation = state.deviceConfig.orientation,
+                                )
                             )
                         }
                     }
@@ -210,12 +215,14 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
                         val previewConfig = state.previewConfigs
                             .firstOrNull { it.functionName == functionName }
                         engine.render(
-                            previewDex = state.dexFile,
-                            projectDex = state.projectDexFiles,
-                            className = state.className,
-                            functionName = functionName,
-                            previewConfig = previewConfig,
-                            orientation = state.deviceConfig.orientation,
+                            RenderRequest(
+                                previewDex = state.dexFile,
+                                projectDex = state.projectDexFiles,
+                                className = state.className,
+                                functionName = functionName,
+                                previewConfig = previewConfig,
+                                orientation = state.deviceConfig.orientation,
+                            )
                         )
                     }
                 }
@@ -234,18 +241,14 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
     /**
      * 【v3.3】拿 preview view 引用 (供 [ScreenshotExporter] 用).
      * 返回 render engine 的 ComposeView, 如果 engine 还没 attach 返回 null.
+     *
+     * v4: 直接走 engine 公开 getter, 不再用反射拿私有字段.
      */
     fun previewViewForExport(): android.view.View? {
-        return renderEngine?.let { engine ->
-            // 反射拿私有字段 composeView
-            val field = engine.javaClass.getDeclaredField("composeView").apply { isAccessible = true }
-            field.get(engine) as? android.view.View
-        } ?: run {
+        return renderEngine?.currentComposeView() ?: run {
             // fallback: 找根 FrameLayout 中的 ComposeView
             window.decorView.findViewById<android.view.ViewGroup>(android.R.id.content)
-                ?.let { root ->
-                    findComposeView(root)
-                }
+                ?.let { root -> findComposeView(root) }
         }
     }
 
@@ -269,13 +272,12 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
      * 触发 AndroidView 重建时), 强制 detach 旧引擎 + 新建引擎. 否则旧 ComposeView
      * 仍然 addView 在旧 FrameLayout 上, 用户看到的是"切回后黑屏".
      *
-     * 【v3.6】在新建引擎时拷贝 [com.itsaky.androidide.compose.preview.runtime.LastRender]
-     * 到新引擎, 让 [PreviewRenderEngine.attach] 自动重放上一次的渲染, 避免"切
-     * 设备模式 / 切 profile 后预览区黑屏". 之前 v3.2 把旧引擎 detach 后, 新引擎
-     * 的 [PreviewRenderEngine.lastRender] 默认是 null, attach 时不会自动重放,
-     * 只能等 [viewModel.previewState] 重新发射 Ready 才会触发 render. 但
-     * collect 不会对"当前值"重新发射, 第一次发射时 new engine 还没创建好,
-     * 后续的 Ready 发射要么不会发生, 要么时序与 attach 错位, 表现为黑屏.
+     * 【v3.6】在新建引擎时把旧引擎的 [com.itsaky.androidide.compose.preview.runtime.LastSnapshot]
+     * 拷到新引擎, 让 [PreviewRenderEngine.attach] 自动重放上一次的渲染, 避免"切
+     * 设备模式 / 切 profile 后预览区黑屏".
+     *
+     * 【v4】改用 [PreviewRenderEngine.snapshotForTransfer] / [PreviewRenderEngine.preloadSnapshot]
+     * 公开 API, 替代 v3 直接读写 engine 内部字段.
      */
     fun attachPreviewContainer(container: android.widget.FrameLayout) {
         val existing = renderEngine
@@ -289,12 +291,12 @@ class ComposePreviewActivity : androidx.appcompat.app.AppCompatActivity() {
                 System.identityHashCode(existing.container),
                 System.identityHashCode(container),
             )
-            // 拷贝 lastRender — 新 engine 的 attach 会用它自动 replay, 避免黑屏.
-            val savedLastRender = existing.lastRender
+            val savedSnapshot = existing.snapshotForTransfer()
             existing.detach()
-            val newEngine = PreviewRenderEngine(this, container).apply {
-                lastRender = savedLastRender
-            }.also { it.attach() }
+            val newEngine = PreviewRenderEngine(this, container).also {
+                it.preloadSnapshot(savedSnapshot)
+                it.attach()
+            }
             renderEngine = newEngine
         }
     }

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/compiler/PreviewDexHashStore.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/compiler/PreviewDexHashStore.kt
@@ -1,0 +1,211 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.compose.preview.compiler
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * 预览 dex 哈希存储 v4.
+ *
+ * ## 用途
+ *
+ * 避免 "用户改了一行无关代码 → gradle assemble 重跑 → 浪费 30s+ → 用户看到的还是
+ * 上次 preview" 这种链式浪费. 哈希用户 compose preview SDK 的 .kt 源 + 编译产物
+ * dex, 存到 IDE home 下, 二次进入 preview 时先比对, 未变化就跳过 gradle 直接渲
+ * 染.
+ *
+ * **不** 哈希 androidx compose SDK 等运行时依赖 — 那部分 dex 由 IDE 主 APK 的
+ * PathClassLoader 解析, 跟用户代码完全无关, 进 build 缓存里, 本 store 完全不碰.
+ *
+ * ## 存储位置
+ *
+ * `<Environment.ANDROIDIDE_HOME>/compose-preview/dex-hashes/<key>.hash`, 故意
+ * 放在 `build/` 之外, 避免 `gradle clean` / `rm -rf build/` 一并清掉.
+ *
+ * ## 哈希策略
+ *
+ *  - **per-key 摘要**: 用 project modulePath + variant 派生一个 key (例如
+ *    `:app-debug`), 文件名就是 `app-debug.hash`, 排查时一眼能定位.
+ *  - **覆盖范围**: 哈希 = SHA-256 (project kt 源 ∪ project dex), 每个文件分别
+ *    digest 后用分隔符合并再 digest 一次, 顺序按 path 排序, 保证幂等.
+ *  - **容错**: 读取失败 / 写失败 / 哈希生成抛异常 → 返回 "未命中", 仍然跑 gradle
+ *    assemble. 缓存是优化, 不能变成正确性问题.
+ *
+ * @author android_zero
+ */
+class PreviewDexHashStore(
+    rootDir: File,
+) {
+
+    private val LOG = LoggerFactory.getLogger(PreviewDexHashStore::class.java)
+
+    /**
+     * 存储目录. 在 IDE home 下, 不会被 gradle clean 清掉. 故意不在 `build/` 下.
+     */
+    val storeDir: File = File(rootDir, "compose-preview/dex-hashes").apply {
+        mkdirs()
+    }
+
+    /**
+     * 对一组文件算 SHA-256 (按 path 排序保证幂等). 任一文件不存在或读失败抛
+     * [HashingException], 调用方应降级为 "未命中" 处理.
+     */
+    @Throws(HashingException::class)
+    fun hashFiles(files: Collection<File>): String {
+        val sorted = files.filter { it.exists() && it.isFile }
+            .sortedBy { it.absolutePath }
+        if (sorted.isEmpty()) {
+            throw HashingException("No files to hash")
+        }
+        val md = MessageDigest.getInstance("SHA-256")
+        for (f in sorted) {
+            // 用 "<path>:<size>:" 作前缀, 防止两个不同文件内容相同的边界情况
+            // (例如空文件) 互相覆盖. SHA-256 本身对长度有抗碰撞, 加 path 是为了
+            // 调试时看到哈希就能定位文件.
+            md.update(f.absolutePath.toByteArray(Charsets.UTF_8))
+            md.update(0)
+            md.update(f.length().toString().toByteArray(Charsets.UTF_8))
+            md.update(0)
+            f.inputStream().use { stream ->
+                val buffer = ByteArray(64 * 1024)
+                while (true) {
+                    val n = stream.read(buffer)
+                    if (n <= 0) break
+                    md.update(buffer, 0, n)
+                }
+            }
+            md.update(0)
+        }
+        return md.digest().toHex()
+    }
+
+    /**
+     * 计算 "compose preview SDK" 的组合哈希 — 用户的 .kt 源 + 编译产物 dex, 不
+     * 含 androidx 等运行时依赖. 调用方负责筛掉 androidx 的 .kt / .dex (只传用户
+     * 模块自己的).
+     */
+    @Throws(HashingException::class)
+    fun combinedHash(
+        userSourceFiles: Collection<File>,
+        projectDexFiles: Collection<File>,
+    ): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update("sources:".toByteArray(Charsets.UTF_8))
+        md.update(hashFiles(userSourceFiles).toByteArray(Charsets.UTF_8))
+        md.update(0)
+        md.update("dex:".toByteArray(Charsets.UTF_8))
+        md.update(hashFiles(projectDexFiles).toByteArray(Charsets.UTF_8))
+        return md.digest().toHex()
+    }
+
+    /**
+     * 检查 [key] 对应的上次快照是否与当前 [userSourceFiles] / [projectDexFiles]
+     * 完全一致. 一致返回 true (可以跳过 gradle), 不一致返回 false (需要重跑).
+     *
+     * 任何异常都返回 false (保守: 宁可多跑一次, 也不因缓存错导致 preview 错).
+     */
+    fun isUnchanged(
+        key: String,
+        userSourceFiles: Collection<File>,
+        projectDexFiles: Collection<File>,
+    ): Boolean {
+        val current = try {
+            combinedHash(userSourceFiles, projectDexFiles)
+        } catch (e: HashingException) {
+            LOG.debug("Hashing failed for {}: {}", key, e.message)
+            return false
+        }
+        val stored = readStored(key) ?: return false
+        return current.equals(stored, ignoreCase = true)
+    }
+
+    /**
+     * 把 [userSourceFiles] / [projectDexFiles] 的当前哈希存到磁盘. gradle 跑
+     * 完后调用, 供下次启动比对.
+     */
+    fun store(
+        key: String,
+        userSourceFiles: Collection<File>,
+        projectDexFiles: Collection<File>,
+    ) {
+        try {
+            val current = combinedHash(userSourceFiles, projectDexFiles)
+            writeStored(key, current)
+        } catch (e: Throwable) {
+            LOG.warn("Failed to write hash for {}", key, e)
+        }
+    }
+
+    /**
+     * 列出所有已存 key. 主要给 debug / "清空缓存" UI 用.
+     */
+    fun listKeys(): List<String> = storeDir.listFiles()
+        ?.filter { it.isFile && it.name.endsWith(".hash") }
+        ?.map { it.name.removeSuffix(".hash") }
+        ?: emptyList()
+
+    /**
+     * 删掉单个 key 的快照 (例如某次 build 失败后, 下次应该强制重跑).
+     */
+    fun invalidate(key: String) {
+        try {
+            hashFile(key).delete()
+        } catch (e: Throwable) {
+            LOG.warn("Failed to invalidate hash for {}", key, e)
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    //  内部
+    // ---------------------------------------------------------------------
+
+    private fun readStored(key: String): String? = try {
+        val f = hashFile(key)
+        if (f.exists()) f.readText(Charsets.UTF_8).trim() else null
+    } catch (e: Throwable) {
+        LOG.debug("Failed to read hash for {}: {}", key, e.message)
+        null
+    }
+
+    private fun writeStored(key: String, value: String) {
+        val f = hashFile(key)
+        f.parentFile?.mkdirs()
+        // 原子写: 写临时文件再 rename, 避免 gradle assemble 过程中被杀导致半截 hash.
+        val tmp = File(f.parentFile, "${f.name}.tmp")
+        tmp.writeText(value, Charsets.UTF_8)
+        if (f.exists()) f.delete()
+        if (!tmp.renameTo(f)) {
+            // rename 失败 (跨 mount) → 退化成 copy
+            tmp.copyTo(f, overwrite = true)
+            tmp.delete()
+        }
+    }
+
+    private fun hashFile(key: String): File =
+        File(storeDir, "${sanitizeKey(key)}.hash")
+
+    private fun sanitizeKey(key: String): String =
+        key.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+
+    private fun ByteArray.toHex(): String =
+        joinToString(separator = "") { "%02x".format(it) }
+}
+
+class HashingException(message: String) : RuntimeException(message)

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepositoryImpl.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/data/repository/ComposePreviewRepositoryImpl.kt
@@ -18,11 +18,13 @@
 package com.itsaky.androidide.compose.preview.data.repository
 
 import android.content.Context
+import com.itsaky.androidide.compose.preview.compiler.PreviewDexHashStore
 import com.itsaky.androidide.compose.preview.data.source.ProjectContext
 import com.itsaky.androidide.compose.preview.data.source.ProjectContextSource
 import com.itsaky.androidide.compose.preview.domain.model.ParsedPreviewSource
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.projects.builder.BuildService
+import com.itsaky.androidide.utils.Environment
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -48,13 +50,22 @@ import java.util.concurrent.TimeUnit
  * `runtimeDex` 字段.
  */
 class ComposePreviewRepositoryImpl(
-    private val projectContextSource: ProjectContextSource = ProjectContextSource()
+    private val projectContextSource: ProjectContextSource = ProjectContextSource(),
 ) : ComposePreviewRepository {
 
     private val LOG = LoggerFactory.getLogger(ComposePreviewRepositoryImpl::class.java)
 
     private var projectContext: ProjectContext? = null
     private var openedFilePath: String? = null
+
+    /**
+     * dex / 源码哈希缓存. v4 引入, 避免每次进入 preview 都重跑 gradle assemble.
+     * 故意在 IDE home 目录下, 跟 `build/` 完全分离, gradle clean 不会清.
+     */
+    private val hashStore: PreviewDexHashStore by lazy {
+        val root = Environment.ANDROIDIDE_HOME ?: File(".androidide")
+        PreviewDexHashStore(root)
+    }
 
     override suspend fun initialize(
         context: Context,
@@ -113,6 +124,30 @@ class ComposePreviewRepositoryImpl(
             val generatedClassName = "${fileName}Kt"
             val fullClassName = "${parsedSource.packageName}.$generatedClassName"
 
+            // === v4 dex 哈希短路 ===
+            // 用户 compose preview SDK 的 .kt 源 + 已有 dex 完全没变 → 直接跳过
+            // gradle assemble, 用现有 dex 渲染. 避免 "用户改了一行代码 / 啥都没改
+            // → gradle 重跑 30s+" 的浪费. androidx compose SDK 等运行时依赖不进
+            // 哈希范围, 那些走 IDE PathClassLoader, 与用户代码无关.
+            val cacheKey = cacheKeyFor(context)
+            val userSourceFiles = collectUserSourceFiles(context)
+            val projectDexFiles = context.projectDexFiles.filter { it.exists() }
+            if (projectDexFiles.isNotEmpty() &&
+                hashStore.isUnchanged(cacheKey, userSourceFiles, projectDexFiles)
+            ) {
+                LOG.info(
+                    "dex hash cache hit for {} — skipping gradle assemble",
+                    cacheKey,
+                )
+                val previewDex = projectDexFiles.first()
+                return@runCatching CompilationResult(
+                    dexFile = previewDex,
+                    className = fullClassName,
+                    projectDexFiles = projectDexFiles,
+                )
+            }
+            LOG.info("dex hash cache miss for {} — running gradle assemble", cacheKey)
+
             // v3.1: 直接跑 gradle 拿 dex. 不再 K2 + D8 进程内编译.
             runGradleAssemble(context)
 
@@ -135,6 +170,13 @@ class ComposePreviewRepositoryImpl(
             // 存在的 dex 作为预览入口, 其它 dex 仍通过 projectDexFiles 一并加载.
             val previewDex = dexFiles.first()
 
+            // 把当前 source + dex 哈希存盘, 供下次进入 preview 比对. 必须在
+            // dexFiles 拿到之后才存 — 万一 gradle 跑完没产出 dex, 不写脏数据.
+            val newSourceFiles = collectUserSourceFiles(refreshedContext)
+            hashStore.store(cacheKey, newSourceFiles, dexFiles)
+            LOG.info("Stored dex hash for {} ({} sources, {} dex files)",
+                cacheKey, newSourceFiles.size, dexFiles.size)
+
             LOG.info(
                 "Preview ready: {} ({} previews, {} project DEX files)",
                 fullClassName, parsedSource.previewConfigs.size, dexFiles.size,
@@ -146,6 +188,35 @@ class ComposePreviewRepositoryImpl(
                 projectDexFiles = dexFiles,
             )
         }
+    }
+
+    /**
+     * 派生缓存 key: modulePath + variant. 例如 `:app-debug`.
+     *
+     * 故意用这两个字段拼, 不同 variant 的 dex 不能复用 (debug / release 产物不同).
+     */
+    private fun cacheKeyFor(context: ProjectContext): String {
+        val module = context.modulePath?.removePrefix(":")?.replace(":", "/") ?: "root"
+        return "$module-${context.variantName}"
+    }
+
+    /**
+     * 收集用户 compose preview SDK 的 .kt 源文件. 走 [ProjectContext.modulePath]
+     * 下的 `src/`, 不递归到 `build/` (那是编译产物, 由 dex 哈希单独覆盖).
+     *
+     * 故意只哈希用户模块, 不动 androidx 等运行时 SDK — 那部分走 IDE 主 APK 的
+     * PathClassLoader, 跟用户代码完全无关, 进 build 缓存里. 即便 androidx 升级,
+     * 也只影响 IDE 主 APK, 不会让这个 hash miss.
+     */
+    private fun collectUserSourceFiles(context: ProjectContext): List<File> {
+        val modulePath = context.modulePath ?: return emptyList()
+        val moduleDir = File(modulePath)
+        if (!moduleDir.isDirectory) return emptyList()
+        val srcDir = File(moduleDir, "src")
+        if (!srcDir.isDirectory) return emptyList()
+        return srcDir.walkTopDown()
+            .filter { it.isFile && it.name.endsWith(".kt") }
+            .toList()
     }
 
     /**

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewRenderEngine.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/runtime/PreviewRenderEngine.kt
@@ -20,11 +20,9 @@ package com.itsaky.androidide.compose.preview.runtime
 import android.content.Context
 import android.content.res.Configuration
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -44,34 +42,55 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import com.itsaky.androidide.compose.preview.PreviewConfig
+import com.itsaky.androidide.compose.preview.ui.DeviceOrientation
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.lang.reflect.Modifier
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Compose 预览渲染引擎 v3.
+ * Compose 预览渲染引擎 v4.
  *
- * ## 关键设计 (取代 v2 [ComposableRenderer])
+ * ## v4 重构要点
  *
- * 1. **ComposeView 由 Activity 直接持有, 不嵌入 Composable 子树**:
- *    v2 方案在 [androidx.compose.ui.viewinterop.AndroidView] 中嵌套 [ComposeView],
- *    会因为 `AndroidView` 的测量/布局与 Compose 的 SubcomposeLayout 冲突, 导致
- *    实际渲染区域为零, 出现"白屏 / BUILD SUCCESSFUL 后不显示". v3 直接把
- *    [ComposeView] add 到 Activity 的根 FrameLayout, 跟 IDE 编辑器侧的预览实现一致.
+ * v3 时期 [PreviewRenderEngine] 出现过几类"修一个 bug 引出两个 bug" 的连锁问题:
  *
- * 2. **ClassLoader 一次性加载, 不可变**:
- *    v2 的 [ComposeClassLoader.setProjectDexFiles] / [setRuntimeDex] 是 "可变容器",
- *    在 `LaunchedEffect` 中调用, 与 setContent 存在时序竞争. v3 改用 [DexRuntime] 一次性
- *    把 preview dex + project dex + runtime dex 全部装入, 之后 [ComposableInvoker] 任意
- *    `loadClass` 都能命中.
+ *  1. **作用域污染** — 私有 `applyContent` 误用了 `render` 的局部变量 (`previewDex` /
+ *     `projectDex` / `fromReplay` / ...). 这些变量在 `applyContent` 不可见, 一旦
+ *     brace 调整, 就会集中爆出 "Unresolved reference / private not applicable to
+ *     local function" 一连串错. v4 改用 [RenderRequest] 显式传递, 杜绝这种"靠外层
+ *     闭包变量"的隐式依赖.
  *
- * 3. **错误显式上抛**:
- *    任何步骤失败 (loadClass null / 函数未找到 / invoke 抛错) 都会渲染到 ComposeView 上,
- *    而非像 v2 那样只 LOG.warn 后展示一个空白 Box.
+ *  2. **首屏空白 / 状态切换后黑屏** — v3 用 `lastRender` 在 `attach` 时 replay,
+ *     但若 `render(...)` 在 `attach` 之前就调用了 (Compose composition 与 view
+ *     状态 collect 时序竞争), 引擎直接 LOG.error 提前返回, 用户看到的是空容器.
+ *     v4 引入 [pendingRequest]: `render` 早于 `attach` 时把请求缓存, `attach` 一
+ *     完成就消费. 即便第一次 `previewState.collect` 在 `attach` 之前发射 Ready
+ *     也只是把请求入队, 不会丢失.
  *
- * 4. **可重入**:
- *    [render] 可多次调用, 内部用 [AtomicReference] 保证同一时间只有一个生效, 旧的
- *    [DexRuntime] 会在新一次 render 开始前释放.
+ *  3. **方法职责混乱** — v3 `render` 同时管 dex 加载、反射实例化、setContent、
+ *     保存快照、写日志; 一行调用触发 4~5 步副作用, 测试 / 单步调试都痛苦. v4 把
+ *     步骤拆成 [loadRuntime] / [loadClassOrError] / [instantiateIfNeeded] /
+ *     [writeContent] 四个无副作用的 helper, 主流程 [render] 只做编排.
+ *
+ *  4. **快照与请求混用** — v3 [LastRender] 既要做 replay 快照, 又要塞 `previewDex` /
+ *     `projectDex`. 切 deviceSim 时, `previewDex` / `projectDex` 多数情况下没变,
+ *     但 `LastRender` 把它们强加进来, 反而容易在 replay 路径上误用. v4 拆成
+ *     [LastSnapshot] (只存"重放"必需的 className / functionName / args /
+ *     previewConfig / orientation, 不带 dex) 和 [RenderRequest] (含 dex).
+ *     Replay 路径直接用现有的 activeRuntime 重新 loadClass, 不需要 dex 信息.
+ *
+ * ## 用法 (ComposePreviewActivity 调用)
+ *
+ * ```
+ * val engine = PreviewRenderEngine(this, container)
+ * engine.attach()                 // 主线程, 一次性
+ * engine.render(RenderRequest(...))
+ * engine.refresh()                // 用最近一次的请求重渲染 (用于 rebuild 后)
+ * engine.detach()                 // Activity.onDestroy
+ * ```
+ *
+ * @author android_zero
  */
 class PreviewRenderEngine(
     private val context: Context,
@@ -87,44 +106,272 @@ class PreviewRenderEngine(
 
     private val invoker = ComposableInvoker()
     private val activeRuntime = AtomicReference<DexRuntime?>(null)
+
     @Volatile
     private var composeView: ComposeView? = null
 
     /**
-     * 上次成功 [render] 调用的参数快照。
+     * 上次成功 [render] 调用的 className / functionName / args / previewConfig /
+     * orientation 快照. 不带 dex (dex 在 [activeRuntime] 里, 生命周期跟随引擎).
      *
-     * 当引擎 [attach] 到一个新的 [ComposeView] (典型场景：Activity 重建后重新
-     * 进入 preview、或者切 deviceSim / profile 触发 [ComposePreviewActivity]
-     * 重建引擎)，自动用这份参数重新调用一次 [render]，让用户看到 "重新进入
-     * preview 也能立刻显示上次渲染的内容"，而不是黑屏。
-     *
-     * 由 [detach] 显式清空。
-     *
-     * @author android_zero
+     * 当引擎 [attach] 到一个新的 [ComposeView] (典型场景: 切 deviceSim / profile
+     * 触发 [ComposePreviewActivity] 重建引擎), 自动用这份快照重新调用一次
+     * [renderFromSnapshot], 让用户看到 "重新进入 preview 也能立刻显示上次渲染的
+     * 内容", 而不是黑屏.
      */
     @Volatile
-    internal var lastRender: LastRender? = null
+    private var lastSnapshot: LastSnapshot? = null
+
+    /**
+     * [render] 在 [attach] 之前就被调用时, 请求先存到这里, [attach] 完成后立刻消费.
+     * 解决 v3 "首屏空白" 的 race condition.
+     */
+    @Volatile
+    private var pendingRequest: RenderRequest? = null
+
+    // ---------------------------------------------------------------------
+    //  生命周期
+    // ---------------------------------------------------------------------
 
     /**
      * 把 [ComposeView] 安装到 [container] 中, 后续 [render] 的内容都会写到这个 view.
-     * 必须在 Activity.onCreate 之后 (主线程) 调用一次.
-     *
-     * 重复调用安全 — 内部会先 detach 旧的 composeView, 然后 [lastRender] 非空时
-     * 立即把内容 setContent 到新 view. 这是修复 v3.2 之后 "切 deviceSim / 切 profile /
-     * fragment 重建后只剩空白 ComposeView" bug 的关键: 旧 view 已经随旧 container
-     * 一起被释放, 新 view 必须重新 setContent 才会有内容.
+     * 必须在主线程调用一次. 重复调用安全 (幂等).
      */
     fun attach() {
         if (composeView != null) return
-        // 【v3.2】如果 container 已经有别的 engine 添加的 ComposeView, 先清理.
-        // 切 deviceSim / profile 时旧 engine 已经被 Activity.detach() 释放, 但
-        // 旧 ComposeView 可能仍残留 (Activity 是 main thread, GC 还没跑).
-        // 【v3.6】使用 downTo 0 反向迭代, 避免 removeViewAt(i) 后索引位移导致跳过
-        // 下一个 view. 之前用 repeat() { i -> removeViewAt(i) } 在多次残留时会
-        // 只删掉一个, 剩下的 ComposeView 在新 engine attach 时被 addView 覆盖
-        // (FrameLayout 只保留一个), 表面看起来 OK, 但容器中残留的 orphan view
-        // 持有旧 activeRuntime 的 ComposeView 引用, 阻碍 GC, 内存里也容易出现
-        // 旧 composition + 新 composition 共存的怪现象.
+        cleanupContainer()
+        val view = newComposeView()
+        container.addView(view)
+        composeView = view
+        LOG.info("PreviewRenderEngine attached to container (id={})", container.id)
+
+        // 优先消费 pendingRequest, 再回放 lastSnapshot. 两者不会同时存在:
+        // pendingRequest 是 render 早于 attach 的产物, lastSnapshot 是上一次成功
+        // render 留下的快照. 一次 attach 只可能命中其中一个.
+        val pending = pendingRequest
+        if (pending != null) {
+            pendingRequest = null
+            LOG.info("Draining pending render on attach: {}#{}", pending.className, pending.functionName)
+            doRender(pending)
+        } else {
+            lastSnapshot?.let { snap ->
+                LOG.info("Replaying last snapshot on attach: {}#{}", snap.className, snap.functionName)
+                renderFromSnapshot(snap)
+            }
+        }
+    }
+
+    /**
+     * 释放 [DexRuntime] 并从 [container] 移除 [ComposeView]. 主线程调用.
+     *
+     * 注意: 不清空 [lastSnapshot] — 重建引擎后能凭它自动 replay. 调用方如果想
+     * 真正丢弃历史 (例如导航离开 preview 页面), 应额外调 [clearHistory].
+     */
+    fun detach() {
+        activeRuntime.getAndSet(null)?.release()
+        composeView?.let { container.removeView(it) }
+        composeView = null
+    }
+
+    /**
+     * 清除 [lastSnapshot] 与 [pendingRequest]. 用户从 preview 页面离开、确认不再
+     * 需要 "重新进入自动 replay" 时由 [ComposePreviewActivity] 调用.
+     */
+    fun clearHistory() {
+        lastSnapshot = null
+        pendingRequest = null
+    }
+
+    /**
+     * 把当前引擎持有的 [LastSnapshot] 拿出来, 用于在 [ComposePreviewActivity] 重建
+     * 引擎时把历史传过去, 避免 "切 deviceSim / profile 后黑屏".
+     *
+     * 配套 [preloadSnapshot] 使用. 取出后本引擎的 [lastSnapshot] 仍保留 (read-only
+     * 视图), 重建后的新引擎调用 [preloadSnapshot] 注入即可.
+     */
+    fun snapshotForTransfer(): LastSnapshot? = lastSnapshot
+
+    /**
+     * 把 [snapshot] 注入到本引擎, 让 [attach] 时能自动 replay. 用于容器变化触发
+     * 引擎重建场景. 调用前引擎不能已经成功 render 过 (否则会和现有 [lastSnapshot]
+     * 冲突), 由调用方保证时序.
+     */
+    fun preloadSnapshot(snapshot: LastSnapshot?) {
+        if (lastSnapshot == null) {
+            lastSnapshot = snapshot
+        }
+    }
+
+    /**
+     * 当前 attach 的 [ComposeView]. 供截图 / 视图导出等场景使用. 未 attach 返回 null.
+     */
+    fun currentComposeView(): ComposeView? = composeView
+
+    // ---------------------------------------------------------------------
+    //  渲染入口
+    // ---------------------------------------------------------------------
+
+    /**
+     * 加载 dex 并渲染指定 Composable. 线程安全 (主线程调用).
+     *
+     * @param request 渲染请求, 包含 dex / className / functionName / args /
+     *                previewConfig / orientation. 见 [RenderRequest].
+     */
+    fun render(request: RenderRequest) {
+        val view = composeView
+        if (view == null) {
+            // attach 还没调用, 排队等 attach 后消费. 解决 v3 首屏空白的 race.
+            LOG.info("render() queued before attach(): {}#{}", request.className, request.functionName)
+            pendingRequest = request
+            return
+        }
+        doRender(request)
+    }
+
+    /**
+     * 用最近一次成功 render 的 [LastSnapshot] 重新渲染. 用于 gradle rebuild 完成
+     * 后不重新传 dex (dex 已存在) 但希望立即看到最新代码的场景.
+     */
+    fun refresh() {
+        val view = composeView ?: run {
+            LOG.warn("refresh() called before attach()")
+            return
+        }
+        val snap = lastSnapshot ?: run {
+            LOG.warn("refresh() called but no last snapshot")
+            return
+        }
+        renderFromSnapshot(snap)
+    }
+
+    // ---------------------------------------------------------------------
+    //  内部步骤 (无副作用 / 单一职责, 便于单测)
+    // ---------------------------------------------------------------------
+
+    private fun doRender(request: RenderRequest) {
+        val view = composeView ?: return  // detached during render, bail
+
+        val runtime = loadRuntime(request)
+        activeRuntime.getAndSet(runtime)?.release()
+
+        val clazz = loadClassOrError(runtime, request.className, view) ?: return
+
+        val instance = if (functionNeedsInstance(clazz, request.functionName)) {
+            instantiateOrNull(clazz, view, request.className) ?: return
+        } else null
+
+        writeContent(view, request, clazz, instance)
+        lastSnapshot = LastSnapshot.from(request)
+        LOG.info("Rendered composable: {}#{} (orientation={})",
+            request.className, request.functionName, request.orientation)
+    }
+
+    private fun renderFromSnapshot(snap: LastSnapshot) {
+        val view = composeView ?: return
+        val runtime = activeRuntime.get() ?: run {
+            showError(view, "Replay failed: no active DexRuntime (was the engine detached?)")
+            return
+        }
+        val clazz = loadClassOrError(runtime, snap.className, view) ?: return
+        val instance = if (functionNeedsInstance(clazz, snap.functionName)) {
+            instantiateOrNull(clazz, view, snap.className)
+        } else null
+        // Replay 路径不写回 lastSnapshot, 也不改 pendingRequest — 它们已经是
+        // 这次 replay 的来源, 写回会造成无意义的覆盖.
+        writeContent(view, snap.toRequest(), clazz, instance)
+        LOG.info("Replayed composable: {}#{}", snap.className, snap.functionName)
+    }
+
+    /** 加载并合并所有 dex 到一个新的 [DexRuntime]. */
+    private fun loadRuntime(request: RenderRequest): DexRuntime {
+        val allDex = buildList {
+            val pd = request.previewDex
+            if (pd != null && pd.exists() && pd.length() > 0) add(pd)
+            request.projectDex.filter { it.exists() && it.length() > 0 }.forEach { add(it) }
+        }.distinctBy { it.absolutePath }
+        return DexRuntime.loadAll(context, allDex)
+    }
+
+    /** 通过 [DexRuntime.loadClass] 拿类, 拿不到就在 [view] 上画错误并返回 null. */
+    private fun loadClassOrError(runtime: DexRuntime, className: String, view: ComposeView): Class<*>? {
+        val clazz = runtime.loadClass(className)
+        if (clazz == null) {
+            showError(view, "Class not found: $className\n\nDex sources:\n" +
+                runtime.dexSources().joinToString("\n") { "  $it" })
+            return null
+        }
+        LOG.info("Loaded class: {} (loader={})", clazz.name, clazz.classLoader?.javaClass?.name)
+        return clazz
+    }
+
+    /** 判断给定方法是否需要先 newInstance 才能调用. */
+    private fun functionNeedsInstance(clazz: Class<*>, functionName: String): Boolean =
+        clazz.declaredMethods.any {
+            !Modifier.isStatic(it.modifiers) && it.name == functionName
+        }
+
+    /** 通过无参构造实例化, 失败则在 [view] 上画错误并返回 null. */
+    private fun instantiateOrNull(clazz: Class<*>, view: ComposeView, className: String): Any? = try {
+        clazz.getDeclaredConstructor().newInstance()
+    } catch (e: Throwable) {
+        LOG.error("Failed to instantiate {} (non-static composable)", className, e)
+        showError(view, "Cannot instantiate ${clazz.simpleName}: ${e.message ?: e::class.java.simpleName}")
+        null
+    }
+
+    /**
+     * 把 [request] + [clazz] + [instance] 写到 [view] 的 setContent. 这是唯一会
+     * 触发 Compose 重组的步骤, 其它步骤 (loadRuntime / loadClass / instantiate)
+     * 失败都直接 return, 不会污染 view.
+     */
+    private fun writeContent(
+        view: ComposeView,
+        request: RenderRequest,
+        clazz: Class<*>,
+        instance: Any?,
+    ) {
+        view.setContent {
+            PreviewScreen(invoker, clazz, instance, request)
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    //  错误显示
+    // ---------------------------------------------------------------------
+
+    /**
+     * 显示错误占位. Compose 渲染, 走 Surface 包好与 Preview 风格一致.
+     */
+    private fun showError(view: ComposeView, message: String) {
+        LOG.warn("Rendering error UI: {}", message)
+        view.setContent {
+            MaterialTheme {
+                ErrorScreen(message)
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    //  View 创建
+    // ---------------------------------------------------------------------
+
+    private fun newComposeView(): ComposeView = ComposeView(context).apply {
+        layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+        )
+        // Activity 销毁时释放 composition
+        setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+    }
+
+    /**
+     * 清掉 [container] 里残留的 [ComposeView]. 切 deviceSim / profile 时旧引擎
+     * 已经 [detach], 但 view 还在 container 里, 阻碍 GC. 用 downTo 0 反向迭代,
+     * 避免 removeViewAt(i) 后索引位移导致跳过下一个 view.
+     */
+    private fun cleanupContainer() {
         for (i in container.childCount - 1 downTo 0) {
             val child = container.getChildAt(i)
             if (child is ComposeView) {
@@ -132,338 +379,182 @@ class PreviewRenderEngine(
                 LOG.debug("Removed orphan ComposeView from container before attach")
             }
         }
+    }
+}
 
-        val view = ComposeView(context).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-            )
-            // Activity 销毁时释放 composition
-            setViewCompositionStrategy(
-                ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
-            )
-        }
-        container.addView(view)
-        composeView = view
-        LOG.info("PreviewRenderEngine attached to container (id={})", container.id)
+// ---------------------------------------------------------------------
+//  数据类
+// ---------------------------------------------------------------------
 
-        // 【v3.6】新 ComposeView 就位后, 如果之前已经渲染过 (lastRender != null),
-        // 立刻按上次参数重放一次, 修复 "再次进入 compose preview 显示黑屏" 的 bug.
-        // 之前要等 viewModel.previewState 重新发射 Ready 才会触发 render, 但
-        // collect 不会对"已经 Ready 的状态"重新发射, 第一次发射时 engine 还是 null
-        // (因为 attach 比 previewState 发射晚到), 等到 attach 完 collect 已经
-        // 错过了, 用户看到的就是空白. 用 lastRender 主动 replay 后, 即便 viewModel
-        // 没有再次发射, 新 ComposeView 上也会显示上次渲染.
-        lastRender?.let { saved ->
-            LOG.info(
-                "Replaying last render on freshly attached ComposeView: {}#{}",
-                saved.className,
-                saved.functionName,
-            )
-            // 用 saved 的参数重新走一遍 render 流程, 但 render 自己会在 composeView
-            // 为 null 时提前返回 — 此时 composeView 已经被设为 view, 所以会成功.
-            render(
-                previewDex = saved.previewDex,
-                projectDex = saved.projectDex,
-                className = saved.className,
-                functionName = saved.functionName,
-                args = saved.args,
-                previewConfig = saved.previewConfig,
-                orientation = saved.orientation,
-                fromReplay = true,
-            )
-        }
+/**
+ * 一次 [PreviewRenderEngine.render] 调用的全部输入.
+ *
+ * 故意做成不可变 + 普通 class (非 data class): args 是 `Array<out Any?>`, data class
+ * 自动生成的 equals 会调 `Arrays.equals` 做内容比较, 但 preview args 通常是动态
+ * 构造的, 内容相等的两个数组在 hash/equals 上仍会跑完全部元素比较, 性能没必要. 这里
+ * 只做"参数打包", 不用作 hash key.
+ */
+class RenderRequest(
+    val previewDex: File?,
+    val projectDex: List<File>,
+    val className: String,
+    val functionName: String,
+    val args: Array<out Any?> = emptyArray(),
+    val previewConfig: PreviewConfig? = null,
+    val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RenderRequest) return false
+        return previewDex == other.previewDex &&
+            projectDex == other.projectDex &&
+            className == other.className &&
+            functionName == other.functionName &&
+            args.contentEquals(other.args) &&
+            previewConfig == other.previewConfig &&
+            orientation == other.orientation
     }
 
-    /**
-     * 释放所有资源: 清空 DexRuntime, 把 ComposeView 从 container 移除, 清掉 lastRender.
-     * Activity.onDestroy 时调用.
-     */
-    fun detach() {
-        activeRuntime.getAndSet(null)?.release()
-        composeView?.let { container.removeView(it) }
-        composeView = null
-        // 【v3.6】detach 时不清空 lastRender, 让 Activity 重建新 engine 后能从旧
-        // engine 把 lastRender 拷贝过去再 attach, 即可看到上次渲染. detach 在
-        // Activity.onDestroy 调用, 此时 new engine 可能还在准备, 提前清空会让
-        // 新 engine attach 时拿不到 lastRender, 又变成黑屏. 真正的 lastRender
-        // 清理在 [render] 之前用新的覆盖, 以及当 Activity 真正不再使用 preview
-        // (用户从导航退到其它页面) 时由 [ComposePreviewActivity] 显式清.
+    override fun hashCode(): Int {
+        var result = previewDex?.hashCode() ?: 0
+        result = 31 * result + projectDex.hashCode()
+        result = 31 * result + className.hashCode()
+        result = 31 * result + functionName.hashCode()
+        result = 31 * result + args.contentHashCode()
+        result = 31 * result + (previewConfig?.hashCode() ?: 0)
+        result = 31 * result + orientation.hashCode()
+        return result
     }
+}
 
-    /**
-     * 加载 dex 并渲染指定 Composable.
-     *
-     * @param previewDex    项目 dex 中包含用户 Composable 的那个 (通常是 mergeProjectDex*
-     *                      或 project_dex_archive 中的第一个). **v3.1 不再是 K2 编译产物**,
-     *                      而是 gradle assemble 的直接产物.
-     * @param projectDex    项目运行时 dex 集合 (含 previewDex + 其它 merge / archive dex).
-     *                      **v3.1 不再有 runtimeDex 参数** — compose runtime 类由 IDE 主
-     *                      APK 的 PathClassLoader 解析.
-     * @param className     用户 Composable 所在类 (含 package).
-     * @param functionName  Composable 函数名.
-     * @param args          透传给 Composable 的 user 参数.
-     * @param previewConfig v3.4 新增 — `@Preview` 标注的完整配置 (背景色 / showBackground /
-     *                      uiMode / showSystemUi). 为 null 时使用默认 (无背景色 / 浅色主题).
-     * @param orientation   v3.5 新增 — 设备方向. 通过 [android.content.res.Configuration]
-     *                      的 ORIENTATION_PORTRAIT / ORIENTATION_LANDSCAPE 字段传给
-     *                      Compose 的 [androidx.compose.ui.platform.LocalConfiguration],
-     *                      让 [androidx.compose.foundation.layout.BoxWithConstraints] /
-     *                      `Modifier.aspectRatio` / `LocalConfiguration.current.orientation`
-     *                      等能正确响应方向. 真机模式: preview 内容按 orientation 重新布局.
-     */
-    fun render(
-        previewDex: File?,
-        projectDex: List<File>,
-        className: String,
-        functionName: String,
-        args: Array<out Any?> = emptyArray(),
-        previewConfig: PreviewConfig? = null,
-        orientation: com.itsaky.androidide.compose.preview.ui.DeviceOrientation =
-            com.itsaky.androidide.compose.preview.ui.DeviceOrientation.PORTRAIT,
-        /**
-         * 【v3.6】内部标志 — 当 [attach] 在 [lastRender] 存在时自动调用本方法
-         * 重放上一次渲染. 这种情况下不要再保存 [lastRender] (会覆盖为相同值)
-         * 也不要再写 LOG.info(已 attach 时打的). 默认 false, 由外部调用者忽略.
-         */
-        fromReplay: Boolean = false,
-    ) {
-        val view = composeView ?: run {
-            LOG.error("render() called before attach()")
-            return
-        }
-
-        // 1) 一次性加载所有 dex. v3.1 永远不传 runtimeDex; 内部合并到同一个 dex 列表.
-        val allDex = buildList {
-            if (previewDex != null && previewDex.exists() && previewDex.length() > 0) {
-                add(previewDex)
-            }
-            projectDex.filter { it.exists() && it.length() > 0 }.forEach { add(it) }
-        }.distinctBy { it.absolutePath }
-
-        val runtime = DexRuntime.loadAll(
-            context = context,
-            dexFiles = allDex,
-        )
-
-        // 替换旧 runtime
-        activeRuntime.getAndSet(runtime)?.release()
-
-        // 2) loadClass
-        val clazz = runtime.loadClass(className)
-        if (clazz == null) {
-            showError(view, "Class not found: $className\n\nDex sources:\n" +
-                runtime.dexSources().joinToString("\n") { "  $it" })
-            return
-        }
-        LOG.info("Loaded class: {} (loader={})", clazz.name, clazz.classLoader?.javaClass?.name)
-
-        // 3) 实例化 (仅当函数非静态时)
-        val instance: Any? = if (clazz.declaredMethods.any { !java.lang.reflect.Modifier.isStatic(it.modifiers) && it.name == functionName }) {
-            try {
-                clazz.getDeclaredConstructor().newInstance()
-            } catch (e: Throwable) {
-                LOG.error("Failed to instantiate {} (non-static composable)", className, e)
-                showError(view, "Cannot instantiate ${clazz.simpleName}: ${e.message ?: e::class.java.simpleName}")
-                return
-            }
-        } else {
-            null
-        }
-
-        // 保存 lastRender 让 [attach] 在新 view 上重放. 用 trySetSize 0 防止在
-        // args 是空数组时大小异常 (虽然没影响, 但跟 args 实际大小对齐).
-        lastRender = LastRender(
+/**
+ * v4 新增: [PreviewRenderEngine] 用于在 [PreviewRenderEngine.attach] 时自动
+ * replay 的快照. 故意只存"重放"必需的字段, 不带 dex — dex 在 [DexRuntime] 里,
+ * 重放时直接拿 [activeRuntime] 重新 loadClass, 不需要重新传 dex.
+ */
+internal class LastSnapshot(
+    val className: String,
+    val functionName: String,
+    val args: Array<out Any?>,
+    val previewConfig: PreviewConfig?,
+    val orientation: DeviceOrientation,
+) {
+    /** 拼回一个 [RenderRequest]. dex 字段由调用方决定 (replay 路径不需要). */
+    fun toRequest(previewDex: File? = null, projectDex: List<File> = emptyList()): RenderRequest =
+        RenderRequest(
+            previewDex = previewDex,
+            projectDex = projectDex,
             className = className,
             functionName = functionName,
-            args = args.copyOf(),
+            args = args,
             previewConfig = previewConfig,
             orientation = orientation,
         )
 
-        // 4) setContent + 通过 currentComposer 注入 (v3.4: 应用 PreviewConfig; v3.5: 应用 orientation)
-        applyContent(view, lastRender!!, clazz, instance)
-        LOG.info("Rendered composable: {}#{} (orientation={})", className, functionName, orientation)
-    }
-
-    /**
-     * 真正在 [view] 上 setContent 的 helper. 拆出来是为了让 [attach] 重建
-     * ComposeView 后能用 [LastRender] 重放, 修复 "fragment 重建后空白" bug.
-     */
-    private fun applyContent(
-        view: ComposeView,
-        saved: LastRender,
-        clazz: Class<*>? = null,
-        instance: Any? = null,
-    ) {
-        // 当 attach 重放时 clazz / instance 没法从 saved 还原 — 用反射再 loadClass.
-        // 走 saved.dex 走不通 (我们没存 dexFile), 只能依赖 activeRuntime.
-        val effectiveClass: Class<*>?
-        val effectiveInstance: Any?
-        if (clazz != null) {
-            effectiveClass = clazz
-            effectiveInstance = instance
-        } else {
-            val runtime = activeRuntime.get() ?: run {
-                showError(view, "Replay failed: no active DexRuntime (was the engine detached?)")
-                return
-            }
-            effectiveClass = runtime.loadClass(saved.className)
-            if (effectiveClass == null) {
-                showError(view, "Replay failed: class not found ${saved.className}")
-                return
-            }
-            effectiveInstance = if (effectiveClass.declaredMethods
-                .any { !java.lang.reflect.Modifier.isStatic(it.modifiers) && it.name == saved.functionName }
-            ) {
-                try {
-                    effectiveClass.getDeclaredConstructor().newInstance()
-                } catch (e: Throwable) {
-                    null
-                }
-            } else {
-                null
-            }
-        }
-
-        view.setContent {
-            // 【v3.5】用 LocalConfiguration 注入 orientation. Compose 在
-            // BoxWithConstraints / Modifier.aspectRatio / LocalConfiguration.current.orientation
-            // 处能正确响应, preview 内容按 orientation 重新布局.
-            val configuration = LocalConfiguration.current
-            val orientedConfiguration = remember(configuration, saved.orientation) {
-                val updated = android.content.res.Configuration(configuration)
-                updated.orientation = if (saved.orientation.isLandscape) {
-                    android.content.res.Configuration.ORIENTATION_LANDSCAPE
-                } else {
-                    android.content.res.Configuration.ORIENTATION_PORTRAIT
-                }
-                updated
-            }
-            CompositionLocalProvider(
-                LocalConfiguration provides orientedConfiguration,
-            ) {
-                PreviewConfigTheme(saved.previewConfig) {
-                    Surface(
-                        modifier = Modifier.fillMaxSize(),
-                        color = MaterialTheme.colorScheme.background,
-                    ) {
-                        RenderComposable(invoker, effectiveClass, effectiveInstance, saved.functionName, saved.args)
-                    }
-                }
-            }
-        }
-        // 【v3.6】保存渲染参数, 供 [attach] 在新 ComposeView 上重放. 必须在
-        // setContent 成功 (走到这里说明 clazz / instance 都 OK) 之后才保存,
-        // 失败 (return 在 loadClass/instantiate 处) 时保留旧 lastRender, 不会
-        // 把错误的 (Class not found) 状态缓存下来.
-        if (!fromReplay) {
-            lastRender = LastRender(
-                previewDex = previewDex,
-                projectDex = projectDex,
-                className = className,
-                functionName = functionName,
-                args = args,
-                previewConfig = previewConfig,
-                orientation = orientation,
-            )
-        }
-        if (!fromReplay) {
-            LOG.info(
-                "Rendered composable: {}#{} (orientation={})",
-                className,
-                functionName,
-                orientation,
-            )
-        }
-    }
-
-    /**
-     * 显示错误占位 (Compose 渲染, 走 Surface 包好与 Preview 风格一致).
-     */
-    private fun showError(view: ComposeView, message: String) {
-        LOG.warn("Rendering error UI: {}", message)
-        view.setContent {
-            MaterialTheme {
-                ErrorContent(message)
-            }
-        }
-    }
-
-    @Composable
-    private fun RenderComposable(
-        invoker: ComposableInvoker,
-        clazz: Class<*>,
-        instance: Any?,
-        functionName: String,
-        args: Array<out Any?>,
-    ) {
-        val composer: Any = runCatching { currentComposer }.getOrNull() ?: run {
-            ErrorContent("currentComposer is null - not in a Composable scope?")
-            return
-        }
-        val result = invoker.invoke(
-            clazz = clazz,
-            functionName = functionName,
-            composer = composer,
-            instance = instance,
-            args = args,
+    companion object {
+        fun from(request: RenderRequest): LastSnapshot = LastSnapshot(
+            className = request.className,
+            functionName = request.functionName,
+            args = request.args.copyOf(),
+            previewConfig = request.previewConfig,
+            orientation = request.orientation,
         )
-        if (!result.ok) {
-            ErrorContent(result.errorMessage ?: "Unknown invoke failure")
+    }
+}
+
+// ---------------------------------------------------------------------
+//  Compose 树 (顶 @Composable, 独立于 PreviewRenderEngine, 便于复用)
+// ---------------------------------------------------------------------
+
+/**
+ * 实际渲染的 Compose 根节点. 拆成顶层 @Composable 是为了:
+ *  - 不在 [PreviewRenderEngine] 内嵌 @Composable 树, 降低阅读耦合
+ *  - 写日志 / 调试时只看 PreviewScreen 就能定位渲染逻辑
+ *
+ * 包了 [CompositionLocalProvider] (orientation) + [PreviewConfigTheme] (uiMode +
+ * showBackground) + [Surface] (背景色), 最后委托给 [RenderComposableScreen].
+ */
+@Composable
+private fun PreviewScreen(
+    invoker: ComposableInvoker,
+    clazz: Class<*>,
+    instance: Any?,
+    request: RenderRequest,
+) {
+    val configuration = LocalConfiguration.current
+    val orientedConfiguration = remember(configuration, request.orientation) {
+        Configuration(configuration).apply {
+            orientation = if (request.orientation.isLandscape) {
+                Configuration.ORIENTATION_LANDSCAPE
+            } else {
+                Configuration.ORIENTATION_PORTRAIT
+            }
         }
     }
-
-    @Composable
-    private fun ErrorContent(message: String) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color(0xFFFFF3F3))
-                .padding(16.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = "Preview Error",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color(0xFFB00020),
-                )
-                Text(
-                    text = message,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color(0xFF666666),
-                    modifier = Modifier.padding(top = 8.dp),
-                )
+    CompositionLocalProvider(
+        LocalConfiguration provides orientedConfiguration,
+    ) {
+        PreviewConfigTheme(request.previewConfig) {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                RenderComposableScreen(invoker, clazz, instance, request.functionName, request.args)
             }
         }
     }
 }
 
-/**
- * v3.6 新增：上一次成功 [PreviewRenderEngine.render] 的参数快照。
- *
- * 仅由 [PreviewRenderEngine] 内部读写；外部仅当引擎重建（container 变化）时
- * 由 [com.itsaky.androidide.compose.preview.ComposePreviewActivity.attachPreviewContainer]
- * 拷贝到新引擎的 [PreviewRenderEngine.lastRender]，再触发 [PreviewRenderEngine.attach]
- * 自动 replay。
- *
- * 故意不用 data class：包含 `Array<out Any?>` 时 data class 自动生成的 equals
- * 会调用 `Arrays.equals` 对 Kotlin 数组做 identity 判定，每次 render 都得重建
- * Array，equals 始终 false；用普通 class 即可——这里只做"快照 / 重放"，不做
- * 集合去重 / 比较。
- *
- * @author android_zero
- */
-internal class LastRender(
-    val previewDex: File?,
-    val projectDex: List<File>,
-    val className: String,
-    val functionName: String,
-    val args: Array<out Any?>,
-    val previewConfig: PreviewConfig?,
-    val orientation: com.itsaky.androidide.compose.preview.ui.DeviceOrientation,
-)
+@Composable
+private fun RenderComposableScreen(
+    invoker: ComposableInvoker,
+    clazz: Class<*>,
+    instance: Any?,
+    functionName: String,
+    args: Array<out Any?>,
+) {
+    val composer: Any = runCatching { currentComposer }.getOrNull() ?: run {
+        ErrorScreen("currentComposer is null - not in a Composable scope?")
+        return
+    }
+    val result = invoker.invoke(
+        clazz = clazz,
+        functionName = functionName,
+        composer = composer,
+        instance = instance,
+        args = args,
+    )
+    if (!result.ok) {
+        ErrorScreen(result.errorMessage ?: "Unknown invoke failure")
+    }
+}
+
+@Composable
+internal fun ErrorScreen(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFFFF3F3))
+            .padding(16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        androidx.compose.foundation.layout.Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Preview Error",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color(0xFFB00020),
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF666666),
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+    }
+}
 
 /**
  * v3.4 新增: 应用 [PreviewConfig] 的 uiMode (浅色/深色) + showBackground 背景.
@@ -476,20 +567,24 @@ internal class LastRender(
  * - [PreviewConfig.backgroundColor] 提供具体色值, 缺省 `0xFFFFFFFF` (白)
  */
 @Composable
-private fun PreviewConfigTheme(
+fun PreviewConfigTheme(
     config: PreviewConfig?,
     content: @Composable () -> Unit,
 ) {
-    val isDark = when {
-        config?.uiMode == null -> isSystemInDarkTheme()
-        config.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES -> true
-        else -> false
+    val dark = when (config?.uiMode) {
+        android.content.res.Configuration.UI_MODE_NIGHT_YES -> true
+        android.content.res.Configuration.UI_MODE_NIGHT_NO -> false
+        else -> isSystemInDarkTheme()
     }
-    val colorScheme = if (isDark) darkColorScheme() else lightColorScheme()
-    MaterialTheme(colorScheme = colorScheme) {
+    val colors = if (dark) darkColorScheme() else lightColorScheme()
+    MaterialTheme(colorScheme = colors) {
         if (config?.showBackground == true) {
-            val bg = config.backgroundColor?.let { Color(it) } ?: Color(0xFFFFFFFF)
-            Box(modifier = Modifier.fillMaxSize().background(bg)) {
+            val bg = config.backgroundColor.takeIf { it != 0 } ?: 0xFFFFFFFF
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(bg.toLong()))
+            ) {
                 content()
             }
         } else {

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/DeviceFrame.kt
@@ -365,43 +365,58 @@ private fun PhoneOrFoldableFrame(
                     )
                     .clip(RoundedCornerShape(profile.cornerRadiusDp.dp))
             ) {
-                // 3) 内容
-                content()
+                // v4 修复 #1: 系统栏与 content 改为 Column sibling, 而不是 Box overlay.
+                // 之前把 content() 和 SystemBarsOverlay 放在同一个 fillMaxSize Box 里,
+                // SystemBarsOverlay 用 Spacer.weight(1f) 假装分隔, 实际 content 占满
+                // 整个屏幕, 系统栏只是覆盖在上面, 用户透过状态栏能看到 preview 内容.
+                // 现在 status bar | content(weight=1f) | nav bar 三段式, preview 内容
+                // 严格限定在两块系统栏之间的区域, 不会再越过虚拟状态栏 / 导航栏.
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (showStatusBar && profile.statusBarHeightDp > 0) {
+                        StatusBar(
+                            profile = profile,
+                            systemBarsTheme = systemBarsTheme,
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        // 3) 内容
+                        content()
 
-                // 4) 切口叠加 (在内容之上) — 用 effectiveCutout (已旋转锚点)
-                if (showCutout && profile.effectiveCutout != null) {
-                    CutoutOverlay(
-                        cutout = profile.effectiveCutout,
-                        modifier = Modifier.fillMaxSize(),
-                    )
+                        // 4) 切口叠加 (在内容之上) — 用 effectiveCutout (已旋转锚点)
+                        if (showCutout && profile.effectiveCutout != null) {
+                            CutoutOverlay(
+                                cutout = profile.effectiveCutout,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+
+                        // 5) 折叠铰链 (仅内屏) — 【PR-C】可拖拽改变 foldAngle
+                        // 【v3.5】横屏时铰链方向翻转: 原 horizontal = true (Galaxy Z Fold)
+                        // 在 LANDSCAPE 模式下变 horizontal = false (竖向铰链).
+                        if (profile.formFactor == DeviceProfile.FormFactor.FOLDABLE_INNER) {
+                            var foldAngle by remember { mutableStateOf(0f) }
+                            FoldableHingeOverlay(
+                                foldAngle = foldAngle,
+                                onFoldAngleChange = { foldAngle = it },
+                                modifier = Modifier.fillMaxSize(),
+                                // 横屏时铰链方向对调: 屏幕从竖向 (长边垂直) 变成
+                                // 横向 (长边水平), 所以铰链从"水平"变"垂直".
+                                horizontal = !profile.orientation.isLandscape,
+                            )
+                        }
+                    }
+                    if (showNavigationBar && profile.navigationBarHeightDp > 0) {
+                        NavigationBar(
+                            profile = profile,
+                            systemBarsTheme = systemBarsTheme,
+                            useGestureNav = useGestureNav,
+                        )
+                    }
                 }
-
-                // 5) 折叠铰链 (仅内屏) — 【PR-C】可拖拽改变 foldAngle
-                // 【v3.5】横屏时铰链方向翻转: 原 horizontal = true (Galaxy Z Fold)
-                // 在 LANDSCAPE 模式下变 horizontal = false (竖向铰链).
-                if (profile.formFactor == DeviceProfile.FormFactor.FOLDABLE_INNER) {
-                    var foldAngle by remember { mutableStateOf(0f) }
-                    FoldableHingeOverlay(
-                        foldAngle = foldAngle,
-                        onFoldAngleChange = { foldAngle = it },
-                        modifier = Modifier.fillMaxSize(),
-                        // 横屏时铰链方向对调: 屏幕从竖向 (长边垂直) 变成
-                        // 横向 (长边水平), 所以铰链从"水平"变"垂直".
-                        horizontal = !profile.orientation.isLandscape,
-                    )
-                }
-
-                // 6) 状态栏 + 导航栏 — 横屏时 status bar / nav bar 仍在
-                // "新屏幕的顶/底" (因为 SystemBarsOverlay 内部已是 Spacer.weight
-                // 布局, 不需要再旋转). 数值不变 (statusBar 高度 = 原 statusBar 高度).
-                SystemBarsOverlay(
-                    profile = profile,
-                    systemBarsTheme = systemBarsTheme,
-                    showStatusBar = showStatusBar,
-                    showNavigationBar = showNavigationBar,
-                    useGestureNav = useGestureNav,
-                    modifier = Modifier.fillMaxSize(),
-                )
             }
 
             // 7) 物理按键 (屏幕外侧) — 用 effectivePhysicalKeys (已旋转).

--- a/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
+++ b/modules/compose-preview/src/main/java/com/itsaky/androidide/compose/preview/ui/SystemBarsOverlay.kt
@@ -88,6 +88,91 @@ import java.util.Locale
  * @param batteryPercent 电量百分比 (0..100, null = 不显示)
  * @param notificationDot 是否显示通知小红点
  */
+/**
+ * 仅渲染状态栏的 composable. v4 拆分: 让 [com.itsaky.androidide.compose.preview.ui.PhoneOrFoldableFrame]
+ * 能把状态栏 / 导航栏作为 content 的 sibling 放在 Column 里, 配合 `weight(1f)`
+ * 让 preview 内容自然限定在两块系统栏之间的区域, 修复 "compose UI 越过虚拟状态栏
+ * 显示在设备外面" 的 bug. 旧 [SystemBarsOverlay] 用 `fillMaxSize` + 透明
+ * `Spacer.weight(1f)` 假装分隔, 实际上 preview 内容仍占满整个屏幕, 状态栏只是
+ * 覆盖在上面, 用户能透过状态栏看到 preview 内容.
+ */
+@Composable
+fun StatusBar(
+    profile: DeviceProfile,
+    systemBarsTheme: SystemBarsTheme = SystemBarsTheme.AUTO,
+    clockProvider: () -> Date = { Date() },
+    batteryPercent: Int? = 85,
+    notificationDot: Boolean = true,
+    modifier: Modifier = Modifier,
+) {
+    val (bg, fg) = resolveThemeColors(systemBarsTheme)
+    var now by remember { mutableStateOf(Date()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            now = clockProvider()
+            delay(1_000)
+        }
+    }
+    val timeText = remember(now) {
+        SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(now)
+    }
+    val isTranslucent = systemBarsTheme.isTranslucent()
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(profile.statusBarHeightDp.dp)
+    ) {
+        StatusBarContent(
+            time = timeText,
+            foreground = fg,
+            background = bg,
+            isTranslucent = isTranslucent,
+            batteryPercent = batteryPercent,
+            notificationDot = notificationDot,
+        )
+    }
+}
+
+/**
+ * 仅渲染导航栏的 composable. 配套 [StatusBar] 使用, 见 [StatusBar] 的注释.
+ */
+@Composable
+fun NavigationBar(
+    profile: DeviceProfile,
+    systemBarsTheme: SystemBarsTheme = SystemBarsTheme.AUTO,
+    useGestureNav: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    val (bg, fg) = resolveThemeColors(systemBarsTheme)
+    val isTranslucent = systemBarsTheme.isTranslucent()
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(profile.navigationBarHeightDp.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        NavigationBarContent(
+            foreground = fg,
+            background = bg,
+            isTranslucent = isTranslucent,
+            useGestureNav = useGestureNav,
+        )
+    }
+}
+
+/**
+ * 统一解析主题色: [SystemBarsTheme.AUTO] 跟随 Composable 当前背景明度.
+ */
+@Composable
+private fun resolveThemeColors(systemBarsTheme: SystemBarsTheme): Pair<Color, Color> {
+    val isDarkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    val resolved = when (systemBarsTheme) {
+        SystemBarsTheme.AUTO -> if (isDarkTheme) SystemBarsTheme.DARK else SystemBarsTheme.LIGHT
+        else -> systemBarsTheme
+    }
+    return resolved.colors()
+}
+
 @Composable
 fun SystemBarsOverlay(
     profile: DeviceProfile,
@@ -100,65 +185,25 @@ fun SystemBarsOverlay(
     notificationDot: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
-    val density = LocalDensity.current
-    val isDarkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
-    val resolvedTheme = when (systemBarsTheme) {
-        SystemBarsTheme.AUTO -> if (isDarkTheme) SystemBarsTheme.DARK else SystemBarsTheme.LIGHT
-        else -> systemBarsTheme
-    }
-    val (bg, fg) = resolvedTheme.colors()
-
-    // v3.4: 时钟 1s 刷新 (秒级), 之前 v2.1 是 10s. 让用户能看见秒针跳.
-    var now by remember { mutableStateOf(Date()) }
-    LaunchedEffect(Unit) {
-        while (true) {
-            now = clockProvider()
-            delay(1_000)
-        }
-    }
-    val timeText = remember(now) {
-        SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(now)
-    }
-
     Column(modifier = modifier.fillMaxSize()) {
-        // 状态栏
         if (showStatusBar && profile.statusBarHeightDp > 0) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(profile.statusBarHeightDp.dp)
-            ) {
-                StatusBarContent(
-                    time = timeText,
-                    foreground = fg,
-                    background = bg,
-                    isTranslucent = resolvedTheme.isTranslucent(),
-                    batteryPercent = batteryPercent,
-                    notificationDot = notificationDot,
-                )
-            }
+            StatusBar(
+                profile = profile,
+                systemBarsTheme = systemBarsTheme,
+                clockProvider = clockProvider,
+                batteryPercent = batteryPercent,
+                notificationDot = notificationDot,
+            )
         } else {
             Spacer(Modifier.height(0.dp))
         }
-
-        // 中间留空 (由外部 content 占位)
         Spacer(modifier = Modifier.weight(1f))
-
-        // 导航栏
         if (showNavigationBar && profile.navigationBarHeightDp > 0) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(profile.navigationBarHeightDp.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                NavigationBarContent(
-                    foreground = fg,
-                    background = bg,
-                    isTranslucent = resolvedTheme.isTranslucent(),
-                    useGestureNav = useGestureNav,
-                )
-            }
+            NavigationBar(
+                profile = profile,
+                systemBarsTheme = systemBarsTheme,
+                useGestureNav = useGestureNav,
+            )
         }
     }
 }


### PR DESCRIPTION
…file tree

Three asks from the user:
  (1) redesign PreviewRenderEngine, fix first-frame blank / deviceSim black screen;
  (2) device frame status / nav bars become Column siblings, no longer overlay content;
  (3) PreviewDexHashStore short-circuits gradle assemble when source + dex unchanged;
  (4) file tree image files open directly in ImagePreviewFragment tab, not external viewer.

(1) PreviewRenderEngine v4
- Introduce [RenderRequest] data class. Replaces v3's "render() takes 7 positional args" implicit-coupling design. applyContent no longer reads from render's closure, eliminating the v3 "private not applicable to local function" / "Unresolved reference" cascade.
- Split [LastSnapshot] (no dex) from v3 [LastRender] (had dex). Replay reloads Class from activeRuntime, no need to carry dex.
- Add [pendingRequest] queue: render() called before attach() now queues and attach() drains it. Fixes the v3 "first-frame blank" race where previewState fires Ready before the engine is attached.
- Decompose into loadRuntime / loadClassOrError / functionNeedsInstance / instantiateOrNull / writeContent. Main render() flow is now just orchestration.
- Public API: snapshotForTransfer / preloadSnapshot / currentComposeView / refresh. Replaces v3's direct field access and reflection hacks.

(2) SystemBarsOverlay split
- New [StatusBar] and [NavigationBar] composables.
- PhoneOrFoldableFrame becomes Column { StatusBar | content(weight=1f) | NavigationBar }. content strictly confined to the area between system bars; fixes v3 "compose UI extends past the virtual status bar".
- Old [SystemBarsOverlay] (overlay mode) preserved for other callers.

(3) PreviewDexHashStore
- New file modules/compose-preview/.../compiler/PreviewDexHashStore.kt.
- Storage: <Environment.ANDROIDIDE_HOME>/compose-preview/dex-hashes/<key>.hash Deliberately outside build/ so gradle clean does not wipe it.
- Hashes: user compose preview SDK .kt sources (under modulePath/src/) + projectDexFiles. SHA-256, files sorted by path for determinism.
- Deliberately skips androidx compose SDK -- those resolve via IDE PathClassLoader; androidx upgrades must not cause a cache miss.
- ComposePreviewRepositoryImpl.compilePreview: check isUnchanged at entry, hit returns existing dex and skips runGradleAssemble. After gradle, store new hash.

(4) FileTreeActionHandler image routing
- Extension hits ImagePreviewFragment.SUPPORTED_FORMATS -> route to EditorFragmentTabManager.openFileTab ("image_preview"), opens in IDE tab. Replaces old Intent.ACTION_VIEW which left the IDE.
- .xml files additionally content-sniffed via FileValidator.isLikelyAndroidVector to avoid misrouting layout / manifest / values xml.

Files:
  A  modules/compose-preview/.../compiler/PreviewDexHashStore.kt M  modules/compose-preview/.../runtime/PreviewRenderEngine.kt M  modules/compose-preview/.../ui/DeviceFrame.kt M  modules/compose-preview/.../ui/SystemBarsOverlay.kt M  modules/compose-preview/.../ComposePreviewActivity.kt M  modules/compose-preview/.../data/repository/ComposePreviewRepositoryImpl.kt M  core/app/.../handlers/FileTreeActionHandler.kt