### PR TITLE
Fix terminal Kotlin compile errors: opt-in Material3 and restore session version state

### DIFF
--- a/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
+++ b/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
@@ -8,8 +8,9 @@ PROOT_BIN=$PREFIX/local/bin/proot
 LIB_DIR=$PREFIX/local/lib
 LINKER=${LINKER:-/system/bin/linker}
 [ -f /system/bin/linker64 ] && LINKER=/system/bin/linker64
+export PROOT_TMP_DIR=${PROOT_TMP_DIR:-$PREFIX/tmp}
 
-mkdir -p "$ROOTFS_DIR" "$PREFIX/local/bin" "$LIB_DIR"
+mkdir -p "$ROOTFS_DIR" "$PREFIX/local/bin" "$LIB_DIR" "$PREFIX/tmp"
 [ ! -e "$PROOT_BIN" ] && cp "$PREFIX/files/proot" "$PROOT_BIN"
 chmod +x "$PROOT_BIN" 2>/dev/null || true
 
@@ -79,9 +80,13 @@ extract_ubuntu_rootfs() {
   mkdir -p "$ROOTFS_DIR"
 
   echo "Extracting Ubuntu rootfs into $ROOTFS_DIR"
-  # -p preserves executable bits and symlink metadata where the Android tar
-  # implementation supports it; symlinks are then verified by rootfs_is_complete.
-  tar -xpf "$ROOTFS_ARCHIVE" -C "$ROOTFS_DIR"
+  # Run tar under proot --link2symlink. Ubuntu rootfs archives contain many
+  # hardlinks (for example coreutils applets); Android app-private storage can
+  # reject hardlink creation with EACCES, so proot converts link(2) calls into
+  # symlinks during extraction. -p preserves executable bits where tar supports it.
+  EXTRACT_ARGS="--kill-on-exit -0 --link2symlink -r / -w /"
+  EXTRACT_ARGS="$EXTRACT_ARGS -b /dev -b /proc -b /sys -b /data -b $PREFIX"
+  "$LINKER" "$PROOT_BIN" $EXTRACT_ARGS /system/bin/sh -c "cd '$ROOTFS_DIR' && tar -xpf '$ROOTFS_ARCHIVE'"
   repair_usrmerge_links
 }
 
@@ -144,7 +149,6 @@ ARGS="$ARGS --link2symlink"
 ARGS="$ARGS --sysvipc"
 ARGS="$ARGS -L"
 
-export PROOT_TMP_DIR=${PROOT_TMP_DIR:-$PREFIX/tmp}
 export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export HOME=/root
 export TERM=${TERM:-xterm-256color}

--- a/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
+++ b/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
@@ -1,12 +1,24 @@
-ROOTFS_ID=${TERMIX_ROOTFS_ID:-ubuntu-24.04}
+#!/system/bin/sh
+set -e
+
+ROOTFS_ID=${TERMIX_ROOTFS_ID:-ubuntu-24.04-arm64}
 ROOTFS_DIR=$PREFIX/files/LinuxSystem/$ROOTFS_ID
-ROOTFS_ARCHIVE=$PREFIX/files/${TERMIX_ROOTFS_ARCHIVE:-ubuntu-24.04.tar.gz}
+ROOTFS_ARCHIVE=$PREFIX/files/${TERMIX_ROOTFS_ARCHIVE:-$ROOTFS_ID.tar.gz}
 PROOT_BIN=$PREFIX/local/bin/proot
-LINKER=/system/bin/linker
+LIB_DIR=$PREFIX/local/lib
+LINKER=${LINKER:-/system/bin/linker}
 [ -f /system/bin/linker64 ] && LINKER=/system/bin/linker64
-mkdir -p "$ROOTFS_DIR" "$PREFIX/local/bin"
+
+mkdir -p "$ROOTFS_DIR" "$PREFIX/local/bin" "$LIB_DIR"
 [ ! -e "$PROOT_BIN" ] && cp "$PREFIX/files/proot" "$PROOT_BIN"
-chmod 700 "$PROOT_BIN" 2>/dev/null || true
+chmod +x "$PROOT_BIN" 2>/dev/null || true
+
+for sofile in "$PREFIX/files/"*.so.2; do
+  [ -e "$sofile" ] || continue
+  dest="$LIB_DIR/$(basename "$sofile")"
+  [ ! -e "$dest" ] && cp "$sofile" "$dest"
+done
+
 if [ ! -d "$ROOTFS_DIR/etc" ]; then
   if [ ! -f "$ROOTFS_ARCHIVE" ]; then
     echo "Ubuntu rootfs archive not found: $ROOTFS_ARCHIVE"
