### PR TITLE
Add Ubuntu environment with categorized selector and versioned rootfs support

### DIFF
--- a/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
+++ b/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
@@ -1,0 +1,27 @@
+ROOTFS_ID=${TERMIX_ROOTFS_ID:-ubuntu-24.04}
+ROOTFS_DIR=$PREFIX/files/LinuxSystem/$ROOTFS_ID
+ROOTFS_ARCHIVE=$PREFIX/files/${TERMIX_ROOTFS_ARCHIVE:-ubuntu-24.04.tar.gz}
+PROOT_BIN=$PREFIX/local/bin/proot
+LINKER=/system/bin/linker
+[ -f /system/bin/linker64 ] && LINKER=/system/bin/linker64
+mkdir -p "$ROOTFS_DIR" "$PREFIX/local/bin"
+[ ! -e "$PROOT_BIN" ] && cp "$PREFIX/files/proot" "$PROOT_BIN"
+chmod 700 "$PROOT_BIN" 2>/dev/null || true
+if [ ! -d "$ROOTFS_DIR/etc" ]; then
+  if [ ! -f "$ROOTFS_ARCHIVE" ]; then
+    echo "Ubuntu rootfs archive not found: $ROOTFS_ARCHIVE"
+    exit 1
+  fi
+  echo "Extracting Ubuntu rootfs into $ROOTFS_DIR"
+  tar -xf "$ROOTFS_ARCHIVE" -C "$ROOTFS_DIR"
+fi
+mkdir -p "$ROOTFS_DIR/tmp" "$ROOTFS_DIR/root" "$ROOTFS_DIR/proc" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/dev" 2>/dev/null || true
+chmod 1777 "$ROOTFS_DIR/tmp" 2>/dev/null || true
+cat > "$ROOTFS_DIR/etc/resolv.conf" <<DNS
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+DNS
+ARGS="-0 -w /root -b /dev -b /proc -b /sys -b /sdcard -b $ROOTFS_DIR/tmp:/dev/shm -r $ROOTFS_DIR"
+export PROOT_TMP_DIR="$PREFIX/tmp"
+mkdir -p "$PROOT_TMP_DIR"
+exec "$LINKER" "$PROOT_BIN" $ARGS /usr/bin/env -i HOME=/root TERM="${TERM:-xterm-256color}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LANG=C.UTF-8 /bin/sh -lc "if [ -x /bin/bash ]; then exec /bin/bash -l; else exec /bin/sh -l; fi"

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/model/WorkingMode.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/model/WorkingMode.kt
@@ -6,4 +6,6 @@ object WorkingMode {
     const val ALPINE_ROOT = 2
     const val ARCH = 3
     const val ARCH_ROOT = 4
+    const val UBUNTU = 5
+    const val UBUNTU_ROOT = 6
 }

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/resources/Strings.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/resources/Strings.kt
@@ -6,9 +6,12 @@ object strings {
     val settings = R.string.settings
     val session = R.string.session
     val default_working_mode = R.string.default_working_mode
+    val ubuntu_desc = R.string.ubuntu_desc
+    val ubuntu_root_desc = R.string.ubuntu_root_desc
     val alpine_desc = R.string.alpine_desc
     val arch_desc = R.string.arch_desc
     val android_desc = R.string.android_desc
+    val terminal_env_ubuntu = R.string.terminal_env_ubuntu
     val terminal_env_alpine = R.string.terminal_env_alpine
     val terminal_env_arch = R.string.terminal_env_arch
     val terminal_env_android = R.string.terminal_env_android

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/service/SessionService.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/service/SessionService.kt
@@ -52,6 +52,8 @@ class SessionService : Service() {
             WorkingMode.ALPINE_ROOT -> "alpine (root)"
             WorkingMode.ARCH -> "arch"
             WorkingMode.ARCH_ROOT -> "arch (root)"
+            WorkingMode.UBUNTU -> "ubuntu"
+            WorkingMode.UBUNTU_ROOT -> "ubuntu (root)"
             else -> sessionId
         }
         return modeName

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/settings/Settings.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/settings/Settings.kt
@@ -47,8 +47,12 @@ object Settings {
         set(value) = Preference.setFloat(key = "wallTransparency",value)
 
     var working_Mode
-        get() = Preference.getInt(key = "workingMode", default = WorkingMode.ALPINE)
+        get() = Preference.getInt(key = "workingMode", default = WorkingMode.UBUNTU)
         set(value) = Preference.setInt(key = "workingMode",value)
+
+    var linux_distribution_version
+        get() = Preference.getString(key = "linux_distribution_version", default = "24.04")
+        set(value) = Preference.setString(key = "linux_distribution_version", value)
 
     var input_mode
         get() = Preference.getInt(key = "input_mode", default = InputMode.DEFAULT)

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/components/SessionTabBar.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/components/SessionTabBar.kt
@@ -305,6 +305,8 @@ private fun getSessionColor(workingMode: Int?, selected: Boolean): Color {
     return when (workingMode) {
         WorkingMode.ALPINE_ROOT -> Color(0xFFEF5350)
         WorkingMode.ARCH_ROOT -> Color(0xFFEF5350)
+        WorkingMode.UBUNTU -> Color(0xFFFFB300)
+        WorkingMode.UBUNTU_ROOT -> Color(0xFFEF5350)
         WorkingMode.ANDROID -> Color(0xFFFFA726)
         else -> if (selected) {
             MaterialTheme.colorScheme.onSurface

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/components/TerminalEnvironmentSelector.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/components/TerminalEnvironmentSelector.kt
@@ -7,17 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -27,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -37,42 +26,63 @@ import androidx.compose.ui.zIndex
 import android.zero.studio.termux.resources.strings
 import android.zero.studio.termux.model.WorkingMode
 
+enum class TerminalEnvironmentCategory(val title: String) {
+    DEVELOPMENT("开发"),
+    NON_DEVELOPMENT("非开发"),
+    OTHER("其它"),
+}
+
 enum class TerminalEnvironmentOption(
     val labelRes: Int,
     val supportsRoot: Boolean,
+    val category: TerminalEnvironmentCategory,
+    val versions: List<String> = emptyList(),
 ) {
+    UBUNTU(
+        labelRes = strings.terminal_env_ubuntu,
+        supportsRoot = true,
+        category = TerminalEnvironmentCategory.DEVELOPMENT,
+        versions = listOf("18.04", "20.04", "22.04", "24.04", "25.10", "26.04", "26.10 snapshot-1", "26.10 snapshot-2"),
+    ),
     ALPINE(
         labelRes = strings.terminal_env_alpine,
         supportsRoot = true,
+        category = TerminalEnvironmentCategory.NON_DEVELOPMENT,
     ),
     ARCH(
         labelRes = strings.terminal_env_arch,
         supportsRoot = true,
+        category = TerminalEnvironmentCategory.NON_DEVELOPMENT,
     ),
     ANDROID(
         labelRes = strings.terminal_env_android,
         supportsRoot = false,
+        category = TerminalEnvironmentCategory.OTHER,
     ),
 }
 
 fun terminalEnvironmentFromWorkingMode(mode: Int): TerminalEnvironmentOption = when (mode) {
+    WorkingMode.UBUNTU,
+    WorkingMode.UBUNTU_ROOT -> TerminalEnvironmentOption.UBUNTU
     WorkingMode.ALPINE,
     WorkingMode.ALPINE_ROOT -> TerminalEnvironmentOption.ALPINE
     WorkingMode.ARCH,
     WorkingMode.ARCH_ROOT -> TerminalEnvironmentOption.ARCH
     WorkingMode.ANDROID -> TerminalEnvironmentOption.ANDROID
-    else -> TerminalEnvironmentOption.ALPINE
+    else -> TerminalEnvironmentOption.UBUNTU
 }
 
 fun workingModeIsRoot(mode: Int): Boolean = when (mode) {
     WorkingMode.ALPINE_ROOT,
-    WorkingMode.ARCH_ROOT -> true
+    WorkingMode.ARCH_ROOT,
+    WorkingMode.UBUNTU_ROOT -> true
     else -> false
 }
 
 fun terminalEnvironmentToWorkingMode(environment: TerminalEnvironmentOption, runAsRoot: Boolean): Int {
     val normalizedRoot = runAsRoot && environment.supportsRoot
     return when (environment) {
+        TerminalEnvironmentOption.UBUNTU -> if (normalizedRoot) WorkingMode.UBUNTU_ROOT else WorkingMode.UBUNTU
         TerminalEnvironmentOption.ALPINE -> if (normalizedRoot) WorkingMode.ALPINE_ROOT else WorkingMode.ALPINE
         TerminalEnvironmentOption.ARCH -> if (normalizedRoot) WorkingMode.ARCH_ROOT else WorkingMode.ARCH
         TerminalEnvironmentOption.ANDROID -> WorkingMode.ANDROID
@@ -82,6 +92,7 @@ fun terminalEnvironmentToWorkingMode(environment: TerminalEnvironmentOption, run
 fun terminalEnvironmentDescriptionRes(environment: TerminalEnvironmentOption, runAsRoot: Boolean): Int {
     val normalizedRoot = runAsRoot && environment.supportsRoot
     return when (environment) {
+        TerminalEnvironmentOption.UBUNTU -> if (normalizedRoot) strings.ubuntu_root_desc else strings.ubuntu_desc
         TerminalEnvironmentOption.ALPINE -> if (normalizedRoot) strings.alpine_root_desc else strings.alpine_desc
         TerminalEnvironmentOption.ARCH -> if (normalizedRoot) strings.arch_root_desc else strings.arch_desc
         TerminalEnvironmentOption.ANDROID -> strings.android_desc
@@ -95,7 +106,35 @@ fun TerminalEnvironmentSegmentedSelector(
     modifier: Modifier = Modifier,
     minButtonHeight: Dp = 44.dp,
 ) {
-    val options = TerminalEnvironmentOption.entries
+    val selectedCategory = selectedEnvironment.category
+    Column(modifier = modifier.fillMaxWidth()) {
+        SegmentedPill(
+            options = TerminalEnvironmentCategory.entries,
+            selected = selectedCategory,
+            label = { it.title },
+            onSelected = { category ->
+                TerminalEnvironmentOption.entries.firstOrNull { it.category == category }?.let(onSelected)
+            },
+            minButtonHeight = minButtonHeight,
+        )
+        SegmentedPill(
+            options = TerminalEnvironmentOption.entries.filter { it.category == selectedCategory },
+            selected = selectedEnvironment,
+            label = { stringResource(it.labelRes) },
+            onSelected = onSelected,
+            minButtonHeight = minButtonHeight,
+        )
+    }
+}
+
+@Composable
+private fun <T> SegmentedPill(
+    options: List<T>,
+    selected: T,
+    label: @Composable (T) -> String,
+    onSelected: (T) -> Unit,
+    minButtonHeight: Dp,
+) {
     val containerShape = RoundedCornerShape(12.dp)
     val pillShape = RoundedCornerShape(10.dp)
     val backgroundColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
@@ -104,70 +143,40 @@ fun TerminalEnvironmentSegmentedSelector(
     val unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
 
     BoxWithConstraints(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = 16.dp, vertical = 6.dp)
             .height(minButtonHeight)
             .clip(containerShape)
             .background(backgroundColor)
             .padding(4.dp),
     ) {
-        val maxWidth = maxWidth
         val segmentWidth = maxWidth / options.size
-        val selectedIndex = options.indexOf(selectedEnvironment)
+        val selectedIndex = options.indexOf(selected).coerceAtLeast(0)
         val indicatorOffset by animateDpAsState(
-            targetValue = if (selectedIndex >= 0) segmentWidth * selectedIndex else 0.dp,
-            animationSpec = tween(
-                durationMillis = 250,
-                easing = FastOutSlowInEasing,
-            ),
-            label = "iosSelectorIndicatorOffset",
+            targetValue = segmentWidth * selectedIndex,
+            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
+            label = "terminalSelectorIndicatorOffset",
         )
-
         Box(
-            modifier = Modifier
-                .offset(x = indicatorOffset)
-                .width(segmentWidth)
-                .fillMaxHeight()
-                .padding(horizontal = 2.dp, vertical = 2.dp)
-                .clip(pillShape)
-                .background(selectedPillColor)
-                .zIndex(0f),
+            modifier = Modifier.offset(x = indicatorOffset).width(segmentWidth).fillMaxHeight().padding(2.dp)
+                .clip(pillShape).background(selectedPillColor).zIndex(0f),
         )
-
-        Row(
-            modifier = Modifier.fillMaxSize(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            options.forEach { environment ->
-                val isSelected = selectedEnvironment == environment
+        Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.SpaceEvenly, verticalAlignment = Alignment.CenterVertically) {
+            options.forEach { option ->
+                val isSelected = selected == option
                 val textColor by animateColorAsState(
                     targetValue = if (isSelected) selectedTextColor else unselectedTextColor,
                     animationSpec = tween(durationMillis = 200),
-                    label = "${environment.name}TextColor",
+                    label = "${option.hashCode()}TextColor",
                 )
-                val fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium
-
                 Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .clip(pillShape)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                        ) { onSelected(environment) }
-                        .zIndex(1f),
+                    modifier = Modifier.weight(1f).fillMaxHeight().clip(pillShape).clickable(
+                        interactionSource = remember { MutableInteractionSource() }, indication = null,
+                    ) { onSelected(option) }.zIndex(1f),
                     contentAlignment = Alignment.Center,
                 ) {
-                    Text(
-                        text = stringResource(environment.labelRes),
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = fontWeight,
-                        color = textColor,
-                        textAlign = TextAlign.Center,
-                    )
+                    Text(label(option), style = MaterialTheme.typography.labelLarge, fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium, color = textColor, textAlign = TextAlign.Center)
                 }
             }
         }

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
@@ -111,12 +111,17 @@ fun Downloader(
             val rootfsUrls = when (workingMode) {
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> urls.arch ?: throw RuntimeException("Arch Linux is not supported for ABI: $abi")
+                WorkingMode.UBUNTU,
+                WorkingMode.UBUNTU_ROOT -> ubuntuRootfsUrls(Settings.linux_distribution_version, abi)
+                    ?: throw RuntimeException("Ubuntu ${Settings.linux_distribution_version} is not supported for ABI: $abi")
                 else -> listOf(urls.alpine)
             }
 
             val rootfsFileName = when (workingMode) {
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> "arch.tar.gz"
+                WorkingMode.UBUNTU,
+                WorkingMode.UBUNTU_ROOT -> "ubuntu-${Settings.linux_distribution_version.normalizedRootfsVersion()}.tar.gz"
                 else -> "alpine.tar.gz"
             }
 
@@ -863,8 +868,40 @@ private data class DownloadProgressSnapshot(
 private fun modeLabel(workingMode: Int): String = when (workingMode) {
     WorkingMode.ARCH -> "ARCH"
     WorkingMode.ARCH_ROOT -> "ARCH ROOT"
+    WorkingMode.UBUNTU -> "UBUNTU ${Settings.linux_distribution_version}"
+    WorkingMode.UBUNTU_ROOT -> "UBUNTU ${Settings.linux_distribution_version} ROOT"
     WorkingMode.ALPINE_ROOT -> "ALPINE ROOT"
     else -> "ALPINE"
+}
+
+private fun String.normalizedRootfsVersion(): String = lowercase().replace(" ", "-")
+
+private fun ubuntuRootfsUrls(version: String, abi: String): List<String>? {
+    val ubuntuAbi = when (abi) {
+        "arm64-v8a" -> "arm64"
+        "armeabi-v7a" -> "armhf"
+        "x86" -> "i386"
+        else -> return null
+    }
+    val file = when (version) {
+        "18.04" -> "ubuntu-base-18.04.5-base-$ubuntuAbi.tar.gz"
+        "20.04" -> "ubuntu-base-20.04.5-base-$ubuntuAbi.tar.gz"
+        "22.04" -> "ubuntu-base-22.04.5-base-$ubuntuAbi.tar.gz"
+        "24.04" -> "ubuntu-base-24.04.4-base-$ubuntuAbi.tar.gz"
+        "25.10" -> "ubuntu-base-25.10-base-$ubuntuAbi.tar.gz"
+        "26.04" -> "ubuntu-base-26.04-base-$ubuntuAbi.tar.gz"
+        "26.10 snapshot-1" -> "ubuntu-base-26.10-snapshot1-base-$ubuntuAbi.tar.gz"
+        "26.10 snapshot-2" -> "ubuntu-base-26.10-snapshot2-base-$ubuntuAbi.tar.gz"
+        else -> return null
+    }
+    if (version == "18.04" && ubuntuAbi !in setOf("arm64", "armhf", "i386")) return null
+    if (version != "18.04" && ubuntuAbi !in setOf("arm64", "armhf")) return null
+    val path = when (version) {
+        "26.10 snapshot-1" -> "26.10/release/snapshot-1"
+        "26.10 snapshot-2" -> "26.10/release/snapshot-2"
+        else -> "$version/release"
+    }
+    return listOf("https://cdimage.ubuntu.com/ubuntu-base/releases/$path/$file")
 }
 
 private fun formatRate(bytesPerSecond: Long): String {

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
@@ -108,12 +108,17 @@ fun Downloader(
             } ?: throw RuntimeException("Unsupported CPU")
 
             val urls = abiMap[abi] ?: throw RuntimeException("Unsupported CPU ABI: $abi")
+            val ubuntuRootfs = if (workingMode == WorkingMode.UBUNTU || workingMode == WorkingMode.UBUNTU_ROOT) {
+                ubuntuRootfsAsset(Settings.linux_distribution_version, abi)
+                    ?: throw RuntimeException("Ubuntu ${Settings.linux_distribution_version} is not supported for ABI: $abi")
+            } else {
+                null
+            }
             val rootfsUrls = when (workingMode) {
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> urls.arch ?: throw RuntimeException("Arch Linux is not supported for ABI: $abi")
                 WorkingMode.UBUNTU,
-                WorkingMode.UBUNTU_ROOT -> ubuntuRootfsUrls(Settings.linux_distribution_version, abi)
-                    ?: throw RuntimeException("Ubuntu ${Settings.linux_distribution_version} is not supported for ABI: $abi")
+                WorkingMode.UBUNTU_ROOT -> listOf(ubuntuRootfs!!.url)
                 else -> listOf(urls.alpine)
             }
 
@@ -121,14 +126,19 @@ fun Downloader(
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> "arch.tar.gz"
                 WorkingMode.UBUNTU,
-                WorkingMode.UBUNTU_ROOT -> "ubuntu-${Settings.linux_distribution_version.normalizedRootfsVersion()}.tar.gz"
+                WorkingMode.UBUNTU_ROOT -> ubuntuRootfs!!.archiveName
                 else -> "alpine.tar.gz"
             }
 
             val filesToDownload = listOf(
                 DownloadFile(listOf(urls.talloc.url), Rootfs.reTerminal.child("libtalloc.so.2"), urls.talloc.sha256),
                 DownloadFile(listOf(urls.proot.url), Rootfs.reTerminal.child("proot"), urls.proot.sha256),
-                DownloadFile(rootfsUrls, Rootfs.reTerminal.child(rootfsFileName))
+                DownloadFile(
+                    urls = rootfsUrls,
+                    outputFile = Rootfs.reTerminal.child(rootfsFileName),
+                    checksumUrl = ubuntuRootfs?.sha256SumsUrl,
+                    checksumFileName = ubuntuRootfs?.fileName,
+                )
             )
 
             needsDownload = filesToDownload.any { !it.outputFile.exists() }
@@ -389,7 +399,18 @@ fun Downloader(
 private data class DownloadFile(
     val urls: List<String>,
     val outputFile: File,
-    val expectedSha256: String? = null
+    val expectedSha256: String? = null,
+    val checksumUrl: String? = null,
+    val checksumFileName: String? = null,
+) {
+    fun hasChecksum(): Boolean = expectedSha256 != null || (checksumUrl != null && checksumFileName != null)
+}
+
+private data class UbuntuRootfsAsset(
+    val url: String,
+    val sha256SumsUrl: String,
+    val fileName: String,
+    val archiveName: String,
 )
 
 private suspend fun setupEnvironment(
@@ -425,9 +446,10 @@ private suspend fun setupEnvironment(
                         onInstallLog("Detected usable Arch rootfs; skipping arch.tar.gz download")
                     }
                 } else {
-                    if (outputFile.exists() && file.expectedSha256 != null && !outputFile.matchesSha256(file.expectedSha256)) {
+                    val expectedSha256 = file.resolveExpectedSha256()
+                    if (outputFile.exists() && expectedSha256 != null && !outputFile.matchesSha256(expectedSha256)) {
                         runOnUiThread {
-                            onInstallLog("Checksum mismatch for existing ${outputFile.name}; redownloading")
+                            onInstallLog("Checksum mismatch for existing ${outputFile.name}; deleting and redownloading")
                         }
                         if (!outputFile.delete()) {
                             throw Exception("Checksum mismatch for ${outputFile.name} and failed to delete stale file")
@@ -444,7 +466,14 @@ private suspend fun setupEnvironment(
                         var lastDownloaded = 0L
                         var smoothedSpeed = 0.0
 
-                        downloadFileWithFallback(file.urls, tempOutputFile) { downloaded, total ->
+                        var checksumAttempt = 0
+                        while (true) {
+                            checksumAttempt++
+                            if (tempOutputFile.exists()) {
+                                tempOutputFile.delete()
+                            }
+
+                            downloadFileWithFallback(file.urls, tempOutputFile) { downloaded, total ->
                             val now = System.nanoTime()
                             val deltaNanos = now - lastSampleAt
                             if (deltaNanos > 0) {
@@ -482,12 +511,25 @@ private suspend fun setupEnvironment(
                             }
                         }
 
-                        if (outputFile.exists()) {
-                            outputFile.delete()
-                        }
+                            if (outputFile.exists()) {
+                                outputFile.delete()
+                            }
 
-                        file.expectedSha256?.let { expectedSha256 ->
-                            verifySha256OrThrow(tempOutputFile, expectedSha256)
+                            if (expectedSha256 != null) {
+                                try {
+                                    verifySha256OrThrow(tempOutputFile, expectedSha256)
+                                } catch (e: Exception) {
+                                    tempOutputFile.delete()
+                                    runOnUiThread {
+                                        onInstallLog("Checksum verification failed for ${outputFile.name} (attempt $checksumAttempt/$MAX_CHECKSUM_ATTEMPTS)")
+                                    }
+                                    if (checksumAttempt < MAX_CHECKSUM_ATTEMPTS) {
+                                        continue
+                                    }
+                                    throw Exception("Checksum verification failed after $MAX_CHECKSUM_ATTEMPTS attempts for ${outputFile.name}", e)
+                                }
+                            }
+                            break
                         }
 
                         if (!tempOutputFile.renameTo(outputFile)) {
@@ -759,6 +801,33 @@ private suspend fun downloadFile(url: String, outputFile: File, onProgress: (Lon
     }
 }
 
+private fun DownloadFile.resolveExpectedSha256(): String? {
+    expectedSha256?.let { return it }
+    val sumsUrl = checksumUrl ?: return null
+    val fileName = checksumFileName ?: return null
+    val sums = OkHttpClient().newCall(Request.Builder().url(sumsUrl).build()).execute().use { response ->
+        if (!response.isSuccessful) {
+            throw Exception("Failed to download checksum file from $sumsUrl: HTTP ${response.code}")
+        }
+        response.body?.string() ?: throw Exception("Empty checksum file from $sumsUrl")
+    }
+    return parseSha256Sums(sums, fileName)
+        ?: throw Exception("Checksum for $fileName not found in $sumsUrl")
+}
+
+private fun parseSha256Sums(sums: String, fileName: String): String? {
+    return sums.lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .firstNotNullOfOrNull { line ->
+            val parts = line.split(Regex("\s+"), limit = 2)
+            if (parts.size != 2) return@firstNotNullOfOrNull null
+            val hash = parts[0]
+            val listedFileName = parts[1].removePrefix("*")
+            hash.takeIf { listedFileName == fileName && it.matches(Regex("[a-fA-F0-9]{64}")) }
+        }
+}
+
 private fun verifySha256OrThrow(file: File, expectedSha256: String) {
     val actualSha256 = file.sha256()
     if (!actualSha256.equals(expectedSha256, ignoreCase = true)) {
@@ -851,6 +920,7 @@ private data class RuntimeAsset(
 private const val ARCH_EXTRACT_TIMEOUT_MINUTES = 30L
 private const val ARCH_READY_MARKER = ".termix-arch-installed"
 private const val MAX_INSTALL_LOG_LINES = 220
+private const val MAX_CHECKSUM_ATTEMPTS = 3
 private const val NANOS_PER_SECOND = 1_000_000_000.0
 
 private data class DownloadProgressSnapshot(
@@ -876,7 +946,7 @@ private fun modeLabel(workingMode: Int): String = when (workingMode) {
 
 private fun String.normalizedRootfsVersion(): String = lowercase().replace(" ", "-")
 
-private fun ubuntuRootfsUrls(version: String, abi: String): List<String>? {
+private fun ubuntuRootfsAsset(version: String, abi: String): UbuntuRootfsAsset? {
     val ubuntuAbi = when (abi) {
         "arm64-v8a" -> "arm64"
         "armeabi-v7a" -> "armhf"
@@ -901,7 +971,12 @@ private fun ubuntuRootfsUrls(version: String, abi: String): List<String>? {
         "26.10 snapshot-2" -> "26.10/release/snapshot-2"
         else -> "$version/release"
     }
-    return listOf("https://cdimage.ubuntu.com/ubuntu-base/releases/$path/$file")
+    return UbuntuRootfsAsset(
+        url = "https://cdimage.ubuntu.com/ubuntu-base/releases/$path/$file",
+        sha256SumsUrl = "https://cdimage.ubuntu.com/ubuntu-base/releases/$path/SHA256SUMS",
+        fileName = file,
+        archiveName = "ubuntu-${version.normalizedRootfsVersion()}-$ubuntuAbi.tar.gz",
+    )
 }
 
 private fun formatRate(bytesPerSecond: Long): String {

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
@@ -26,6 +26,10 @@ import android.zero.studio.termux.App
 import android.zero.studio.termux.model.WorkingMode
 import android.zero.studio.termux.ui.screens.terminal.Rootfs
 import android.zero.studio.termux.ui.screens.terminal.TerminalScreen
+import android.zero.studio.termux.ui.components.TerminalEnvironmentOption
+import android.zero.studio.termux.ui.components.terminalEnvironmentFromWorkingMode
+import android.zero.studio.termux.ui.components.terminalEnvironmentToWorkingMode
+import android.zero.studio.termux.ui.components.workingModeIsRoot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -68,6 +72,9 @@ fun Downloader(
     var needsDownload by remember { mutableStateOf(false) }
     var setupError by remember { mutableStateOf<String?>(null) }
     var retryToken by remember { mutableIntStateOf(0) }
+    var selectedInstallEnvironment by remember { mutableStateOf(terminalEnvironmentFromWorkingMode(Settings.working_Mode)) }
+    var selectedInstallVersion by remember { mutableStateOf(Settings.linux_distribution_version) }
+    var installRequested by remember { mutableStateOf(Rootfs.isFilesDownloaded(Settings.working_Mode)) }
 
     fun appendInstallerLog(line: String) {
         installerLogs += line
@@ -82,7 +89,10 @@ fun Downloader(
         }
     }
 
-    LaunchedEffect(retryToken) {
+    LaunchedEffect(installRequested, retryToken) {
+        if (!installRequested) {
+            return@LaunchedEffect
+        }
         progress = 0f
         rootfsProgress = 0f
         rootfsSpeedBytes = 0L
@@ -201,7 +211,116 @@ fun Downloader(
     }
 
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (!isSetupComplete) {
+        if (!installRequested) {
+            var environmentExpanded by remember { mutableStateOf(false) }
+            var versionExpanded by remember { mutableStateOf(false) }
+            val installOptions = TerminalEnvironmentOption.entries.filter { it != TerminalEnvironmentOption.ANDROID }
+            val versionOptions = selectedInstallEnvironment.versions
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = modifier
+                    .fillMaxWidth(0.92f)
+                    .padding(horizontal = 12.dp, vertical = 16.dp)
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(16.dp),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.75f)),
+                    tonalElevation = 1.dp,
+                    color = MaterialTheme.colorScheme.surface,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp)
+                    ) {
+                        Text(
+                            text = downloadPanelTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium
+                        )
+                        ExposedDropdownMenuBox(
+                            expanded = environmentExpanded,
+                            onExpandedChange = { environmentExpanded = !environmentExpanded },
+                        ) {
+                            OutlinedTextField(
+                                value = stringResource(selectedInstallEnvironment.labelRes),
+                                onValueChange = {},
+                                readOnly = true,
+                                singleLine = true,
+                                label = { Text("Linux 系统") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = environmentExpanded) },
+                                modifier = Modifier.menuAnchor().fillMaxWidth(),
+                            )
+                            ExposedDropdownMenu(
+                                expanded = environmentExpanded,
+                                onDismissRequest = { environmentExpanded = false },
+                            ) {
+                                installOptions.forEach { environment ->
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(environment.labelRes)) },
+                                        onClick = {
+                                            selectedInstallEnvironment = environment
+                                            if (selectedInstallVersion !in environment.versions && environment.versions.isNotEmpty()) {
+                                                selectedInstallVersion = environment.versions.first()
+                                            }
+                                            environmentExpanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                        if (versionOptions.isNotEmpty()) {
+                            if (selectedInstallVersion !in versionOptions) {
+                                selectedInstallVersion = versionOptions.first()
+                            }
+                            ExposedDropdownMenuBox(
+                                expanded = versionExpanded,
+                                onExpandedChange = { versionExpanded = !versionExpanded },
+                            ) {
+                                OutlinedTextField(
+                                    value = selectedInstallVersion,
+                                    onValueChange = {},
+                                    readOnly = true,
+                                    singleLine = true,
+                                    label = { Text("系统版本") },
+                                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = versionExpanded) },
+                                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                                )
+                                ExposedDropdownMenu(
+                                    expanded = versionExpanded,
+                                    onDismissRequest = { versionExpanded = false },
+                                ) {
+                                    versionOptions.forEach { version ->
+                                        DropdownMenuItem(
+                                            text = { Text(version) },
+                                            onClick = {
+                                                selectedInstallVersion = version
+                                                versionExpanded = false
+                                            },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        FilledTonalButton(
+                            modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
+                            onClick = {
+                                Settings.linux_distribution_version = selectedInstallVersion
+                                Settings.working_Mode = terminalEnvironmentToWorkingMode(
+                                    selectedInstallEnvironment,
+                                    workingModeIsRoot(Settings.working_Mode) && selectedInstallEnvironment.supportsRoot,
+                                )
+                                installRequested = true
+                                retryToken++
+                            },
+                        ) {
+                            Text(stringResource(strings.installing))
+                        }
+                    }
+                }
+            }
+        } else if (!isSetupComplete) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -820,7 +939,7 @@ private fun parseSha256Sums(sums: String, fileName: String): String? {
         .map { it.trim() }
         .filter { it.isNotEmpty() }
         .firstNotNullOfOrNull { line ->
-            val parts = line.split(Regex("\s+"), limit = 2)
+            val parts = line.split(Regex("\\s+"), limit = 2)
             if (parts.size != 2) return@firstNotNullOfOrNull null
             val hash = parts[0]
             val listedFileName = parts[1].removePrefix("*")

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/settings/Settings.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/settings/Settings.kt
@@ -26,6 +26,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -171,6 +175,7 @@ fun Settings(modifier: Modifier = Modifier,navController: NavController) {
     var selectedLayoutMode by remember { mutableIntStateOf(Settings.layout_mode) }
     var selectedCloseLastSessionBehavior by remember { mutableIntStateOf(Settings.close_last_session_behavior) }
     var selectedShellType by remember { mutableIntStateOf(Settings.default_shell) }
+    var selectedLinuxVersion by remember { mutableStateOf(Settings.linux_distribution_version) }
 
     val applyTerminalEnvironmentSelection: (TerminalEnvironmentOption, Boolean) -> Unit = { environment, rootEnabled ->
         val normalizedRoot = rootEnabled && environment.supportsRoot
@@ -638,6 +643,45 @@ fun Settings(modifier: Modifier = Modifier,navController: NavController) {
                     applyTerminalEnvironmentSelection(environment, startWithRoot)
                 },
             )
+
+            if (selectedTerminalEnvironment.versions.isNotEmpty()) {
+                var versionExpanded by remember { mutableStateOf(false) }
+                val versionOptions = selectedTerminalEnvironment.versions
+                if (selectedLinuxVersion !in versionOptions) {
+                    selectedLinuxVersion = versionOptions.first()
+                    Settings.linux_distribution_version = selectedLinuxVersion
+                }
+                ExposedDropdownMenuBox(
+                    expanded = versionExpanded,
+                    onExpandedChange = { versionExpanded = !versionExpanded },
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                ) {
+                    OutlinedTextField(
+                        value = selectedLinuxVersion,
+                        onValueChange = {},
+                        readOnly = true,
+                        singleLine = true,
+                        label = { Text("系统安装版本") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = versionExpanded) },
+                        modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    )
+                    ExposedDropdownMenu(
+                        expanded = versionExpanded,
+                        onDismissRequest = { versionExpanded = false },
+                    ) {
+                        versionOptions.forEach { version ->
+                            DropdownMenuItem(
+                                text = { Text(version) },
+                                onClick = {
+                                    selectedLinuxVersion = version
+                                    Settings.linux_distribution_version = version
+                                    versionExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+            }
 
             if (selectedTerminalEnvironment.supportsRoot) {
                 PreferenceSwitch(

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/MkSession.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/MkSession.kt
@@ -44,6 +44,8 @@ object MkSession {
             val defaultWorkingDir = when (workingMode) {
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> archHomeDir().path
+                WorkingMode.UBUNTU,
+                WorkingMode.UBUNTU_ROOT -> filesDir.child("LinuxSystem").child("ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}").child("root").path
                 else -> alpineHomeDir().path
             }
             val workingDir = pendingCommand?.workingDir ?: defaultWorkingDir
@@ -90,6 +92,12 @@ object MkSession {
                 setExecutable(true)
             }
 
+            localBinDir().child("init-ubuntu-host").apply {
+                createFileIfNot()
+                writeText(assets.open("init-ubuntu-host.sh").bufferedReader().use { it.readText() })
+                setExecutable(true)
+            }
+
 
             val sessionTmpDir = getTempDir().child(session_id).also {
                 if (it.exists()) {
@@ -108,6 +116,8 @@ object MkSession {
                 "BIN=${localBinDir()}",
                 "DEBUG=${BuildConfig.DEBUG}",
                 "PREFIX=${filesDir.parentFile!!.path}",
+                "TERMIX_ROOTFS_ID=ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}",
+                "TERMIX_ROOTFS_ARCHIVE=ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}.tar.gz",
                 "LD_LIBRARY_PATH=${localLibDir().absolutePath}",
                 "LINKER=${if(File("/system/bin/linker64").exists()){"/system/bin/linker64"}else{"/system/bin/linker"}}",
                 "NATIVE_LIB_DIR=${applicationInfo.nativeLibraryDir}",
@@ -156,6 +166,8 @@ object MkSession {
                     WorkingMode.ALPINE_ROOT -> arrayOf("-c", localBinDir().child("init-root").absolutePath)
                     WorkingMode.ARCH -> arrayOf("-c", localBinDir().child("init-arch-host").absolutePath)
                     WorkingMode.ARCH_ROOT -> arrayOf("-c", localBinDir().child("init-arch-root").absolutePath)
+                    WorkingMode.UBUNTU,
+                    WorkingMode.UBUNTU_ROOT -> arrayOf("-c", localBinDir().child("init-ubuntu-host").absolutePath)
                     else -> arrayOf()
                 }
                 "/system/bin/sh"

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/MkSession.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/MkSession.kt
@@ -1,6 +1,7 @@
 package android.zero.studio.termux.ui.screens.terminal
 
 import android.os.Environment
+import android.os.Build
 import android.zero.studio.termux.libcommons.alpineDir
 import android.zero.studio.termux.libcommons.alpineHomeDir
 import android.zero.studio.termux.libcommons.archHomeDir
@@ -41,11 +42,15 @@ object MkSession {
                 "EXTERNAL_STORAGE" to System.getenv("EXTERNAL_STORAGE")
             )
 
+            val ubuntuRootfsAbi = Build.SUPPORTED_ABIS.firstOrNull { it == "arm64-v8a" || it == "armeabi-v7a" || it == "x86" }
+                ?.let { if (it == "arm64-v8a") "arm64" else if (it == "armeabi-v7a") "armhf" else "i386" }
+                ?: "unknown"
+            val ubuntuRootfsId = "ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}-$ubuntuRootfsAbi"
             val defaultWorkingDir = when (workingMode) {
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> archHomeDir().path
                 WorkingMode.UBUNTU,
-                WorkingMode.UBUNTU_ROOT -> filesDir.child("LinuxSystem").child("ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}").child("root").path
+                WorkingMode.UBUNTU_ROOT -> filesDir.child("LinuxSystem").child(ubuntuRootfsId).child("root").path
                 else -> alpineHomeDir().path
             }
             val workingDir = pendingCommand?.workingDir ?: defaultWorkingDir
@@ -116,8 +121,8 @@ object MkSession {
                 "BIN=${localBinDir()}",
                 "DEBUG=${BuildConfig.DEBUG}",
                 "PREFIX=${filesDir.parentFile!!.path}",
-                "TERMIX_ROOTFS_ID=ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}",
-                "TERMIX_ROOTFS_ARCHIVE=ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}.tar.gz",
+                "TERMIX_ROOTFS_ID=$ubuntuRootfsId",
+                "TERMIX_ROOTFS_ARCHIVE=$ubuntuRootfsId.tar.gz",
                 "LD_LIBRARY_PATH=${localLibDir().absolutePath}",
                 "LINKER=${if(File("/system/bin/linker64").exists()){"/system/bin/linker64"}else{"/system/bin/linker"}}",
                 "NATIVE_LIB_DIR=${applicationInfo.nativeLibraryDir}",

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/Rootfs.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/Rootfs.kt
@@ -1,6 +1,7 @@
 package android.zero.studio.termux.ui.screens.terminal
 
 import android.os.Environment
+import android.os.Build
 import androidx.compose.runtime.mutableStateOf
 import android.zero.studio.termux.libcommons.application
 import android.zero.studio.termux.libcommons.archDir
@@ -25,12 +26,22 @@ object Rootfs {
         return workingMode != WorkingMode.ANDROID
     }
 
+    private fun ubuntuRootfsAbi(): String {
+        val abi = Build.SUPPORTED_ABIS.firstOrNull { it == "arm64-v8a" || it == "armeabi-v7a" || it == "x86" }
+        return when (abi) {
+            "arm64-v8a" -> "arm64"
+            "armeabi-v7a" -> "armhf"
+            "x86" -> "i386"
+            else -> "unknown"
+        }
+    }
+
     private fun rootfsFileName(workingMode: Int): String {
         return when (workingMode) {
             WorkingMode.ARCH,
             WorkingMode.ARCH_ROOT -> "arch.tar.gz"
             WorkingMode.UBUNTU,
-            WorkingMode.UBUNTU_ROOT -> "ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}.tar.gz"
+            WorkingMode.UBUNTU_ROOT -> "ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}-${ubuntuRootfsAbi()}.tar.gz"
             else -> "alpine.tar.gz"
         }
     }

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/Rootfs.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/Rootfs.kt
@@ -29,6 +29,8 @@ object Rootfs {
         return when (workingMode) {
             WorkingMode.ARCH,
             WorkingMode.ARCH_ROOT -> "arch.tar.gz"
+            WorkingMode.UBUNTU,
+            WorkingMode.UBUNTU_ROOT -> "ubuntu-${Settings.linux_distribution_version.lowercase().replace(" ", "-")}.tar.gz"
             else -> "alpine.tar.gz"
         }
     }

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt
@@ -30,6 +30,10 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -279,6 +283,7 @@ fun TerminalScreen(
             val initialEnvironment = terminalEnvironmentFromWorkingMode(Settings.working_Mode)
             selectedNewSessionEnvironment = initialEnvironment
             startNewSessionWithRoot = workingModeIsRoot(Settings.working_Mode) && initialEnvironment.supportsRoot
+            selectedNewSessionVersion = Settings.linux_distribution_version
             showAddDialog = true
         }
 
@@ -348,6 +353,44 @@ fun TerminalScreen(
                         },
                     )
 
+                    if (selectedNewSessionEnvironment.versions.isNotEmpty()) {
+                        var versionExpanded by remember { mutableStateOf(false) }
+                        val versionOptions = selectedNewSessionEnvironment.versions
+                        if (selectedNewSessionVersion !in versionOptions) {
+                            selectedNewSessionVersion = versionOptions.first()
+                        }
+                        ExposedDropdownMenuBox(
+                            expanded = versionExpanded,
+                            onExpandedChange = { versionExpanded = !versionExpanded },
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                        ) {
+                            OutlinedTextField(
+                                value = selectedNewSessionVersion,
+                                onValueChange = {},
+                                readOnly = true,
+                                singleLine = true,
+                                label = { Text("系统版本") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = versionExpanded) },
+                                modifier = Modifier.menuAnchor().fillMaxWidth(),
+                            )
+                            ExposedDropdownMenu(
+                                expanded = versionExpanded,
+                                onDismissRequest = { versionExpanded = false },
+                            ) {
+                                versionOptions.forEach { version ->
+                                    DropdownMenuItem(
+                                        text = { Text(version) },
+                                        onClick = {
+                                            selectedNewSessionVersion = version
+                                            Settings.linux_distribution_version = version
+                                            versionExpanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+
                     if (selectedNewSessionEnvironment.supportsRoot) {
                         PreferenceSwitch(
                             checked = startNewSessionWithRoot,
@@ -376,6 +419,9 @@ fun TerminalScreen(
                             .padding(horizontal = 16.dp, vertical = 8.dp)
                             .heightIn(min = 48.dp),
                         onClick = {
+                            if (selectedNewSessionEnvironment.versions.isNotEmpty()) {
+                                Settings.linux_distribution_version = selectedNewSessionVersion
+                            }
                             createNewSession(
                                 workingMode = terminalEnvironmentToWorkingMode(
                                     selectedNewSessionEnvironment,
@@ -464,6 +510,8 @@ fun getSessionTextColor(workingMode: Int?): androidx.compose.ui.graphics.Color {
     return when (workingMode) {
         WorkingMode.ALPINE_ROOT -> androidx.compose.ui.graphics.Color(0xFFEF5350)
         WorkingMode.ARCH_ROOT -> androidx.compose.ui.graphics.Color(0xFFEF5350)
+        WorkingMode.UBUNTU -> androidx.compose.ui.graphics.Color(0xFFFFB300)
+        WorkingMode.UBUNTU_ROOT -> androidx.compose.ui.graphics.Color(0xFFEF5350)
         WorkingMode.ANDROID -> androidx.compose.ui.graphics.Color(0xFFFFA726)
         else -> MaterialTheme.colorScheme.onSurface
     }

--- a/core/ZeroStudio-Terminal/src/main/res/values-zh/strings.xml
+++ b/core/ZeroStudio-Terminal/src/main/res/values-zh/strings.xml
@@ -4,8 +4,11 @@
     <string name="use_shizuku">自动登录 Shizuku</string>
     <string name="use_shizuku_desc">自动执行 rish 命令</string>
     <string name="default_working_mode">默认工作模式</string>
+    <string name="ubuntu_desc">Ubuntu Linux (proot)</string>
+    <string name="ubuntu_root_desc">Ubuntu Linux（以真实 Root 启动 proot）</string>
     <string name="alpine_desc">Alpine Linux</string>
     <string name="android_desc">Terminal Android Shell</string>
+    <string name="terminal_env_ubuntu">Ubuntu</string>
     <string name="terminal_env_alpine">Alpine</string>
     <string name="terminal_env_arch">Arch</string>
     <string name="terminal_env_android">Android</string>

--- a/core/ZeroStudio-Terminal/src/main/res/values/strings.xml
+++ b/core/ZeroStudio-Terminal/src/main/res/values/strings.xml
@@ -4,9 +4,12 @@
     <string name="use_shizuku">Auto Login to shizuku</string>
     <string name="use_shizuku_desc">Automatically execute rish command</string>
     <string name="default_working_mode">Default Working mode</string>
+    <string name="ubuntu_desc">Ubuntu Linux (proot)</string>
+    <string name="ubuntu_root_desc">Ubuntu Linux (proot with real root startup)</string>
     <string name="alpine_desc">Alpine Linux</string>
     <string name="arch_desc">Arch Linux ARM (proot)</string>
     <string name="android_desc">Terminal Android shell</string>
+    <string name="terminal_env_ubuntu">Ubuntu</string>
     <string name="terminal_env_alpine">Alpine</string>
     <string name="terminal_env_arch">Arch</string>
     <string name="terminal_env_android">Android</string>


### PR DESCRIPTION
### Motivation

- Provide a clearer environment selection by grouping Linux environments into three tabs (开发 / 非开发 / 其它) so development distributions (e.g. Ubuntu) are separate from non-development ones (Alpine / Arch) and Android is grouped as Other. 
- Allow choosing and persisting a specific Linux distribution version when multiple rootfs releases are available (Ubuntu), and surface that choice in both the "new session" dialog and Settings. 
- Install and run multiple distributions/versions in isolated folders to avoid rootfs conflicts and make proot-based launches per-distribution/version reproducible.

### Description

- Refactor environment selector into categories and a two-row segmented control by introducing `TerminalEnvironmentCategory` and changing `TerminalEnvironmentOption` to include `category` and `versions`; replace the old single-row selector with a category pill + option pill UI (`core/.../TerminalEnvironmentSelector.kt`).
- Add `UBUNTU` / `UBUNTU_ROOT` working modes in `WorkingMode` and wire them throughout the UI/service codepaths so Ubuntu appears as a selectable environment and shows an appropriate label/color in session UI (`model/WorkingMode.kt`, `service/SessionService.kt`, `ui/components/SessionTabBar.kt`, `ui/screens/terminal/TerminalScreen.kt`).
- Persist a selected distribution version in settings via `Settings.linux_distribution_version` (default `"24.04"`) and change the terminal default working mode to Ubuntu by default (`settings/Settings.kt`).
- Add a version chooser UI using Material 3 `ExposedDropdownMenuBox` + `OutlinedTextField` in both the new-session dialog and Settings when the selected environment exposes multiple versions (`ui/screens/terminal/TerminalScreen.kt`, `ui/screens/settings/Settings.kt`).
- Extend the downloader to resolve Ubuntu rootfs URLs per selected version and ABI with `ubuntuRootfsUrls(...)`, and produce versioned rootfs filenames (e.g. `ubuntu-24.04.tar.gz`) (`ui/screens/downloader/Downloader.kt`).
- Make rootfs handling and checks version-aware (Rootfs filename selection) and add isolated install layout under `files/LinuxSystem/<id>` so each distribution/version/arch has its own folder (`ui/screens/terminal/Rootfs.kt`, `ui/screens/terminal/MkSession.kt`).
- Add a proot launcher asset `init-ubuntu-host.sh` that extracts/uses `PREFIX/files/LinuxSystem/<id>` and launches proot against that isolated rootfs, and wire `init-ubuntu-host` into session creation environment variables (`assets/init-ubuntu-host.sh`, `ui/screens/terminal/MkSession.kt`).
- Add resource strings for Ubuntu and small UI polish (labels, descriptions) in resource files and resource mapping (`resources/Strings.kt`, `res/values/strings.xml`, `res/values-zh/strings.xml`).

### Testing

- Attempted to compile Kotlin module with `./gradlew :core:ZeroStudio-Terminal:compileDebugKotlin`, which failed due to the build using Java 25 and Kotlin/Gradle tooling not accepting that Java runtime (error from Kotlin toolchain parsing Java version). (failed)
- Re-ran build with `JAVA_HOME` set to a Java 17 JDK (`JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ./gradlew :core:ZeroStudio-Terminal:compileDebugKotlin`), which progressed further but artifact resolution failed because Maven Central returned HTTP 403 for a build plugin dependency (`com.mooltiverse.oss.nyx:gradle:2.5.2`), blocking a full build in this environment. (blocked)
- Attempted to create a GitHub PR with `gh pr create`, but GitHub CLI authentication is not configured in the environment so PR creation could not be completed here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7968d94104832f898f8c11134a0d17)