### PR TITLE
Fix terminal Compose compile errors

### DIFF
--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
@@ -36,6 +36,7 @@ import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 import kotlin.math.roundToLong
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Downloader(
     modifier: Modifier = Modifier,

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/settings/Settings.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/settings/Settings.kt
@@ -640,6 +640,7 @@ fun Settings(modifier: Modifier = Modifier,navController: NavController) {
             )
 
             if (selectedTerminalEnvironment.supportsRoot) {
+                val selectedEnvironmentLabel = stringResource(selectedTerminalEnvironment.labelRes)
                 PreferenceSwitch(
                     checked = startWithRoot,
                     onCheckedChange = {
@@ -649,7 +650,7 @@ fun Settings(modifier: Modifier = Modifier,navController: NavController) {
                     modifier = modifier,
                     description = stringResource(
                         strings.terminal_env_root_toggle_desc,
-                        stringResource(selectedTerminalEnvironment.labelRes),
+                        selectedEnvironmentLabel,
                     ),
                     onClick = {
                         applyTerminalEnvironmentSelection(selectedTerminalEnvironment, !startWithRoot)

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt
@@ -349,6 +349,7 @@ fun TerminalScreen(
                     )
 
                     if (selectedNewSessionEnvironment.supportsRoot) {
+                        val selectedEnvironmentLabel = stringResource(selectedNewSessionEnvironment.labelRes)
                         PreferenceSwitch(
                             checked = startNewSessionWithRoot,
                             onCheckedChange = {
@@ -357,7 +358,7 @@ fun TerminalScreen(
                             label = stringResource(strings.terminal_env_root_toggle),
                             description = stringResource(
                                 strings.terminal_env_root_toggle_desc,
-                                stringResource(selectedNewSessionEnvironment.labelRes),
+                                selectedEnvironmentLabel,
                             ),
                             onClick = {
                                 startNewSessionWithRoot = !startNewSessionWithRoot


### PR DESCRIPTION
### Motivation
- Resolve Kotlin/Compose compile errors caused by using experimental Material3 APIs and by calling a composable (`stringResource`) inside another composable call argument.

### Description
- Opted-in `Downloader` to Material3 experimental APIs by adding `@OptIn(ExperimentalMaterial3Api::class)` above the `@Composable fun Downloader` declaration in `core/ZeroStudio-Terminal/src/main/java/.../downloader/Downloader.kt`.
- Precomputed the terminal environment label via `val selectedEnvironmentLabel = stringResource(selectedTerminalEnvironment.labelRes)` and used it in the root-toggle `description` to avoid nested `stringResource` calls in `core/.../settings/Settings.kt`.
- Applied the same precomputed label change to the add-session dialog in `core/.../terminal/TerminalScreen.kt` to prevent composable invocation from an argument position.

### Testing
- Ran `git diff --check` which passed with no issues.
- Ran `./gradlew :core:ZeroStudio-Terminal:compileDebugKotlin` which failed due to the environment Java version (OpenJDK 25) being incompatible with the Kotlin/Gradle tooling used by the build.
- Retried with `JAVA_HOME=$HOME/.local/share/mise/installs/java/17.0.2 PATH=$JAVA_HOME/bin:$PATH ./gradlew :core:ZeroStudio-Terminal:compileDebugKotlin` which failed to resolve Gradle classpath artifacts because Maven Central returned `403 Forbidden` when fetching `com.mooltiverse.oss.nyx:gradle:2.5.2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79fa01f638832cb2f0fc8666ed795c)