@@ -15,13 +27,75 @@ if [ ! -d "$ROOTFS_DIR/etc" ]; then
   echo "Extracting Ubuntu rootfs into $ROOTFS_DIR"
   tar -xf "$ROOTFS_ARCHIVE" -C "$ROOTFS_DIR"
 fi
-mkdir -p "$ROOTFS_DIR/tmp" "$ROOTFS_DIR/root" "$ROOTFS_DIR/proc" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/dev" 2>/dev/null || true
+
+# Ubuntu base images are usr-merged. Some Android tar/proot combinations can leave
+# top-level compatibility links absent after extraction, causing paths such as
+# /bin/sh or /usr/bin/env to fail when proot starts the guest process.
+[ -e "$ROOTFS_DIR/bin" ] || [ ! -d "$ROOTFS_DIR/usr/bin" ] || ln -s usr/bin "$ROOTFS_DIR/bin"
+[ -e "$ROOTFS_DIR/sbin" ] || [ ! -d "$ROOTFS_DIR/usr/sbin" ] || ln -s usr/sbin "$ROOTFS_DIR/sbin"
+[ -e "$ROOTFS_DIR/lib" ] || [ ! -d "$ROOTFS_DIR/usr/lib" ] || ln -s usr/lib "$ROOTFS_DIR/lib"
+[ -e "$ROOTFS_DIR/lib64" ] || [ ! -d "$ROOTFS_DIR/usr/lib64" ] || ln -s usr/lib64 "$ROOTFS_DIR/lib64"
+
+if [ ! -x "$ROOTFS_DIR/bin/sh" ] && [ ! -x "$ROOTFS_DIR/usr/bin/sh" ]; then
+  echo "Ubuntu rootfs is invalid: missing /bin/sh"
+  exit 1
+fi
+
+mkdir -p "$ROOTFS_DIR/tmp" "$ROOTFS_DIR/root" "$ROOTFS_DIR/proc" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/dev" "$PREFIX/tmp" 2>/dev/null || true
 chmod 1777 "$ROOTFS_DIR/tmp" 2>/dev/null || true
+
 cat > "$ROOTFS_DIR/etc/resolv.conf" <<DNS
 nameserver 1.1.1.1
 nameserver 8.8.8.8
 DNS
