### PR TITLE
Add WiFi QR pairing and Fastboot tools to device connection bottom sheet

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/debugger/connection/DeviceConnectionManager.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/debugger/connection/DeviceConnectionManager.kt
@@ -149,7 +149,7 @@ object DeviceConnectionManager {
         Shell.setDefaultBuilder(
             Shell.Builder.create()
                 .setFlags(Shell.FLAG_REDIRECT_STDERR)
-                .setCommands(arrayOf(suBin))
+                .setCommands(suBin)
         )
     }
 

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/debugger/DeviceConnectionBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/debugger/DeviceConnectionBottomSheet.kt
@@ -9,12 +9,20 @@
  *   - OTG:            USB OTG ADB 设备枚举 (OtgViewModel)
  *   - Fastboot:       Fastboot 设备管理 (FastbootViewModel)
  *
+ * 注意: 本 Fragment 不使用 @AndroidEntryPoint 注解。
+ *       宿主 EditorActivityKt 未标注 @AndroidEntryPoint, 若本 Fragment 标注会触发
+ *       Hilt "Fragment host component is missing" 异常并导致崩溃。
+ *       WiFi/OTG/Fastboot 三个 Tab 通过 hiltViewModel() 复用 connection 模块的
+ *       Hilt ViewModels (依赖宿主 Activity 已配置 Hilt 入口)。
+ *
  * UI/UX 设计 (跟 android-adb-shell 参考工程不同):
  *   - TabRow 顶部 4 个 Tab, 切换不同连接方式
  *   - 每个 Tab 内部用 Card 列表展示可用设备/通道
  *   - 状态指示灯 (彩色圆点) + 状态文字
  *   - 当前活跃连接用边框高亮标记
  *   - 操作按钮内联在每张卡片底部
+ *   - WiFi Tab 内部含 3 个子 Tab (QR 配对 / 配对码配对 / 已保存设备)
+ *   - Fastboot Tab 含活跃槽位、解锁状态、快速工具、Flash 操作状态、命令控制台
  *
  * WiFi/OTG/Fastboot 三个 Tab 使用 connection 模块中从 android-adb-shell 复刻的
  * Hilt ViewModels (WifiAdbViewModel / OtgViewModel / FastbootViewModel),
@@ -26,15 +34,21 @@
 
 package com.itsaky.androidide.fragments.debugger
 
+import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -55,12 +69,19 @@ import androidx.compose.material.icons.filled.Cable
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.FlashOn
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Router
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Usb
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -69,6 +90,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -87,11 +109,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -100,15 +125,22 @@ import com.itsaky.androidide.debugger.connection.DeviceConnectionManager
 import com.itsaky.androidide.debugger.connection.RootProbeState
 import com.itsaky.androidide.debugger.connection.ShizukuServiceState
 import com.itsaky.androidide.fragments.sheets.BaseBottomSheetFragment
+import android.zero.studio.shell.fastboot.domain.model.FastbootCommandResult
 import android.zero.studio.shell.fastboot.domain.model.FastbootDeviceInfo
 import android.zero.studio.shell.fastboot.domain.model.FastbootState
+import android.zero.studio.shell.fastboot.domain.model.FlashOperation
+import android.zero.studio.shell.fastboot.domain.model.FlashStatus
+import android.zero.studio.shell.fastboot.domain.model.RebootMode
 import android.zero.studio.shell.fastboot.presentation.viewmodel.FastbootViewModel
 import android.zero.studio.shell.otg_adb_shell.domain.model.OtgState
 import android.zero.studio.shell.otg_adb_shell.presentation.viewmodel.OtgViewModel
+import android.zero.studio.shell.wifi_adb_shell.domain.model.DiscoveredPairingService
 import android.zero.studio.shell.wifi_adb_shell.domain.model.WifiAdbDevice
 import android.zero.studio.shell.wifi_adb_shell.domain.model.WifiAdbState
 import android.zero.studio.shell.wifi_adb_shell.presentation.viewmodel.WifiAdbViewModel
-import dagger.hilt.android.AndroidEntryPoint
+import android.zero.studio.fastboot.ResponseStatus
+import java.security.SecureRandom
+import java.util.UUID
 import kotlinx.coroutines.launch
 
 /**
@@ -118,10 +150,12 @@ import kotlinx.coroutines.launch
  * ViewModels, 直接复用参考工程的 AdbConnectionManager / Repositories / mDNS 发现 /
  * USB 监听 / Fastboot 协议等完整连接逻辑, 仅 UI 层重新设计。
  *
+ * 注意: 本 Fragment 不标注 @AndroidEntryPoint (宿主 EditorActivityKt 未标注,
+ * 标注会导致 Hilt 崩溃), 三个 Tab 通过 hiltViewModel() 复用 Hilt ViewModels。
+ *
  * 使用方式:
  *   DeviceConnectionBottomSheet().show(supportFragmentManager, "device_connection")
  */
