### PR TITLE
fix: correct GitPhoneScreen receiver type and remove invalid weight imports

### DIFF
--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitBranchesScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitBranchesScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Text

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitChangesScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitChangesScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitConflictScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitConflictScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Text

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitDiffScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitDiffScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitHistoryScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitHistoryScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitMockTheme.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitMockTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -58,7 +59,7 @@ internal object GitMockText {
 }
 
 @Composable
-internal fun GitPhoneScreen(content: @Composable Column.() -> Unit) {
+internal fun GitPhoneScreen(content: @Composable ColumnScope.() -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitRepositoriesScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitRepositoriesScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitStashScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitStashScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Text

--- a/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitTagsScreen.kt
+++ b/core/app/src/main/java/com/itsaky/androidide/ui/screen/git/GitTagsScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text


### PR DESCRIPTION
## Problem

`core:app:compileDebugKotlin` failed with a cascade of errors across the Git mock screens:
- `Cannot access 'val RowColumnParentData?.weight: Float': it is internal in file.`
- `Unresolved reference 'Column'`
- `Expression 'weight' of type 'Float' cannot be invoked as a function.`

## Root cause

`GitPhoneScreen` declared its content lambda as `Column.() -> Unit`, using the
`Column` **composable function** as a receiver *type*. `Column` is a function,
not a type, so:
1. `Column` was unresolved at the declaration and at every `GitPhoneScreen { }` call site.
2. Because the lambda receiver was not `ColumnScope`, `Modifier.weight()` was
   not in scope. The screen files tried to work around this with
   `import androidx.compose.foundation.layout.weight`, which resolves to the
   **internal** `RowColumnParentData.weight` property  failing with
   "it is internal in file" and "cannot be invoked as a function".

## Fix

- `GitMockTheme.kt`: change the receiver to `ColumnScope.() -> Unit` and add
  the `ColumnScope` import (this is the root-cause fix).
- Remove the invalid `import androidx.compose.foundation.layout.weight` from the
  8 screen files that had it. `Modifier.weight()` now resolves correctly via
  `ColumnScope` (inside `GitPhoneScreen`), `RowScope` (inside `Row`), and
  `FlowRowScope` (inside `FlowRow`).

No runtime behavior changes; this only fixes compilation.

## Files changed

- `GitMockTheme.kt` (receiver type + import)
- `GitBranchesScreen.kt`, `GitChangesScreen.kt`, `GitConflictScreen.kt`,
  `GitDiffScreen.kt`, `GitHistoryScreen.kt`, `GitRepositoriesScreen.kt`,
  `GitStashScreen.kt`, `GitTagsScreen.kt` (drop invalid `weight` import)