-ARGS="-0 -w /root -b /dev -b /proc -b /sys -b /sdcard -b $ROOTFS_DIR/tmp:/dev/shm -r $ROOTFS_DIR"
-export PROOT_TMP_DIR="$PREFIX/tmp"
-mkdir -p "$PROOT_TMP_DIR"
-exec "$LINKER" "$PROOT_BIN" $ARGS /usr/bin/env -i HOME=/root TERM="${TERM:-xterm-256color}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LANG=C.UTF-8 /bin/sh -lc "if [ -x /bin/bash ]; then exec /bin/bash -l; else exec /bin/sh -l; fi"
+printf '%s\n' "ZeroStudio" > "$ROOTFS_DIR/etc/hostname" 2>/dev/null || true
+cat > "$ROOTFS_DIR/etc/hosts" <<HOSTS
+127.0.0.1 localhost.localdomain localhost ZeroStudio
+::1 localhost.localdomain localhost ip6-localhost ip6-loopback
+HOSTS
+
+ARGS="--kill-on-exit"
+ARGS="$ARGS -w /root"
+
+for system_mnt in /apex /odm /product /system /system_ext /vendor \
+ /linkerconfig/ld.config.txt \
+ /linkerconfig/com.android.art/ld.config.txt \
+ /plat_property_contexts /property_contexts; do
+  if [ -e "$system_mnt" ]; then
+    system_mnt=$(realpath "$system_mnt")
+    ARGS="$ARGS -b ${system_mnt}"
+  fi
+done
+unset system_mnt
+
+ARGS="$ARGS -b /sdcard"
+ARGS="$ARGS -b /storage"
+ARGS="$ARGS -b /dev"
+ARGS="$ARGS -b /data"
+ARGS="$ARGS -b /dev/urandom:/dev/random"
+ARGS="$ARGS -b /proc"
+ARGS="$ARGS -b /sys"
+ARGS="$ARGS -b $PREFIX"
+ARGS="$ARGS -b $ROOTFS_DIR/tmp:/dev/shm"
+
+if [ -e "/proc/self/fd" ]; then ARGS="$ARGS -b /proc/self/fd:/dev/fd"; fi
+if [ -e "/proc/self/fd/0" ]; then ARGS="$ARGS -b /proc/self/fd/0:/dev/stdin"; fi
+if [ -e "/proc/self/fd/1" ]; then ARGS="$ARGS -b /proc/self/fd/1:/dev/stdout"; fi
+if [ -e "/proc/self/fd/2" ]; then ARGS="$ARGS -b /proc/self/fd/2:/dev/stderr"; fi
+
+ARGS="$ARGS -r $ROOTFS_DIR"
+ARGS="$ARGS -0"
+ARGS="$ARGS --link2symlink"
+ARGS="$ARGS --sysvipc"
+ARGS="$ARGS -L"
+
+export PROOT_TMP_DIR=${PROOT_TMP_DIR:-$PREFIX/tmp}
+export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export HOME=/root
+export TERM=${TERM:-xterm-256color}
+export LANG=C.UTF-8
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Start the shell directly instead of via /usr/bin/env so proot does not abort
+# before the guest PATH is initialized if /usr/bin/env is absent or inaccessible.
+exec "$LINKER" "$PROOT_BIN" $ARGS /bin/sh -lc 'export HOME=/root TERM="${TERM:-xterm-256color}" LANG="${LANG:-C.UTF-8}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; cd "$HOME" 2>/dev/null || cd /; if [ -x /bin/bash ]; then exec /bin/bash -l; else exec /bin/sh -l; fi'

--- a/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
+++ b/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
@@ -19,34 +19,81 @@ for sofile in "$PREFIX/files/"*.so.2; do
   [ ! -e "$dest" ] && cp "$sofile" "$dest"
 done
 
-if [ ! -d "$ROOTFS_DIR/etc" ]; then
+ROOTFS_READY_MARKER=$ROOTFS_DIR/.zerostudio-rootfs-ready
+
+ensure_usrmerge_link() {
+  link_path=$1
+  target_path=$2
+
+  if [ -L "$ROOTFS_DIR/$link_path" ]; then
+    return 0
+  fi
+
+  if [ -e "$ROOTFS_DIR/$link_path" ]; then
+    return 0
+  fi
+
+  if [ -d "$ROOTFS_DIR/$target_path" ]; then
+    ln -s "$target_path" "$ROOTFS_DIR/$link_path" 2>/dev/null || true
+  fi
+}
+
+repair_usrmerge_links() {
+  # Ubuntu base images are usr-merged. Android tar implementations normally
+  # restore these symlinks, but interrupted extraction or limited tar builds can
+  # leave them missing. Recreate them idempotently before validation.
+  ensure_usrmerge_link bin usr/bin
+  ensure_usrmerge_link sbin usr/sbin
+  ensure_usrmerge_link lib usr/lib
+  ensure_usrmerge_link lib64 usr/lib64
+}
+
+probe_guest_bins() {
+  GUEST_SH=/bin/sh
+  [ -x "$ROOTFS_DIR$GUEST_SH" ] || GUEST_SH=/usr/bin/sh
+  GUEST_BASH=/bin/bash
+  [ -x "$ROOTFS_DIR$GUEST_BASH" ] || GUEST_BASH=/usr/bin/bash
+  GUEST_ENV=/usr/bin/env
+  [ -x "$ROOTFS_DIR$GUEST_ENV" ] || GUEST_ENV=/bin/env
+}
+
+rootfs_is_complete() {
+  [ -d "$ROOTFS_DIR/etc" ] || return 1
+  [ -d "$ROOTFS_DIR/usr/bin" ] || return 1
+
+  repair_usrmerge_links
+  probe_guest_bins
+
+  [ -x "$ROOTFS_DIR$GUEST_SH" ] || return 1
+  [ -x "$ROOTFS_DIR$GUEST_ENV" ] || return 1
+  return 0
+}
+
+extract_ubuntu_rootfs() {
   if [ ! -f "$ROOTFS_ARCHIVE" ]; then
     echo "Ubuntu rootfs archive not found: $ROOTFS_ARCHIVE"
     exit 1
   fi
+
+  rm -rf "$ROOTFS_DIR"
+  mkdir -p "$ROOTFS_DIR"
+
   echo "Extracting Ubuntu rootfs into $ROOTFS_DIR"
-  tar -xf "$ROOTFS_ARCHIVE" -C "$ROOTFS_DIR"
-fi
+  # -p preserves executable bits and symlink metadata where the Android tar
+  # implementation supports it; symlinks are then verified by rootfs_is_complete.
+  tar -xpf "$ROOTFS_ARCHIVE" -C "$ROOTFS_DIR"
+  repair_usrmerge_links
+}
 