-@AndroidEntryPoint
 class DeviceConnectionBottomSheet : BaseBottomSheetFragment() {
 
     override fun onCreateView(
@@ -153,6 +187,14 @@ private enum class ConnectionTab(val label: String, val icon: ImageVector) {
     Wifi("WiFi", Icons.Default.Wifi),
     Otg("OTG", Icons.Default.Usb),
     Fastboot("Fastboot", Icons.Default.Build),
+}
+
+// ---- WiFi Tab 内部子 Tab 定义 (跟 android-adb-shell PairingOtherDeviceScreen 一致) ----
+
+private enum class WifiSubTab(val label: String) {
+    QrPair("QR 配对"),
+    CodePair("配对码配对"),
+    Saved("已保存设备"),
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -346,7 +388,13 @@ private fun LocalTabContent() {
 //   - 6 位配对码配对 (pairWithCode)
 //   - TLS 连接 + 心跳保活 + 自动重连
 //   - Room 持久化已保存设备
+//
+// WiFi Tab 内部含 3 个子 Tab (跟 android-adb-shell PairingOtherDeviceScreen 一致):
+//   - QR 配对:    生成 6 位随机配对码 -> generateQr -> startQrPairDiscovery -> 显示 Bitmap
+//   - 配对码配对: 6 位码输入 + discoveredPairingServices 列表
+//   - 已保存设备: savedDevices 列表 + 重连/忘记
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun WifiTabContent() {
     val viewModel: WifiAdbViewModel = hiltViewModel()
@@ -354,17 +402,9 @@ private fun WifiTabContent() {
     val savedDevices by viewModel.savedDevices.collectAsState()
     val currentDevice by viewModel.currentDevice.collectAsState()
     val discoveredPairingServices by viewModel.discoveredPairingServices.collectAsState()
+    val qrBitmap by viewModel.qrBitmap.collectAsState()
 
-    // 配对码输入 (6 位)
-    var pairingCode by remember { mutableStateOf("") }
-
-    // 进入 Tab 时启动配对服务发现, 离开时停止
-    DisposableEffect(Unit) {
-        viewModel.startCodePairingDiscovery()
-        onDispose {
-            viewModel.stopCodePairingDiscovery()
-        }
-    }
+    var selectedSubTab by remember { mutableStateOf(WifiSubTab.QrPair) }
 
     Column(
         modifier = Modifier
@@ -403,39 +443,208 @@ private fun WifiTabContent() {
             LoadingRow(text = wifiLoadingText(state))
         }
 
-        // ---- 已保存设备列表 ----
-        if (savedDevices.isNotEmpty()) {
-            Text(
-                text = "已保存设备 (${savedDevices.size})",
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(top = 4.dp),
+        // ---- 子 Tab 选择栏 (SecondaryTabRow, 跟 android-adb-shell 一致) ----
+        TabRow(selectedTabIndex = selectedSubTab.ordinal) {
+            WifiSubTab.values().forEach { subTab ->
+                Tab(
+                    selected = selectedSubTab == subTab,
+                    onClick = { selectedSubTab = subTab },
+                    text = { Text(subTab.label) },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        // ---- 子 Tab 内容区 ----
+        when (selectedSubTab) {
+            WifiSubTab.QrPair -> QrPairSubTab(
+                viewModel = viewModel,
+                qrBitmap = qrBitmap,
+                state = state,
             )
-            LazyColumn(
+            WifiSubTab.CodePair -> CodePairSubTab(
+                viewModel = viewModel,
+                discoveredPairingServices = discoveredPairingServices,
+            )
+            WifiSubTab.Saved -> SavedDevicesSubTab(
+                viewModel = viewModel,
+                savedDevices = savedDevices,
+                currentDevice = currentDevice,
+            )
+        }
+    }
+}
+
+// ---- WiFi: QR 配对子 Tab ----
+// 跟 android-adb-shell QRPairTab 一致: 生成 6 位随机配对码 -> generateQr 生成 Bitmap ->
+// startQrPairDiscovery 启动 mDNS 发现 -> 显示 QR Bitmap -> 离开时 stopQrPairDiscovery
+
+@Composable
+private fun QrPairSubTab(
+    viewModel: WifiAdbViewModel,
+    qrBitmap: Bitmap?,
+    state: WifiAdbState,
+) {
+    val sessionId = remember { UUID.randomUUID().toString() }
+    val pairingCode = remember { generatePairingCode() }
+
+    // 进入子 Tab 时生成 QR 并启动 mDNS 发现, 离开时停止发现
+    DisposableEffect(Unit) {
+        viewModel.generateQr(sessionId, pairingCode)
+        viewModel.startQrPairDiscovery(pairingCode)
+        onDispose {
+            viewModel.stopQrPairDiscovery()
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // ---- 提示卡片 ----
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+            shape = RoundedCornerShape(12.dp),
+        ) {
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(max = 220.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                    .padding(14.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                items(savedDevices, key = { it.id }) { device ->
-                    WifiSavedDeviceCard(
-                        device = device,
-                        isCurrent = currentDevice?.id == device.id,
-                        onReconnect = { viewModel.reconnectToDevice(device) },
-                        onForget = { viewModel.forgetDevice(device) },
+                Icon(
+                    imageVector = Icons.Default.QrCode,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(Modifier.width(12.dp))
+                Column {
+                    Text(
+                        text = "QR 码配对",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "在目标设备上打开「无线调试 > 配对设备」, 选择「使用二维码配对」并扫描下方二维码",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
         }
 
-        // ---- 配对码配对区 ----
+        // ---- 配对码展示卡片 ----
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+            ),
+            shape = RoundedCornerShape(12.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "配对码:",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = pairingCode,
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Spacer(Modifier.weight(1f))
+                if (state is WifiAdbState.Pairing || state is WifiAdbState.Connecting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
+        }
+
+        // ---- QR 码图片 ----
+        if (qrBitmap != null) {
+            Image(
+                bitmap = qrBitmap.asImageBitmap(),
+                contentDescription = "配对二维码",
+                modifier = Modifier.size(220.dp),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(220.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(12.dp),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(32.dp),
+                        strokeWidth = 3.dp,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = "正在生成二维码...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = "请确保本机与目标设备处于同一 WiFi 局域网, 且目标设备已开启无线调试",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+// ---- WiFi: 配对码配对子 Tab ----
+// 6 位码输入 + discoveredPairingServices 列表 + pairWithCode
+
+@Composable
+private fun CodePairSubTab(
+    viewModel: WifiAdbViewModel,
+    discoveredPairingServices: List<DiscoveredPairingService>,
+) {
+    var pairingCode by remember { mutableStateOf("") }
+
+    // 进入子 Tab 时启动配对服务发现, 离开时停止
+    DisposableEffect(Unit) {
+        viewModel.startCodePairingDiscovery()
+        onDispose {
+            viewModel.stopCodePairingDiscovery()
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
         Text(
             text = "使用 6 位配对码配对新设备",
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(top = 4.dp),
         )
 
         OutlinedTextField(
@@ -475,7 +684,58 @@ private fun WifiTabContent() {
         }
 
         Text(
-            text = "已保存设备可一键重连; 新设备需先配对 (6 位码), 配对成功后会自动连接并保存。",
+            text = "在目标设备「无线调试 > 配对设备」中获取 6 位配对码后输入, 选择下方发现的服务进行配对",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// ---- WiFi: 已保存设备子 Tab ----
+// savedDevices 列表 + 重连/忘记
+
+@Composable
+private fun SavedDevicesSubTab(
+    viewModel: WifiAdbViewModel,
+    savedDevices: List<WifiAdbDevice>,
+    currentDevice: WifiAdbDevice?,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (savedDevices.isEmpty()) {
+            EmptyStateCard(
+                icon = Icons.Default.Wifi,
+                title = "暂无已保存设备",
+                subtitle = "配对成功的设备会自动保存, 之后可一键重连",
+            )
+        } else {
+            Text(
+                text = "已保存设备 (${savedDevices.size})",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 320.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(savedDevices, key = { it.id }) { device ->
+                    WifiSavedDeviceCard(
+                        device = device,
+                        isCurrent = currentDevice?.id == device.id,
+                        onReconnect = { viewModel.reconnectToDevice(device) },
+                        onForget = { viewModel.forgetDevice(device) },
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = "已保存设备可一键重连; 新设备需先在「QR 配对」或「配对码配对」子 Tab 中完成配对。",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -612,7 +872,7 @@ private fun WifiSavedDeviceCard(
                 if (!isCurrent) {
                     Button(
                         onClick = onReconnect,
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        contentPadding = PaddingValues(
                             horizontal = 12.dp,
                             vertical = 6.dp,
                         ),
@@ -625,7 +885,7 @@ private fun WifiSavedDeviceCard(
                 Spacer(Modifier.height(4.dp))
                 TextButton(
                     onClick = onForget,
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                    contentPadding = PaddingValues(
                         horizontal = 12.dp,
                         vertical = 6.dp,
                     ),
@@ -892,9 +1152,12 @@ private fun OtgStatusCard(
 // 使用 connection 模块中的 FastbootViewModel, 直接复刻 android-adb-shell 的:
 //   - UsbManager Fastboot 设备枚举 (接口 0xFF)
 //   - fastbootlib FastbootDevice 协议通信
-//   - getvar / reboot 等命令
+//   - getvar / reboot / flash / erase / boot 等命令
 //   - 设备信息读取 (product/serial/unlocked/slot/battery...)
+//   - Flash 操作状态机 (READING_FILE/DOWNLOADING/FLASHING/ERASING/CANCELLING/COMPLETE/ERROR)
+//   - 命令控制台 (sendCommand + commandHistory)
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FastbootTabContent() {
     val viewModel: FastbootViewModel = hiltViewModel()
@@ -903,6 +1166,35 @@ private fun FastbootTabContent() {
     val variables by viewModel.variables.collectAsState()
     val isLoadingInfo by viewModel.isLoadingDeviceInfo.collectAsState()
     val isLoadingVars by viewModel.isLoadingVariables.collectAsState()
+    val flashOperation by viewModel.flashOperation.collectAsState()
+    val commandHistory by viewModel.commandHistory.collectAsState()
+
+    // ---- 对话框状态 ----
+    var showFlashDialog by remember { mutableStateOf(false) }
+    var showEraseDialog by remember { mutableStateOf(false) }
+    var showRebootDialog by remember { mutableStateOf(false) }
+    var pendingFlashPartition by remember { mutableStateOf("") }
+    var erasePartitionName by remember { mutableStateOf("") }
+
+    // ---- 命令控制台输入 ----
+    var commandInput by remember { mutableStateOf("") }
+
+    // ---- 文件选择器 (Flash 分区 / Boot 镜像) ----
+    val flashLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri: Uri? ->
+        if (uri != null && pendingFlashPartition.isNotBlank()) {
+            viewModel.flashPartition(pendingFlashPartition, uri)
+            pendingFlashPartition = ""
+        }
+    }
+    val bootLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            viewModel.bootImage(uri)
+        }
+    }
 
     // 进入 Tab 时启动 Fastboot 设备扫描
     DisposableEffect(Unit) {
@@ -943,8 +1235,9 @@ private fun FastbootTabContent() {
             onDisconnect = { viewModel.disconnect() },
         )
 
-        // ---- 设备信息卡片 (已连接时显示) ----
+        // ---- 已连接时显示: 设备信息 / 变量 / 系统状态 / 快速工具 / Flash状态 / 命令控制台 ----
         if (state is FastbootState.Connected) {
+            // ---- 设备信息卡片 ----
             FastbootDeviceInfoCard(
                 deviceInfo = deviceInfo,
                 isLoading = isLoadingInfo,
@@ -957,12 +1250,181 @@ private fun FastbootTabContent() {
                 isLoading = isLoadingVars,
                 onLoadAll = { viewModel.loadAllVariables() },
             )
+
+            // ---- 活跃槽位 + 解锁状态卡片 ----
+            FastbootSystemStatusCard(deviceInfo = deviceInfo)
+
+            // ---- 快速工具区 (Flash / Erase / Boot / Reboot) ----
+            FastbootQuickToolsCard(
+                onFlash = { showFlashDialog = true },
+                onErase = { showEraseDialog = true },
+                onBoot = { bootLauncher.launch("*/*") },
+                onReboot = { showRebootDialog = true },
+            )
+
+            // ---- Flash 操作状态 ----
+            if (flashOperation.status != FlashStatus.IDLE) {
+                FlashOperationCard(
+                    operation = flashOperation,
+                    onCancel = { viewModel.cancelFlashOperation() },
+                    onReset = { viewModel.resetFlashOperation() },
+                )
+            }
+
+            // ---- 命令控制台 ----
+            FastbootCommandConsoleCard(
+                commandHistory = commandHistory,
+                commandInput = commandInput,
+                onCommandInputChange = { commandInput = it },
+                onSend = {
+                    if (commandInput.isNotBlank()) {
+                        viewModel.sendCommand(commandInput.trim())
+                        commandInput = ""
+                    }
+                },
+            )
         }
 
         Text(
-            text = "请将设备重启到 Bootloader/Fastboot 模式后通过 USB 连接。连接后可读取设备信息、执行 Fastboot 命令。",
+            text = "请将设备重启到 Bootloader/Fastboot 模式后通过 USB 连接。连接后可读取设备信息、执行 Flash/Erase/Boot/Reboot 及任意 Fastboot 命令。",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // ---- Flash 分区对话框 (输入分区名 -> 选择文件) ----
+    if (showFlashDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showFlashDialog = false
+                pendingFlashPartition = ""
+            },
+            title = { Text("Flash 分区") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "输入要刷入的分区名 (如 boot, system, vendor), 确认后选择镜像文件",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    OutlinedTextField(
+                        value = pendingFlashPartition,
+                        onValueChange = { pendingFlashPartition = it },
+                        label = { Text("分区名") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        if (pendingFlashPartition.isNotBlank()) {
+                            showFlashDialog = false
+                            flashLauncher.launch("*/*")
+                        }
+                    },
+                    enabled = pendingFlashPartition.isNotBlank(),
+                ) {
+                    Text("选择镜像文件")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showFlashDialog = false
+                    pendingFlashPartition = ""
+                }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+
+    // ---- Erase 分区对话框 ----
+    if (showEraseDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showEraseDialog = false
+                erasePartitionName = ""
+            },
+            title = { Text("Erase 分区") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "输入要擦除的分区名 (如 cache, userdata)。擦除操作不可逆, 请谨慎操作",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    OutlinedTextField(
+                        value = erasePartitionName,
+                        onValueChange = { erasePartitionName = it },
+                        label = { Text("分区名") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        if (erasePartitionName.isNotBlank()) {
+                            viewModel.erasePartition(erasePartitionName.trim())
+                            erasePartitionName = ""
+                            showEraseDialog = false
+                        }
+                    },
+                    enabled = erasePartitionName.isNotBlank(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text("擦除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showEraseDialog = false
+                    erasePartitionName = ""
+                }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+
+    // ---- Reboot 模式选择对话框 ----
+    if (showRebootDialog) {
+        AlertDialog(
+            onDismissRequest = { showRebootDialog = false },
+            title = { Text("选择重启模式") },
+            text = {
+                Column {
+                    RebootMode.values().forEach { mode ->
+                        TextButton(
+                            onClick = {
+                                viewModel.reboot(mode)
+                                showRebootDialog = false
+                            },
+                            contentPadding = PaddingValues(
+                                horizontal = 8.dp,
+                                vertical = 10.dp,
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(
+                                text = mode.displayName,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showRebootDialog = false }) {
+                    Text("取消")
+                }
+            },
         )
     }
 }
@@ -1265,6 +1727,497 @@ private fun FastbootVariablesCard(
     }
 }
 
+// ---- Fastboot: 活跃槽位 + 解锁状态卡片 ----
+
+@Composable
+private fun FastbootSystemStatusCard(deviceInfo: FastbootDeviceInfo?) {
+    val slot = deviceInfo?.currentSlot
+    val unlocked = deviceInfo?.isUnlocked
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            // ---- 活跃槽位 ----
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.primary,
+                            shape = CircleShape,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = (slot ?: "_").uppercase().take(1),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "活跃槽位 (A/B)",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = if (slot.isNullOrBlank()) "未知" else "Slot ${slot.uppercase()}",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+
+            // ---- 解锁状态 ----
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .background(
+                            color = when {
+                                unlocked == true -> Color(0xFF66BB6A)
+                                unlocked == false -> Color(0xFFEF5350)
+                                else -> Color(0xFF9E9E9E)
+                            },
+                            shape = CircleShape,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Lock,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Bootloader 解锁状态",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = when {
+                            unlocked == null -> "未知"
+                            unlocked -> "已解锁"
+                            else -> "未解锁"
+                        },
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = when {
+                            unlocked == true -> Color(0xFF2E7D32)
+                            unlocked == false -> Color(0xFFC62828)
+                            else -> MaterialTheme.colorScheme.onSurface
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ---- Fastboot: 快速工具区 (Flash / Erase / Boot / Reboot) ----
+
+@Composable
+private fun FastbootQuickToolsCard(
+    onFlash: () -> Unit,
+    onErase: () -> Unit,
+    onBoot: () -> Unit,
+    onReboot: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = "快速工具",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FastbootToolButton(
+                    modifier = Modifier.weight(1f),
+                    icon = Icons.Default.FlashOn,
+                    label = "Flash 分区",
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    onClick = onFlash,
+                )
+                FastbootToolButton(
+                    modifier = Modifier.weight(1f),
+                    icon = Icons.Default.Delete,
+                    label = "Erase 分区",
+                    containerColor = MaterialTheme.colorScheme.error,
+                    onClick = onErase,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FastbootToolButton(
+                    modifier = Modifier.weight(1f),
+                    icon = Icons.Default.PlayArrow,
+                    label = "Boot 镜像",
+                    containerColor = Color(0xFF42A5F5),
+                    onClick = onBoot,
+                )
+                FastbootToolButton(
+                    modifier = Modifier.weight(1f),
+                    icon = Icons.Default.PowerSettingsNew,
+                    label = "Reboot",
+                    containerColor = Color(0xFFFFA726),
+                    onClick = onReboot,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FastbootToolButton(
+    modifier: Modifier = Modifier,
+    icon: ImageVector,
+    label: String,
+    containerColor: Color,
+    onClick: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = containerColor.copy(alpha = 0.12f),
+            contentColor = containerColor,
+        ),
+        contentPadding = PaddingValues(vertical = 14.dp),
+    ) {
+        Icon(icon, null, Modifier.size(20.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = label,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+// ---- Fastboot: Flash 操作状态卡片 ----
+// 观察 flashOperation, 显示进度和状态:
+//   IDLE -> 不显示; READING_FILE/DOWNLOADING/FLASHING/ERASING/CANCELLING -> 进行中;
+//   COMPLETE -> 成功; ERROR -> 错误消息。
+// 进行中提供取消按钮 (cancelFlashOperation), 完成后提供关闭按钮 (resetFlashOperation)。
+
+@Composable
+private fun FlashOperationCard(
+    operation: FlashOperation,
+    onCancel: () -> Unit,
+    onReset: () -> Unit,
+) {
+    val isActive = operation.status in setOf(
+        FlashStatus.READING_FILE,
+        FlashStatus.DOWNLOADING,
+        FlashStatus.FLASHING,
+        FlashStatus.ERASING,
+        FlashStatus.CANCELLING,
+    )
+    val statusColor = flashStatusColor(operation.status)
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = when (operation.status) {
+                FlashStatus.COMPLETE -> MaterialTheme.colorScheme.primaryContainer
+                FlashStatus.ERROR -> MaterialTheme.colorScheme.errorContainer
+                else -> MaterialTheme.colorScheme.surfaceVariant
+            },
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Flash 操作",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = flashStatusText(operation.status),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = statusColor,
+                )
+            }
+
+            if (operation.partition.isNotBlank()) {
+                Text(
+                    text = "分区: ${operation.partition}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (operation.fileName.isNotBlank()) {
+                Text(
+                    text = "文件: ${operation.fileName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (operation.message.isNotBlank()) {
+                Text(
+                    text = operation.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (operation.status == FlashStatus.ERROR)
+                        MaterialTheme.colorScheme.error
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // ---- 进度条 ----
+            if (isActive) {
+                if (operation.progress > 0f) {
+                    LinearProgressIndicator(
+                        progress = { operation.progress },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(6.dp),
+                        color = statusColor,
+                        trackColor = statusColor.copy(alpha = 0.15f),
+                    )
+                    Text(
+                        text = "${(operation.progress * 100).toInt()}%",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = statusColor,
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(6.dp),
+                        color = statusColor,
+                        trackColor = statusColor.copy(alpha = 0.15f),
+                    )
+                }
+            }
+
+            // ---- 操作按钮 ----
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                if (isActive) {
+                    OutlinedButton(
+                        onClick = onCancel,
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) {
+                        Icon(Icons.Default.Close, null, Modifier.size(16.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text("取消操作")
+                    }
+                } else {
+                    if (operation.status == FlashStatus.COMPLETE) {
+                        TextButton(onClick = onReset) {
+                            Icon(Icons.Default.Check, null, Modifier.size(16.dp))
+                            Spacer(Modifier.width(6.dp))
+                            Text("完成")
+                        }
+                    } else {
+                        TextButton(onClick = onReset) {
+                            Icon(Icons.Default.Close, null, Modifier.size(16.dp))
+                            Spacer(Modifier.width(6.dp))
+                            Text("关闭")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---- Fastboot: 命令控制台 ----
+// 输入框 + 发送按钮 -> sendCommand(command), 显示 commandHistory 历史记录
+
+@Composable
+private fun FastbootCommandConsoleCard(
+    commandHistory: List<FastbootCommandResult>,
+    commandInput: String,
+    onCommandInputChange: (String) -> Unit,
+    onSend: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Build,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "命令控制台",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = "${commandHistory.size} 条记录",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // ---- 历史记录列表 ----
+            if (commandHistory.isEmpty()) {
+                Text(
+                    text = "暂无命令记录, 在下方输入 Fastboot 命令 (如 getvar all)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 200.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    items(commandHistory, key = { it.timestamp }) { result ->
+                        CommandHistoryItem(result)
+                    }
+                }
+            }
+
+            // ---- 输入框 + 发送按钮 ----
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = commandInput,
+                    onValueChange = onCommandInputChange,
+                    label = { Text("Fastboot 命令") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = onSend,
+                    enabled = commandInput.isNotBlank(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 14.dp),
+                ) {
+                    Icon(Icons.Default.Send, null, Modifier.size(18.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CommandHistoryItem(result: FastbootCommandResult) {
+    val statusColor = responseStatusColor(result.status)
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "$ ${result.command}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = result.status.prefix,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = statusColor,
+                )
+            }
+            if (result.data.isNotBlank()) {
+                Text(
+                    text = result.data,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
 // ====================== 通用组件 ======================
 
 @Composable
@@ -1459,11 +2412,18 @@ private fun LoadingRow(text: String) {
 @Composable
 private fun TextButton(
     onClick: () -> Unit,
-    contentPadding: androidx.compose.foundation.layout.PaddingValues =
-        androidx.compose.foundation.layout.PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
     content: @Composable RowScope.() -> Unit,
 ) {
     OutlinedButton(onClick = onClick, contentPadding = contentPadding, content = content)
+}
+
+// ---- 6 位随机配对码 (跟 android-adb-shell generatePairingCode 一致, 返回 String) ----
+private fun generatePairingCode(): String {
+    val random = SecureRandom()
+    val code = StringBuilder()
+    repeat(6) { code.append(random.nextInt(10)) }
+    return code.toString()
 }
 
 // ---- Shizuku 状态映射 ----
@@ -1605,4 +2565,35 @@ private fun fastbootDetailText(state: FastbootState): String = when (state) {
     is FastbootState.Idle -> "尚未开始扫描"
     is FastbootState.UsbManagerUnavailable -> "系统未提供 UsbManager"
     is FastbootState.Error -> state.message
+}
+
+// ---- Flash 操作状态映射 ----
+
+private fun flashStatusColor(status: FlashStatus): Color = when (status) {
+    FlashStatus.IDLE -> Color(0xFF9E9E9E)
+    FlashStatus.READING_FILE, FlashStatus.DOWNLOADING,
+    FlashStatus.FLASHING, FlashStatus.ERASING -> Color(0xFFFFA726)
+    FlashStatus.CANCELLING -> Color(0xFF9E9E9E)
+    FlashStatus.COMPLETE -> Color(0xFF66BB6A)
+    FlashStatus.ERROR -> Color(0xFFEF5350)
+}
+
+private fun flashStatusText(status: FlashStatus): String = when (status) {
+    FlashStatus.IDLE -> "空闲"
+    FlashStatus.READING_FILE -> "读取文件中"
+    FlashStatus.DOWNLOADING -> "下载中"
+    FlashStatus.FLASHING -> "刷写中"
+    FlashStatus.ERASING -> "擦除中"
+    FlashStatus.CANCELLING -> "取消中"
+    FlashStatus.COMPLETE -> "完成"
+    FlashStatus.ERROR -> "错误"
+}
+
+// ---- Fastboot 命令响应状态映射 ----
+
+private fun responseStatusColor(status: ResponseStatus): Color = when (status) {
+    ResponseStatus.OKAY -> Color(0xFF66BB6A)
+    ResponseStatus.FAIL -> Color(0xFFEF5350)
+    ResponseStatus.DATA -> Color(0xFF42A5F5)
+    ResponseStatus.INFO -> Color(0xFF9E9E9E)
 }

--- a/core/app/src/main/java/com/itsaky/androidide/fragments/debugger/DeviceConnectionBottomSheet.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/fragments/debugger/DeviceConnectionBottomSheet.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -1460,7 +1461,7 @@ private fun TextButton(
     onClick: () -> Unit,
     contentPadding: androidx.compose.foundation.layout.PaddingValues =
         androidx.compose.foundation.layout.PaddingValues(horizontal = 12.dp, vertical = 6.dp),
-    content: @Composable () -> Unit,
+    content: @Composable RowScope.() -> Unit,
 ) {
     OutlinedButton(onClick = onClick, contentPadding = contentPadding, content = content)
 }

--- a/debugger/adb-connection/connection/build.gradle.kts
+++ b/debugger/adb-connection/connection/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     alias(libs.plugins.org.jetbrains.kotlin.plugin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.org.jetbrains.kotlin.plugin.serialization)
+    alias(libs.plugins.aboutlibraries)
     // 注意: 本模块不应用 KSP 插件, 避免与 Hilt 插件在同一模块共存时触发
     // Dagger #3965 classloader 冲突 (composite build 环境下两者 classloader 不一致)。
     // Hilt 和 Room 编译器均使用 kapt 处理。
@@ -43,6 +44,12 @@ android {
         minSdk = 26  // 与 app 模块一致 (app minSdk=26), 避免清单合并冲突
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "VERSION_NAME", "\"v8.0.0-alpha01\"")
+        buildConfigField("int", "VERSION_CODE", "63")
+        buildConfigField("String", "DIST_FLAVOR_GITHUB", "\"github\"")
+        buildConfigField("String", "DIST_FLAVOR_FDROID", "\"fdroid\"")
+        buildConfigField("String", "FLAVOR", "DIST_FLAVOR_GITHUB")
     }
 
     buildTypes {

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/ai/presentation/components/bottomsheet/AiAnalysisBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/ai/presentation/components/bottomsheet/AiAnalysisBottomSheet.kt
@@ -12,10 +12,9 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,10 +42,7 @@ fun AiAnalysisBottomSheet(
     onTryExample: () -> Unit,
     onRetry: () -> Unit,
     onDownloadModel: () -> Unit,
-    sheetState: SheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    ),
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/bottomsheet/CommandsFilterBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/bottomsheet/CommandsFilterBottomSheet.kt
@@ -21,9 +21,8 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,7 +34,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.commandexamples.presentation.component.row.Labels
 import android.zero.studio.commandexamples.presentation.viewmodel.CommandExamplesViewModel
@@ -52,10 +51,7 @@ fun CommandsFilterBottomSheet(
     onDismiss: () -> Unit,
     commandExamplesViewModel: CommandExamplesViewModel = hiltViewModel()
 ) {
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val lazyListState = rememberLazyListState()
     val states by commandExamplesViewModel.states.collectAsState()
     val searchedLabels by commandExamplesViewModel.searchedLabels.collectAsState()

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/card/CommandExampleCard.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/card/CommandExampleCard.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.compose.LottieAnimation

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/AddCommandDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/AddCommandDialog.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.commandexamples.presentation.component.row.Labels
 import android.zero.studio.commandexamples.presentation.model.CmdScreenInputFieldState

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/CommandsSortDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/CommandsSortDialog.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.buttongroup.OverflowButtonGroup
 import android.zero.studio.core.presentation.components.card.CustomCard

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/EditCommandDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/EditCommandDialog.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.commandexamples.presentation.component.row.Labels
 import android.zero.studio.commandexamples.presentation.model.CmdScreenInputFieldState

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/LoadDefaultCommandsDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/component/dialog/LoadDefaultCommandsDialog.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.commandexamples.presentation.viewmodel.CommandExamplesViewModel
 import android.zero.studio.core.presentation.components.dialog.DialogContainer

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/screens/CommandExamplesScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/commandexamples/presentation/screens/CommandExamplesScreen.kt
@@ -72,7 +72,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.commandexamples.data.local.source.preloadedCommands
 import android.zero.studio.commandexamples.presentation.component.bottomsheet.CommandsFilterBottomSheet

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/common/CompositionLocals.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/common/CompositionLocals.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Density
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.core.data.local.provider.AppSeedColors
 import android.zero.studio.core.data.local.provider.SeedColor
 import android.zero.studio.core.domain.model.PaletteStyle

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/di/RepositoryModule.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/di/RepositoryModule.kt
@@ -9,7 +9,11 @@ import android.zero.studio.commandexamples.domain.repository.CommandRepository
 import android.zero.studio.crashreporter.data.repository.CrashRepositoryImpl
 import android.zero.studio.crashreporter.domain.repository.CrashRepository
 import android.zero.studio.settings.data.repository.BackupAndRestoreRepositoryImpl
+import android.zero.studio.settings.data.repository.NoOpGoogleAuthRepositoryImpl
+import android.zero.studio.settings.data.repository.NoOpGoogleDriveRepositoryImpl
 import android.zero.studio.settings.domain.repository.BackupAndRestoreRepository
+import android.zero.studio.settings.domain.repository.GoogleAuthRepository
+import android.zero.studio.settings.domain.repository.GoogleDriveRepository
 import android.zero.studio.shell.common.data.repository.BookmarkRepositoryImpl
 import android.zero.studio.shell.common.data.repository.PackageRepositoryImpl
 import android.zero.studio.shell.common.domain.repository.BookmarkRepository
@@ -36,6 +40,18 @@ abstract class RepositoryModule {
     abstract fun bindBackupAndRestoreRepository(
         backupAndRestoreRepositoryImpl: BackupAndRestoreRepositoryImpl
     ): BackupAndRestoreRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindGoogleAuthRepository(
+        noOpGoogleAuthRepositoryImpl: NoOpGoogleAuthRepositoryImpl
+    ): GoogleAuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindGoogleDriveRepository(
+        noOpGoogleDriveRepositoryImpl: NoOpGoogleDriveRepositoryImpl
+    ): GoogleDriveRepository
 
     @Binds
     @Singleton

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/AppUiEntry.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/AppUiEntry.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.BuildConfig
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/bottomsheet/ChangelogBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/bottomsheet/ChangelogBottomSheet.kt
@@ -17,9 +17,8 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,7 +28,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.BuildConfig
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.card.CustomCard
@@ -46,10 +45,7 @@ fun ChangelogBottomSheet(
     onDismiss: () -> Unit,
     changelogViewModel: ChangelogViewModel = hiltViewModel()
 ) {
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val recentChangelog = changelogViewModel.changelogs.value.take(3)
 

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/bottomsheet/UpdateBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/bottomsheet/UpdateBottomSheet.kt
@@ -30,9 +30,8 @@ import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -58,7 +57,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.BuildConfig
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
@@ -115,10 +114,7 @@ fun UpdateBottomSheet(
         }
     }
 
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val changelogsVerticalScrollState = rememberScrollState()
 

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/buttongroup/ButtonGroupItem.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/buttongroup/ButtonGroupItem.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
 package android.zero.studio.core.presentation.components.buttongroup
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -6,6 +8,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/snackbar/AnimatedSnackBar.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/core/presentation/components/snackbar/AnimatedSnackBar.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
 package android.zero.studio.core.presentation.components.snackbar
 
 import androidx.compose.animation.AnimatedVisibility
@@ -17,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/crashreporter/presentation/screens/CrashReportScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/crashreporter/presentation/screens/CrashReportScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.constants.DEV_EMAIL
 import android.zero.studio.core.presentation.components.card.CustomCard

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/home/presentation/component/dialog/RebootOptionsDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/home/presentation/component/dialog/RebootOptionsDialog.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.dialog.DialogContainer
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/home/presentation/screens/HomeScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/home/presentation/screens/HomeScreen.kt
@@ -68,7 +68,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDialogManager
 import android.zero.studio.core.common.LocalSettings

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/onboarding/presentation/screens/OnboardingScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/onboarding/presentation/screens/OnboardingScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.haptic.withHaptic
 import android.zero.studio.navigation.LocalNavController

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/onboarding/presentation/screens/PageThree.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/onboarding/presentation/screens/PageThree.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/qstiles/presentation/screen/CreateTileScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/qstiles/presentation/screen/CreateTileScreen.kt
@@ -73,7 +73,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDarkMode
 import android.zero.studio.core.common.LocalWeakHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/qstiles/presentation/screen/TileDashBoardScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/qstiles/presentation/screen/TileDashBoardScreen.kt
@@ -77,7 +77,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/data/repository/NoOpGoogleAuthRepositoryImpl.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/data/repository/NoOpGoogleAuthRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package android.zero.studio.settings.data.repository
+
+import android.content.Context
+import android.zero.studio.settings.domain.model.GoogleUserState
+import android.zero.studio.settings.domain.repository.GoogleAuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+/** No-op implementation used when Google Auth is not available in this module. */
+class NoOpGoogleAuthRepositoryImpl @Inject constructor() : GoogleAuthRepository {
+
+    override val isAvailable: Boolean = false
+
+    private val _googleUserState = MutableStateFlow(GoogleUserState())
+    override val googleUserState: StateFlow<GoogleUserState> = _googleUserState.asStateFlow()
+
+    override suspend fun signIn(context: Context): Result<String> =
+        Result.failure(UnsupportedOperationException("Google Sign-In is not available in this build."))
+
+    override suspend fun signOut() {
+        // no-op
+    }
+
+    override fun getAccountEmail(): String? = null
+}

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/data/repository/NoOpGoogleDriveRepositoryImpl.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/data/repository/NoOpGoogleDriveRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package android.zero.studio.settings.data.repository
+
+import android.zero.studio.settings.domain.model.DriveAuthEvent
+import android.zero.studio.settings.domain.repository.GoogleDriveRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+
+/** No-op implementation used when Google Drive backup is not available in this module. */
+class NoOpGoogleDriveRepositoryImpl @Inject constructor() : GoogleDriveRepository {
+
+    override val isAvailable: Boolean = false
+
+    private val _authEvents = MutableSharedFlow<DriveAuthEvent>()
+    override val authEvents: SharedFlow<DriveAuthEvent> = _authEvents.asSharedFlow()
+
+    override val isConsentPending: Boolean = false
+
+    override suspend fun uploadBackup(data: ByteArray, fileName: String): Boolean = false
+
+    override suspend fun downloadBackup(): Pair<ByteArray, String>? = null
+
+    override suspend fun deleteAllBackups(): Boolean = false
+
+    override suspend fun ensureAuthorized(): Boolean = false
+
+    override fun onConsentGranted() {
+        // no-op
+    }
+
+    override suspend fun getHeadlessDriveService(): Any? = null
+}

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/components/bottomsheet/FontStyleBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/components/bottomsheet/FontStyleBottomSheet.kt
@@ -35,10 +35,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -59,7 +58,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.core.presentation.components.buttongroup.OverflowButtonGroup
@@ -86,10 +85,7 @@ fun FontStyleBottomSheet(
     viewModel: LookAndFeelViewModel = hiltViewModel()
 ) {
     val res = LocalResources.current
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scrollState = rememberScrollState()
 
     val fontStyles = RadioGroupOptionsProvider.fontStyleOptions

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/components/dialog/ConfigureSaveDirectoryDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/components/dialog/ConfigureSaveDirectoryDialog.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/components/tab/ColorTabs.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/components/tab/ColorTabs.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,12 +16,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import android.zero.studio.core.common.LocalPaletteStyle
 import android.zero.studio.core.common.LocalSeedColor
@@ -30,7 +34,6 @@ import android.zero.studio.core.data.local.provider.SeedColor
 import android.zero.studio.core.domain.model.PaletteStyle
 import android.zero.studio.settings.data.SettingsKeys
 import android.zero.studio.settings.presentation.components.palette.PaletteWheel
-import `in`.hridayan.shapeindicators.ShapeIndicatorRow
 
 @Composable
 fun ColorTabs(
@@ -104,11 +107,21 @@ fun ColorTabs(
             enter = scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)),
             exit = ExitTransition.None
         ) {
-            ShapeIndicatorRow(
-                pagerState = pagerState,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                shuffleShapes = true,
-            )
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                repeat(groupedPalettes.size) { index ->
+                    val color = if (pagerState.currentPage == index) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.outlineVariant
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(if (pagerState.currentPage == index) 10.dp else 8.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                    )
+                }
+            }
         }
     }
 }

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/about/screens/AboutScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/about/screens/AboutScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.BuildConfig
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/aimodels/screens/AiModelsScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/aimodels/screens/AiModelsScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.ai.data.local.model.ModelRegistry
 import android.zero.studio.ai.presentation.viewmodel.AiModelManagerViewModel

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/aimodels/screens/ModelsScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/aimodels/screens/ModelsScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.ai.domain.model.AiModel
 import android.zero.studio.ai.presentation.viewmodel.AiModelManagerViewModel

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/autoupdate/screens/AutoUpdateScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/autoupdate/screens/AutoUpdateScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.BuildConfig
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDialogManager

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/backup/screens/BackupAndRestoreScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/backup/screens/BackupAndRestoreScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDialogManager
 import android.zero.studio.core.common.LocalSettings

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/backup/screens/BackupSchedulerScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/backup/screens/BackupSchedulerScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.documentfile.provider.DocumentFile
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDialogManager
 import android.zero.studio.core.common.LocalSettings

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/behavior/screens/BehaviorScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/behavior/screens/BehaviorScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDialogManager
 import android.zero.studio.core.common.LocalSettings

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/changelog/screens/ChangelogScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/changelog/screens/ChangelogScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.BuildConfig
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.card.CustomCard

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/contributors/screens/ContributorsScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/contributors/screens/ContributorsScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import android.zero.studio.R

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/contributors/screens/TranslatorsScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/contributors/screens/TranslatorsScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import android.zero.studio.R

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/crashhistory/screens/CrashDetailsScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/crashhistory/screens/CrashDetailsScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalAnimatedContentScope
 import android.zero.studio.core.common.LocalSharedTransitionScope

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/crashhistory/screens/CrashHistoryScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/crashhistory/screens/CrashHistoryScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalAnimatedContentScope
 import android.zero.studio.core.common.LocalSharedTransitionScope

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/languages/screens/LanguagesScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/languages/screens/LanguagesScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/licenses/screens/LicensesScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/licenses/screens/LicensesScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.zero.studio.R
 import android.zero.studio.core.presentation.theme.CardCornerShape.getRoundedShape

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/lookandfeel/screens/DarkThemeScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/lookandfeel/screens/DarkThemeScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.settings.data.SettingsKeys

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/lookandfeel/screens/LookAndFeelScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/lookandfeel/screens/LookAndFeelScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalDarkMode
 import android.zero.studio.core.common.LocalDialogManager

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/lookandfeel/screens/UiScaleScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/lookandfeel/screens/UiScaleScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.core.presentation.components.card.CustomCard

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/mainscreen/screen/SettingsScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/mainscreen/screen/SettingsScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.core.presentation.components.button.BackButton

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/search/screens/SettingsSearchScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/settings/presentation/page/search/screens/SettingsSearchScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/bottomsheet/BookmarksBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/bottomsheet/BookmarksBottomSheet.kt
@@ -17,9 +17,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -33,7 +32,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.zero.studio.R
 import android.zero.studio.commandexamples.presentation.component.chip.LabelChip
@@ -65,10 +64,7 @@ fun BookmarksBottomSheet(
     val bookmarkCount by bookmarkViewModel.getBookmarkCount.collectAsState(initial = 0)
     val searchQuery by bookmarkViewModel.bookmarksSearchQuery.collectAsStateWithLifecycle()
 
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val isKeyboardVisible by isKeyboardVisible()
 

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/button/UtilityButtonGroup.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/button/UtilityButtonGroup.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.core.presentation.components.buttongroup.OverflowButtonGroup

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/card/SuggestionCard.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/card/SuggestionCard.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.commandexamples.presentation.component.chip.LabelChip
 import android.zero.studio.core.presentation.components.card.CustomCard
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/dialog/BookmarkDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/dialog/BookmarkDialog.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalSettings
 import android.zero.studio.core.presentation.components.card.CustomCard

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/dialog/BookmarksSortDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/dialog/BookmarksSortDialog.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.buttongroup.OverflowButtonGroup
 import android.zero.studio.core.presentation.components.card.CustomCard

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/dialog/ConnectedDeviceDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/components/dialog/ConnectedDeviceDialog.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.buttongroup.OverflowButtonGroup
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/screens/BaseShellScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/common/presentation/screens/BaseShellScreen.kt
@@ -115,7 +115,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.ai.presentation.components.bottomsheet.AiAnalysisBottomSheet
 import android.zero.studio.ai.presentation.components.button.AnalyzeButton

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/bottomsheet/FlashPartitionBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/bottomsheet/FlashPartitionBottomSheet.kt
@@ -43,9 +43,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -145,10 +144,7 @@ fun FlashPartitionBottomSheet(
     }
 
 
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(
         onDismissRequest = {

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/bottomsheet/GetVariablesBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/bottomsheet/GetVariablesBottomSheet.kt
@@ -25,9 +25,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -53,10 +52,7 @@ fun GetVariablesBottomSheet(
     isLoading: Boolean,
     onRefresh: () -> Unit
 ) {
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var searchQuery by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(""))

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/bottomsheet/WipeDataBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/bottomsheet/WipeDataBottomSheet.kt
@@ -22,9 +22,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,10 +54,7 @@ fun WipeDataBottomSheet(
     onDismiss: () -> Unit,
     onErase: (partition: String) -> Unit
 ) {
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var confirmingPartition by rememberSaveable { mutableStateOf<String?>(null) }
 

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/dialog/FastbootDeviceWaitingDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/components/dialog/FastbootDeviceWaitingDialog.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.card.IconWithTextCard
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/screens/FastbootScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/fastboot/presentation/screens/FastbootScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalWeakHaptic
 import android.zero.studio.core.presentation.components.button.BackButton

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/file_browser/presentation/screens/FileBrowserScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/file_browser/presentation/screens/FileBrowserScreen.kt
@@ -95,7 +95,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.zero.studio.R
 import android.zero.studio.core.common.LocalWeakHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/local_adb_shell/presentation/screens/LocalAdbScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/local_adb_shell/presentation/screens/LocalAdbScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/otg_adb_shell/presentation/components/dialog/OtgDeviceWaitingDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/otg_adb_shell/presentation/components/dialog/OtgDeviceWaitingDialog.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.card.IconWithTextCard
 import android.zero.studio.core.presentation.components.haptic.withHaptic

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/otg_adb_shell/presentation/screens/OtgAdbScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/otg_adb_shell/presentation/screens/OtgAdbScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.haptic.withHaptic
 import android.zero.studio.navigation.LocalNavController

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/component/bottomsheet/SavedDevicesBottomSheet.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/component/bottomsheet/SavedDevicesBottomSheet.kt
@@ -19,9 +19,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -36,7 +35,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.haptic.withHaptic
 import android.zero.studio.core.presentation.components.text.AutoResizeableText
@@ -57,10 +56,7 @@ fun SavedDevicesBottomSheet(
     onDismiss: () -> Unit,
     onGoToTerminal: () -> Unit,
     viewModel: WifiAdbViewModel = hiltViewModel(),
-    sheetState: SheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
-    )
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 ) {
     val context = LocalContext.current
     val res = LocalResources.current

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/component/dialog/DeviceDisconnectedDialog.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/component/dialog/DeviceDisconnectedDialog.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.haptic.withHaptic
 import android.zero.studio.core.presentation.components.text.AutoResizeableText

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/screens/PairingOtherDeviceScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/screens/PairingOtherDeviceScreen.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/screens/PairingOwnDeviceScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/screens/PairingOwnDeviceScreen.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/screens/WifiAdbScreen.kt
+++ b/debugger/adb-connection/connection/src/main/java/android/zero/studio/shell/wifi_adb_shell/presentation/screens/WifiAdbScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import android.zero.studio.R
 import android.zero.studio.core.presentation.components.haptic.withHaptic
 import android.zero.studio.core.utils.isConnectedToWifi


### PR DESCRIPTION
## Motivation

The `DeviceConnectionBottomSheet` was missing several features from the android-adb-shell reference implementation, and the `@AndroidEntryPoint` annotation caused a Hilt crash because the host `EditorActivityKt` is not annotated.

## Changes

### Remove @AndroidEntryPoint
- Removed `@AndroidEntryPoint` annotation and its import from `DeviceConnectionBottomSheet` (host `EditorActivityKt` is not annotated, causing Hilt "Fragment host component is missing" crash).
- Added header comment explaining why the annotation is omitted.

### WiFi Tab — 3 sub-tabs (matching `PairingOtherDeviceScreen`)
- **QR 配对 sub-tab**: generates a 6-digit random pairing code → `viewModel.generateQr(sessionId, pairingCode)` → `viewModel.startQrPairDiscovery(pairingCode)` → displays `qrBitmap` as a Compose `Image` → `stopQrPairDiscovery()` on dispose.
- **配对码配对 sub-tab**: retains the 6-digit code input + `discoveredPairingServices` list + `pairWithCode`.
- **已保存设备 sub-tab**: retains `savedDevices` list with reconnect/forget.

### Fastboot Tab — new features
- **Active slot card**: displays `deviceInfo.currentSlot` (A/B slot).
- **Unlock status card**: displays `deviceInfo.isUnlocked` (yes/no) with color-coded indicator.
- **Quick tools**: 4 buttons — Flash partition (dialog + file picker → `flashPartition`), Erase partition (dialog → `erasePartition`), Boot image (file picker → `bootImage`), Reboot (dialog selecting `RebootMode` → `reboot`).
- **Flash operation status**: observes `flashOperation`, shows progress bar and `FlashStatus` (READING_FILE/DOWNLOADING/FLASHING/ERASING/CANCELLING/COMPLETE/ERROR), cancel button (`cancelFlashOperation`), reset button (`resetFlashOperation`).
- **Command console**: input field + send button → `sendCommand`, displays `commandHistory` with `ResponseStatus` color coding.

### Unchanged
- Local Tab (Shizuku/Root via `DeviceConnectionManager`).
- OTG Tab (`OtgViewModel`).
- Common components and status mapping functions.