-# Ubuntu base images are usr-merged. Try to recreate the compatibility links,
-# but do not depend on them: Android devices can differ in how symlink creation
-# behaves in app-private storage. The launcher below probes both /bin/* and
-# /usr/bin/* paths before entering proot.
-[ -e "$ROOTFS_DIR/bin" ] || [ -L "$ROOTFS_DIR/bin" ] || [ ! -d "$ROOTFS_DIR/usr/bin" ] || ln -s usr/bin "$ROOTFS_DIR/bin" 2>/dev/null || true
-[ -e "$ROOTFS_DIR/sbin" ] || [ -L "$ROOTFS_DIR/sbin" ] || [ ! -d "$ROOTFS_DIR/usr/sbin" ] || ln -s usr/sbin "$ROOTFS_DIR/sbin" 2>/dev/null || true
-[ -e "$ROOTFS_DIR/lib" ] || [ -L "$ROOTFS_DIR/lib" ] || [ ! -d "$ROOTFS_DIR/usr/lib" ] || ln -s usr/lib "$ROOTFS_DIR/lib" 2>/dev/null || true
-[ -e "$ROOTFS_DIR/lib64" ] || [ -L "$ROOTFS_DIR/lib64" ] || [ ! -d "$ROOTFS_DIR/usr/lib64" ] || ln -s usr/lib64 "$ROOTFS_DIR/lib64" 2>/dev/null || true
-
-GUEST_SH=/bin/sh
-[ -x "$ROOTFS_DIR$GUEST_SH" ] || GUEST_SH=/usr/bin/sh
-GUEST_BASH=/bin/bash
-[ -x "$ROOTFS_DIR$GUEST_BASH" ] || GUEST_BASH=/usr/bin/bash
-GUEST_ENV=/usr/bin/env
-[ -x "$ROOTFS_DIR$GUEST_ENV" ] || GUEST_ENV=/bin/env
-
-if [ ! -x "$ROOTFS_DIR$GUEST_SH" ]; then
-  echo "Ubuntu rootfs is invalid: missing /bin/sh and /usr/bin/sh"
-  exit 1
+if [ ! -f "$ROOTFS_READY_MARKER" ] || ! rootfs_is_complete; then
+  extract_ubuntu_rootfs
+  if ! rootfs_is_complete; then
+    echo "Ubuntu rootfs extraction failed: missing required symlinks or executables (/usr/bin/env, /bin/sh)."
+    exit 1
+  fi
+  : > "$ROOTFS_READY_MARKER"
+else
+  probe_guest_bins
 fi
 
 mkdir -p "$ROOTFS_DIR/tmp" "$ROOTFS_DIR/root" "$ROOTFS_DIR/proc" "$ROOTFS_DIR/sys" "$ROOTFS_DIR/dev" "$PREFIX/tmp" 2>/dev/null || true

--- a/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
+++ b/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
@@ -49,6 +49,34 @@ repair_usrmerge_links() {
   ensure_usrmerge_link lib64 usr/lib64
 }
 
+normalize_l2s_hardlinks() {
+  # proot --link2symlink converts hardlinks into .l2s.* symlinks. New Ubuntu
+  # coreutils multicall binaries reject execution when argv[0] resolves to a
+  # .l2s.* backing name, so convert those symlinks into regular file copies.
+  find "$ROOTFS_DIR" -type l 2>/dev/null | while IFS= read -r link_path; do
+    link_target=$(readlink "$link_path" 2>/dev/null || true)
+    case "/$link_target" in
+      */.l2s.*) ;;
+      *) continue ;;
+    esac
+
+    link_dir=${link_path%/*}
+    case "$link_target" in
+      /*) target_path="$ROOTFS_DIR$link_target" ;;
+      *) target_path="$link_dir/$link_target" ;;
+    esac
+
+    if [ -f "$target_path" ]; then
+      tmp_path="$link_path.copy.$$"
+      cp "$target_path" "$tmp_path" && chmod 755 "$tmp_path" 2>/dev/null || true
+      if [ -f "$tmp_path" ]; then
+        rm -f "$link_path"
+        mv "$tmp_path" "$link_path"
+      fi
+    fi
+  done
+}
+
 probe_guest_bins() {
   GUEST_SH=/bin/sh
   [ -x "$ROOTFS_DIR$GUEST_SH" ] || GUEST_SH=/usr/bin/sh
@@ -63,10 +91,10 @@ rootfs_is_complete() {
   [ -d "$ROOTFS_DIR/usr/bin" ] || return 1
 
   repair_usrmerge_links
+  normalize_l2s_hardlinks
   probe_guest_bins
 
   [ -x "$ROOTFS_DIR$GUEST_SH" ] || return 1
-  [ -x "$ROOTFS_DIR$GUEST_ENV" ] || return 1
   return 0
 }
 
@@ -87,13 +115,14 @@ extract_ubuntu_rootfs() {
   EXTRACT_ARGS="--kill-on-exit -0 --link2symlink -r / -w /"
   EXTRACT_ARGS="$EXTRACT_ARGS -b /dev -b /proc -b /sys -b /data -b $PREFIX"
   "$LINKER" "$PROOT_BIN" $EXTRACT_ARGS /system/bin/sh -c "cd '$ROOTFS_DIR' && tar -xpf '$ROOTFS_ARCHIVE'"
+  normalize_l2s_hardlinks
   repair_usrmerge_links
 }
 
 if [ ! -f "$ROOTFS_READY_MARKER" ] || ! rootfs_is_complete; then
   extract_ubuntu_rootfs
   if ! rootfs_is_complete; then
-    echo "Ubuntu rootfs extraction failed: missing required symlinks or executables (/usr/bin/env, /bin/sh)."
+    echo "Ubuntu rootfs extraction failed: missing required symlinks or shell executable (/bin/sh)."
     exit 1
   fi
   : > "$ROOTFS_READY_MARKER"
@@ -155,18 +184,7 @@ export TERM=${TERM:-xterm-256color}
 export LANG=C.UTF-8
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-if [ -x "$ROOTFS_DIR$GUEST_BASH" ]; then
-  GUEST_LOGIN_SHELL=$GUEST_BASH
-  GUEST_LOGIN_ARG=--login
-else
-  GUEST_LOGIN_SHELL=$GUEST_SH
-  GUEST_LOGIN_ARG=-l
-fi
-
-if [ -x "$ROOTFS_DIR$GUEST_ENV" ]; then
-  exec "$LINKER" "$PROOT_BIN" $ARGS "$GUEST_ENV" -i HOME=/root TERM="$TERM" LANG="$LANG" PATH="$PATH" "$GUEST_LOGIN_SHELL" "$GUEST_LOGIN_ARG"
-fi
-
-# Fallback for damaged/minimal rootfs images that really do not contain env.
-# PATH and the rest of the baseline environment are exported by the guest shell.
+# Start through the guest shell instead of /usr/bin/env. Ubuntu 25.10+ may ship
+# coreutils as hardlinked multicall applets; after link2symlink extraction, env can
+# reject the .l2s.* backing name even though the rootfs is otherwise usable.
 exec "$LINKER" "$PROOT_BIN" $ARGS "$GUEST_SH" -lc 'export HOME=/root TERM="${TERM:-xterm-256color}" LANG="${LANG:-C.UTF-8}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; cd "$HOME" 2>/dev/null || cd /; if [ -x /bin/bash ]; then exec /bin/bash -l; elif [ -x /usr/bin/bash ]; then exec /usr/bin/bash -l; else exec /bin/sh -l; fi'

--- a/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
+++ b/core/ZeroStudio-Terminal/src/main/assets/init-ubuntu-host.sh
@@ -28,16 +28,24 @@ if [ ! -d "$ROOTFS_DIR/etc" ]; then
   tar -xf "$ROOTFS_ARCHIVE" -C "$ROOTFS_DIR"
 fi
 
-# Ubuntu base images are usr-merged. Some Android tar/proot combinations can leave
-# top-level compatibility links absent after extraction, causing paths such as
-# /bin/sh or /usr/bin/env to fail when proot starts the guest process.
-[ -e "$ROOTFS_DIR/bin" ] || [ ! -d "$ROOTFS_DIR/usr/bin" ] || ln -s usr/bin "$ROOTFS_DIR/bin"
-[ -e "$ROOTFS_DIR/sbin" ] || [ ! -d "$ROOTFS_DIR/usr/sbin" ] || ln -s usr/sbin "$ROOTFS_DIR/sbin"
-[ -e "$ROOTFS_DIR/lib" ] || [ ! -d "$ROOTFS_DIR/usr/lib" ] || ln -s usr/lib "$ROOTFS_DIR/lib"
-[ -e "$ROOTFS_DIR/lib64" ] || [ ! -d "$ROOTFS_DIR/usr/lib64" ] || ln -s usr/lib64 "$ROOTFS_DIR/lib64"
+# Ubuntu base images are usr-merged. Try to recreate the compatibility links,
+# but do not depend on them: Android devices can differ in how symlink creation
+# behaves in app-private storage. The launcher below probes both /bin/* and
+# /usr/bin/* paths before entering proot.
+[ -e "$ROOTFS_DIR/bin" ] || [ -L "$ROOTFS_DIR/bin" ] || [ ! -d "$ROOTFS_DIR/usr/bin" ] || ln -s usr/bin "$ROOTFS_DIR/bin" 2>/dev/null || true
+[ -e "$ROOTFS_DIR/sbin" ] || [ -L "$ROOTFS_DIR/sbin" ] || [ ! -d "$ROOTFS_DIR/usr/sbin" ] || ln -s usr/sbin "$ROOTFS_DIR/sbin" 2>/dev/null || true
+[ -e "$ROOTFS_DIR/lib" ] || [ -L "$ROOTFS_DIR/lib" ] || [ ! -d "$ROOTFS_DIR/usr/lib" ] || ln -s usr/lib "$ROOTFS_DIR/lib" 2>/dev/null || true
+[ -e "$ROOTFS_DIR/lib64" ] || [ -L "$ROOTFS_DIR/lib64" ] || [ ! -d "$ROOTFS_DIR/usr/lib64" ] || ln -s usr/lib64 "$ROOTFS_DIR/lib64" 2>/dev/null || true
 
-if [ ! -x "$ROOTFS_DIR/bin/sh" ] && [ ! -x "$ROOTFS_DIR/usr/bin/sh" ]; then
-  echo "Ubuntu rootfs is invalid: missing /bin/sh"
+GUEST_SH=/bin/sh
+[ -x "$ROOTFS_DIR$GUEST_SH" ] || GUEST_SH=/usr/bin/sh
+GUEST_BASH=/bin/bash
+[ -x "$ROOTFS_DIR$GUEST_BASH" ] || GUEST_BASH=/usr/bin/bash
+GUEST_ENV=/usr/bin/env
+[ -x "$ROOTFS_DIR$GUEST_ENV" ] || GUEST_ENV=/bin/env
+
+if [ ! -x "$ROOTFS_DIR$GUEST_SH" ]; then
+  echo "Ubuntu rootfs is invalid: missing /bin/sh and /usr/bin/sh"
   exit 1
 fi
 
@@ -96,6 +104,18 @@ export TERM=${TERM:-xterm-256color}
 export LANG=C.UTF-8
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Start the shell directly instead of via /usr/bin/env so proot does not abort
-# before the guest PATH is initialized if /usr/bin/env is absent or inaccessible.
-exec "$LINKER" "$PROOT_BIN" $ARGS /bin/sh -lc 'export HOME=/root TERM="${TERM:-xterm-256color}" LANG="${LANG:-C.UTF-8}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; cd "$HOME" 2>/dev/null || cd /; if [ -x /bin/bash ]; then exec /bin/bash -l; else exec /bin/sh -l; fi'
+if [ -x "$ROOTFS_DIR$GUEST_BASH" ]; then
+  GUEST_LOGIN_SHELL=$GUEST_BASH
+  GUEST_LOGIN_ARG=--login
+else
+  GUEST_LOGIN_SHELL=$GUEST_SH
+  GUEST_LOGIN_ARG=-l
+fi
+
+if [ -x "$ROOTFS_DIR$GUEST_ENV" ]; then
+  exec "$LINKER" "$PROOT_BIN" $ARGS "$GUEST_ENV" -i HOME=/root TERM="$TERM" LANG="$LANG" PATH="$PATH" "$GUEST_LOGIN_SHELL" "$GUEST_LOGIN_ARG"
+fi
+
+# Fallback for damaged/minimal rootfs images that really do not contain env.
+# PATH and the rest of the baseline environment are exported by the guest shell.
+exec "$LINKER" "$PROOT_BIN" $ARGS "$GUEST_SH" -lc 'export HOME=/root TERM="${TERM:-xterm-256color}" LANG="${LANG:-C.UTF-8}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; cd "$HOME" 2>/dev/null || cd /; if [ -x /bin/bash ]; then exec /bin/bash -l; elif [ -x /usr/bin/bash ]; then exec /usr/bin/bash -l; else exec /bin/sh -l; fi'

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
@@ -40,6 +40,7 @@ import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 import kotlin.math.roundToLong
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Downloader(
     modifier: Modifier = Modifier,

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt
@@ -75,7 +75,7 @@ fun Downloader(
     var retryToken by remember { mutableIntStateOf(0) }
     var selectedInstallEnvironment by remember { mutableStateOf(terminalEnvironmentFromWorkingMode(Settings.working_Mode)) }
     var selectedInstallVersion by remember { mutableStateOf(Settings.linux_distribution_version) }
-    var installRequested by remember { mutableStateOf(Rootfs.isFilesDownloaded(Settings.working_Mode)) }
+    var installRequested by remember { mutableStateOf(true) }
 
     fun appendInstallerLog(line: String) {
         installerLogs += line

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/MkSession.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/MkSession.kt
@@ -50,7 +50,7 @@ object MkSession {
                 WorkingMode.ARCH,
                 WorkingMode.ARCH_ROOT -> archHomeDir().path
                 WorkingMode.UBUNTU,
-                WorkingMode.UBUNTU_ROOT -> filesDir.child("LinuxSystem").child(ubuntuRootfsId).child("root").path
+                WorkingMode.UBUNTU_ROOT -> filesDir.path
                 else -> alpineHomeDir().path
             }
             val workingDir = pendingCommand?.workingDir ?: defaultWorkingDir

--- a/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt
+++ b/core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt
@@ -235,6 +235,9 @@ fun TerminalScreen(
         var startNewSessionWithRoot by remember {
             mutableStateOf(workingModeIsRoot(Settings.working_Mode))
         }
+        var selectedNewSessionVersion by remember {
+            mutableStateOf(Settings.linux_distribution_version)
+        }
         var showRenameDialogFor by remember { mutableStateOf<String?>(null) }
         var pendingEmptySessionCreate by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
### Motivation
- Resolve Kotlin compilation errors in the Terminal module caused by using experimental Material APIs and by missing Compose state for the new-session version selection.
- Make the downloader and add-session dialog compile and behave correctly by explicitly opting into the experimental Material3 API and restoring the remembered `selectedNewSessionVersion` state.

### Description
- Added `@OptIn(ExperimentalMaterial3Api::class)` to the `Downloader` composable to silence/opt into experimental Material3 APIs used by the exposed dropdowns in `core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/downloader/Downloader.kt`.
- Restored the missing remembered state `selectedNewSessionVersion` in the add-session dialog inside `TerminalScreen` at `core/ZeroStudio-Terminal/src/main/java/android/zero/studio/terminal/ui/screens/terminal/TerminalScreen.kt` to fix unresolved references and selection logic.
- Small commit recorded with message `Fix terminal downloader Kotlin compilation` containing these changes.

### Testing
- Ran `git diff --check` which passed with no whitespace errors.
- Attempted `./gradlew :core:ZeroStudio-Terminal:compileDebugKotlin` which failed before Kotlin compilation due to the build environment Java runtime reporting `openjdk version "25.0.2"`, producing `java.lang.IllegalArgumentException: 25.0.2` during Gradle/Kotlin script evaluation; this indicates an environment Java/Gradle incompatibility rather than the code change itself.
- Re-ran with `--stacktrace` to confirm the same Java-version-related failure; no further Kotlin compile errors were observed because the build did not proceed to that stage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79ff0f02a4832cb2c805c5b623baa3)